### PR TITLE
Fix account creation when the network is slow, with flow changes

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -202,8 +202,8 @@ export const { signAndSendTransactions } = createActions({
 export const { switchAccount, refreshAccount, refreshAccountExternal, resetAccounts, refreshUrl, setFormLoader } = createActions({
     SWITCH_ACCOUNT: wallet.selectAccount.bind(wallet),
     REFRESH_ACCOUNT: [
-        wallet.loadAccount.bind(wallet),
-        () => ({ accountId: wallet.accountId, })
+        wallet.refreshAccount.bind(wallet),
+        () => ({ accountId: wallet.getAccountId() })
     ],
     REFRESH_ACCOUNT_EXTERNAL: [
         async (accountId) => ({

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -203,7 +203,7 @@ export const { switchAccount, refreshAccount, refreshAccountExternal, refreshUrl
     SWITCH_ACCOUNT: wallet.selectAccount.bind(wallet),
     REFRESH_ACCOUNT: [
         wallet.refreshAccount.bind(wallet),
-        () => ({ accountId: wallet.getAccountId() })
+        () => ({ accountId: wallet.accountId })
     ],
     REFRESH_ACCOUNT_EXTERNAL: [
         async (accountId) => ({

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -199,7 +199,7 @@ export const { signAndSendTransactions } = createActions({
     ]
 })
 
-export const { switchAccount, refreshAccount, refreshAccountExternal, resetAccounts, refreshUrl, setFormLoader } = createActions({
+export const { switchAccount, refreshAccount, refreshAccountExternal, refreshUrl, setFormLoader } = createActions({
     SWITCH_ACCOUNT: wallet.selectAccount.bind(wallet),
     REFRESH_ACCOUNT: [
         wallet.refreshAccount.bind(wallet),
@@ -212,7 +212,6 @@ export const { switchAccount, refreshAccount, refreshAccountExternal, resetAccou
         }),
         accountId => ({ accountId })
     ],
-    RESET_ACCOUNTS: wallet.clearState.bind(wallet),
     REFRESH_URL: null,
     SET_FORM_LOADER: null
 })

--- a/src/components/Routing.js
+++ b/src/components/Routing.js
@@ -106,9 +106,9 @@ class Routing extends Component {
             handleRedirectUrl(this.props.router.location)
             handleClearUrl()
             refreshAccount()
-            
+
             const { state: { globalAlertPreventClear } = {} } = history.location
-            if (!globalAlertPreventClear) {
+            if (!globalAlertPreventClear && !this.props.account.globalAlertPreventClear) {
                 clearAlert()
             }
 

--- a/src/components/accounts/AccountFormAccountId.js
+++ b/src/components/accounts/AccountFormAccountId.js
@@ -74,6 +74,12 @@ class AccountFormAccountId extends Component {
     }
 
     input = createRef()
+    componentDidMount = () => {
+        const { defaultAccountId, checkAvailability } = this.props
+        if (defaultAccountId) {
+            checkAvailability(defaultAccountId)
+        }
+    }
 
     handleChangeAccountId = (e, { name, value }) => {
         const { pattern, handleChange, type } = this.props

--- a/src/components/accounts/AccountFormAccountId.js
+++ b/src/components/accounts/AccountFormAccountId.js
@@ -75,9 +75,10 @@ class AccountFormAccountId extends Component {
 
     input = createRef()
     componentDidMount = () => {
-        const { defaultAccountId, checkAvailability } = this.props
+        const { defaultAccountId } = this.props
+        const { accountId } = this.state
         if (defaultAccountId) {
-            checkAvailability(defaultAccountId)
+            this.handleChangeAccountId({}, { name: 'accountId', value: accountId})
         }
     }
 

--- a/src/components/accounts/AccountFormContainer.js
+++ b/src/components/accounts/AccountFormContainer.js
@@ -64,18 +64,13 @@ const CustomContainer = styled(Container)`
 `
 
 /* eslint-disable jsx-a11y/accessible-emoji */
-const AccountFormContainer = ({ location, title, text, children, wide, disclaimer = true, loginResetAccounts }) => (
+const AccountFormContainer = ({ title, text, children, wide, disclaimer = true }) => (
     <CustomContainer>
         <Grid stackable>
           <Grid.Row columns={wide ? `1` : `2`} className='page-title'>
                 <Grid.Column computer={wide ? 16 : 9} tablet={wide ? 16 : 8} mobile={16}>
                     <h1>{title}</h1>
                     <h2>{text}</h2>
-                    {location && loginResetAccounts && (
-                        <Header as='h3' className='color-blue'>
-                            You have been redirected to this page because we had to reset the developer accounts. Please create a new account. We apologize for the inconveience.
-                        </Header>
-                    )}
                 </Grid.Column>
             </Grid.Row>
         </Grid>
@@ -87,7 +82,6 @@ const AccountFormContainer = ({ location, title, text, children, wide, disclaime
 )
 
 AccountFormContainer.propTypes = {
-    location: PropTypes.object,
     title: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.object
@@ -98,8 +92,7 @@ AccountFormContainer.propTypes = {
     ]),
     children: PropTypes.element,
     wide: PropTypes.bool,
-    disclaimer: PropTypes.bool,
-    loginResetAccounts: PropTypes.bool
+    disclaimer: PropTypes.bool
 }
 
 export default AccountFormContainer

--- a/src/components/accounts/CreateAccount.js
+++ b/src/components/accounts/CreateAccount.js
@@ -63,7 +63,7 @@ const StyledContainer = styled(Container)`
 class CreateAccount extends Component {
     state = {
         loader: false,
-        accountId: this.props.loginResetAccountNotConfirmed || '',
+        accountId: (this.props.resetAccount && this.props.resetAccount.accountIdNotConfirmed) || '',
         token: ''
     }
 
@@ -108,7 +108,7 @@ class CreateAccount extends Component {
 
     render() {
         const { loader, accountId, recaptchaFallback } = this.state
-        const { requestStatus, formLoader, checkNewAccount, loginResetAccountNotConfirmed, clear, setFormLoader } = this.props
+        const { requestStatus, formLoader, checkNewAccount, resetAccount, clear, setFormLoader } = this.props
         const useRequestStatus = accountId.length > 0 ? requestStatus : undefined;
 
         return (
@@ -127,7 +127,7 @@ class CreateAccount extends Component {
                         accountId={accountId}
                         clearRequestStatus={clear}
                         setFormLoader={setFormLoader}
-                        defaultAccountId={loginResetAccountNotConfirmed}
+                        defaultAccountId={resetAccount && resetAccount.accountIdNotConfirmed}
                     />
                     <AccountNote/>
                     <FormButton

--- a/src/components/accounts/CreateAccount.js
+++ b/src/components/accounts/CreateAccount.js
@@ -63,7 +63,7 @@ const StyledContainer = styled(Container)`
 class CreateAccount extends Component {
     state = {
         loader: false,
-        accountId: '',
+        accountId: this.props.loginResetAccountNotConfirmed || '',
         token: ''
     }
 
@@ -107,8 +107,8 @@ class CreateAccount extends Component {
     }
 
     render() {
-        const { loader, accountId } = this.state
-        const { requestStatus, formLoader, checkNewAccount, loginResetAccounts, clear, setFormLoader } = this.props
+        const { loader, accountId, recaptchaFallback } = this.state
+        const { requestStatus, formLoader, checkNewAccount, loginResetAccountNotConfirmed, clear, setFormLoader } = this.props
         const useRequestStatus = accountId.length > 0 ? requestStatus : undefined;
 
         return (
@@ -127,6 +127,7 @@ class CreateAccount extends Component {
                         accountId={accountId}
                         clearRequestStatus={clear}
                         setFormLoader={setFormLoader}
+                        defaultAccountId={loginResetAccountNotConfirmed}
                     />
                     <AccountNote/>
                     <FormButton

--- a/src/components/accounts/CreateAccount.js
+++ b/src/components/accounts/CreateAccount.js
@@ -67,18 +67,6 @@ class CreateAccount extends Component {
         token: ''
     }
 
-    componentDidMount = () => {
-        const { loginError, resetAccounts } = this.props;
-
-        if (loginError) {
-            console.error('Error loading account:', loginError)
-
-            if (loginError.indexOf('does not exist while viewing') !== -1) {
-                resetAccounts()
-            }
-        }
-    }
-
     componentWillUnmount = () => {
         this.props.clear()
     }
@@ -128,11 +116,6 @@ class CreateAccount extends Component {
                 <form onSubmit={e => {this.handleCreateAccount(); e.preventDefault();}} autoComplete='off'>
                     <h1><Translate id='createAccount.pageTitle'/></h1>
                     <h2>Just choose a username and you're all set!</h2>
-                    {loginResetAccounts &&
-                        <h3 className='color-blue'>
-                            You have been redirected to this page because we had to reset the developer accounts. Please create a new account. We apologize for the inconveience.
-                        </h3>
-                    }
                     <h6><Translate id='createAccount.accountIdInput.title'/></h6>
                     <AccountFormAccountId
                         formLoader={formLoader}

--- a/src/components/accounts/CreateAccount.js
+++ b/src/components/accounts/CreateAccount.js
@@ -63,7 +63,7 @@ const StyledContainer = styled(Container)`
 class CreateAccount extends Component {
     state = {
         loader: false,
-        accountId: (this.props.resetAccount && this.props.resetAccount.accountIdNotConfirmed) || '',
+        accountId: '',
         token: ''
     }
 
@@ -110,7 +110,7 @@ class CreateAccount extends Component {
         const { loader, accountId, recaptchaFallback } = this.state
         const { requestStatus, formLoader, checkNewAccount, resetAccount, clear, setFormLoader } = this.props
         const useRequestStatus = accountId.length > 0 ? requestStatus : undefined;
-
+        
         return (
             <StyledContainer className='small-centered'>
                 <form onSubmit={e => {this.handleCreateAccount(); e.preventDefault();}} autoComplete='off'>

--- a/src/components/accounts/CreateAccount.js
+++ b/src/components/accounts/CreateAccount.js
@@ -127,7 +127,7 @@ class CreateAccount extends Component {
                         accountId={accountId}
                         clearRequestStatus={clear}
                         setFormLoader={setFormLoader}
-                        defaultAccountId={resetAccount && resetAccount.accountIdNotConfirmed}
+                        defaultAccountId={resetAccount && resetAccount.accountIdNotConfirmed.split('.')[0]}
                     />
                     <AccountNote/>
                     <FormButton

--- a/src/components/accounts/CreateAccountForm.js
+++ b/src/components/accounts/CreateAccountForm.js
@@ -19,7 +19,8 @@ const CreateAccountForm = ({
     checkAvailability,
     accountId,
     clearRequestStatus,
-    setFormLoader
+    setFormLoader,
+    defaultAccountId
 }) => (
     <Container>
         <Header as='h4'><Translate id='createAccount.accountIdInput.title' /></Header>
@@ -33,7 +34,9 @@ const CreateAccountForm = ({
             accountId={accountId}
             clearRequestStatus={clearRequestStatus}
             setFormLoader={setFormLoader}
-        />  
+            defaultAccountId={defaultAccountId}
+        />
+        
         <FormButton
             type='submit'
             color='blue'

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -105,7 +105,7 @@ const url = handleActions({
 }, initialState)
 
 const account = handleActions({
-    [refreshAccount]: (state, { error, payload, ready, meta }) => {
+    [refreshAccount]: (state, { payload, ready, meta }) => {
         if (!ready) {
             return {
                 ...state,
@@ -113,27 +113,20 @@ const account = handleActions({
             }
         }
 
-        if (error) {
-            return {
-                ...state,
-                loader: false,
-                loginError: payload.message
-            }
+        const resetAccountState = {
+            loginResetAccount: payload.loginResetAccount,
+            globalAlertPreventClear: payload.globalAlertPreventClear,
+            globalAlert: payload.loginResetAccount ? {
+                success: false,
+                messageCode: 'account.create.errorAccountNotExist'
+            } : state.globalAlert
         }
-
+        
         return {
             ...state,
-            accountId: payload.accountId,
-            amount: payload.amount,
-            stake: payload.stake,
-            nonce: payload.nonce,
-            code_hash: payload.code_hash,
-            locked: payload.locked,
-            storageUsage: payload.storage_usage,
-            accounts: payload.accounts,
-            loader: false,
-            loginResetAccounts: undefined,
-            balance: payload.balance
+            ...payload,
+            ...resetAccountState,
+            loader: false
         }
     },
     [resetAccounts]: (state) => ({

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -113,8 +113,12 @@ const account = handleActions({
             }
         }
 
-        const resetAccountState = {
+        const resetAccountState = state.loginResetAccountPreventClear ? {
+            loginResetAccountPreventClear: false
+        } : {
             loginResetAccount: payload.loginResetAccount,
+            loginResetAccountPreventClear: payload.loginResetAccountPreventClear,
+            loginResetAccountNotConfirmed: payload.loginResetAccountNotConfirmed,
             globalAlertPreventClear: payload.globalAlertPreventClear,
             globalAlert: payload.loginResetAccount ? {
                 success: false,

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -113,17 +113,12 @@ const account = handleActions({
             }
         }
 
-        const resetAccountState = state.loginResetAccountPreventClear ? {
-            loginResetAccountPreventClear: false
-        } : {
-            loginResetAccount: payload.loginResetAccount,
-            loginResetAccountPreventClear: payload.loginResetAccountPreventClear,
-            loginResetAccountNotConfirmed: payload.loginResetAccountNotConfirmed,
+        const resetAccountState = {
             globalAlertPreventClear: payload.globalAlertPreventClear,
-            globalAlert: payload.loginResetAccount ? {
-                success: false,
-                messageCode: 'account.create.errorAccountNotExist'
-            } : state.globalAlert
+            resetAccount: (state.resetAccount && state.resetAccount.preventClear) ? {
+                ...state.resetAccount,
+                preventClear: false
+            } : payload.resetAccount
         }
         
         return {

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -17,7 +17,7 @@
                 "create": "Checking availability",
                 "check": "Checking"
             },
-            "errorAccountNotExist": "You have been redirected to this page because we had to reset the developer accounts. Please create a new account. We apologize for the inconveience."
+            "errorAccountNotExist": "There was a problem creating your account. Please try again!"
         },
         "available": {
             "success": "User found.",

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -16,7 +16,8 @@
             "checkingAvailablity": {
                 "create": "Checking availability",
                 "check": "Checking"
-            }
+            },
+            "errorAccountNotExist": "You have been redirected to this page because we had to reset the developer accounts. Please create a new account. We apologize for the inconveience."
         },
         "available": {
             "success": "User found.",

--- a/src/utils/localStorage.js
+++ b/src/utils/localStorage.js
@@ -1,25 +1,13 @@
 import { keyAccountConfirmed } from './wallet'
 
 export const setAccountConfirmed = (accountId, confirmed) => {
-    try {
-        localStorage.setItem(keyAccountConfirmed(accountId), confirmed)
-    } catch (err) {
-        console.warn(err)
-    }
+    localStorage.setItem(keyAccountConfirmed(accountId), confirmed)
 }
 
 export const getAccountConfirmed = (accountId) => {
-    try {
-        return localStorage.getItem(keyAccountConfirmed(accountId)) === 'true'
-    } catch (err) {
-        console.warn(err)
-    }
+    return localStorage.getItem(keyAccountConfirmed(accountId)) === 'true'
 }
 
 export const removeAccountConfirmed = (accountId) => {
-    try {
-        localStorage.removeItem(keyAccountConfirmed(accountId))
-    } catch (err) {
-        console.warn(err)
-    }
+    localStorage.removeItem(keyAccountConfirmed(accountId))
 }

--- a/src/utils/localStorage.js
+++ b/src/utils/localStorage.js
@@ -1,24 +1,24 @@
-const keyAccountConfirmed = (accountId, networkId) => `wallet.account:${accountId}:${networkId}:confirmed`
+import { keyAccountConfirmed } from './wallet'
 
-export const setAccountConfirmed = (accountId, networkId, confirmed) => {
+export const setAccountConfirmed = (accountId, confirmed) => {
     try {
-        localStorage.setItem(keyAccountConfirmed(accountId, networkId), confirmed)
+        localStorage.setItem(keyAccountConfirmed(accountId), confirmed)
     } catch (err) {
         console.warn(err)
     }
 }
 
-export const getAccountConfirmed = (accountId, networkId) => {
+export const getAccountConfirmed = (accountId) => {
     try {
-        return localStorage.getItem(keyAccountConfirmed(accountId, networkId)) === 'true'
+        return localStorage.getItem(keyAccountConfirmed(accountId)) === 'true'
     } catch (err) {
         console.warn(err)
     }
 }
 
-export const removeAccountConfirmed = (accountId, networkId) => {
+export const removeAccountConfirmed = (accountId) => {
     try {
-        localStorage.removeItem(keyAccountConfirmed(accountId, networkId))
+        localStorage.removeItem(keyAccountConfirmed(accountId))
     } catch (err) {
         console.warn(err)
     }

--- a/src/utils/localStorage.js
+++ b/src/utils/localStorage.js
@@ -1,0 +1,25 @@
+const keyAccountConfirmed = (accountId, networkId) => `wallet.account:${accountId}:${networkId}:confirmed`
+
+export const setAccountConfirmed = (accountId, networkId, confirmed) => {
+    try {
+        localStorage.setItem(keyAccountConfirmed(accountId, networkId), confirmed)
+    } catch (err) {
+        console.warn(err)
+    }
+}
+
+export const getAccountConfirmed = (accountId, networkId) => {
+    try {
+        return localStorage.getItem(keyAccountConfirmed(accountId, networkId)) === 'true'
+    } catch (err) {
+        console.warn(err)
+    }
+}
+
+export const removeAccountConfirmed = (accountId, networkId) => {
+    try {
+        localStorage.removeItem(keyAccountConfirmed(accountId, networkId))
+    } catch (err) {
+        console.warn(err)
+    }
+}

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -302,8 +302,8 @@ class Wallet {
     async saveAndSelectAccount(accountId, keyPair) {
         await this.saveAccount(accountId, keyPair)
         this.accountId = accountId
-        setAccountConfirmed(this.accountId, false)
         this.save()
+        setAccountConfirmed(this.accountId, false)
     }
 
     async saveAccount(accountId, keyPair) {

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -146,10 +146,16 @@ class Wallet {
                 this.selectAccount(nextAccountId)
 
                 return {
-                    loginResetAccount: true,
-                    loginResetAccountPreventClear: accountIdNotConfirmed,
-                    loginResetAccountNotConfirmed: accountId,
+                    resetAccount: {
+                        reset: true,
+                        preventClear: accountIdNotConfirmed,
+                        accountIdNotConfirmed: accountId
+                    },
                     globalAlertPreventClear: accountIdNotConfirmed || this.isEmpty(),
+                    globalAlert: {
+                        success: false,
+                        messageCode: 'account.create.errorAccountNotExist'
+                    },
                     ...(!this.isEmpty() && !accountIdNotConfirmed && await this.loadAccount())
                 }
             }

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -29,6 +29,7 @@ const KEY_WALLET_ACCOUNTS = KEY_UNIQUE_PREFIX + 'wallet:accounts_v2'
 const KEY_ACTIVE_ACCOUNT_ID = KEY_UNIQUE_PREFIX + 'wallet:active_account_id_v2'
 const ACCESS_KEY_FUNDING_AMOUNT = process.env.REACT_APP_ACCESS_KEY_FUNDING_AMOUNT || '100000000'
 const ACCOUNT_ID_REGEX = /^(([a-z\d]+[-_])*[a-z\d]+\.)*([a-z\d]+[-_])*[a-z\d]+$/
+export const keyAccountConfirmed = (accountId) => `wallet.account:${accountId}:${NETWORK_ID}:confirmed`
 
 const WALLET_METADATA_METHOD = '__wallet__metadata'
 
@@ -130,18 +131,18 @@ class Wallet {
     async refreshAccount() {
         try {
             const account = await this.loadAccount()
-            setAccountConfirmed(this.accountId, NETWORK_ID, true)
+            setAccountConfirmed(this.accountId, true)
             return account
         } catch (error) {
             console.error('Error loading account:', error)
 
             if (error.toString().indexOf('does not exist while viewing') !== -1) {
                 const accountId = this.accountId
-                const accountIdNotConfirmed = !getAccountConfirmed(accountId, NETWORK_ID)
+                const accountIdNotConfirmed = !getAccountConfirmed(accountId)
                 
                 this.clearAccountState()
                 const nextAccountId = Object.keys(this.accounts).find((account) => (
-                    getAccountConfirmed(account, NETWORK_ID)
+                    getAccountConfirmed(account)
                 )) || Object.keys(this.accounts)[0]
                 this.selectAccount(nextAccountId)
 
@@ -301,7 +302,7 @@ class Wallet {
     async saveAndSelectAccount(accountId, keyPair) {
         await this.saveAccount(accountId, keyPair)
         this.accountId = accountId
-        setAccountConfirmed(this.accountId, NETWORK_ID, false)
+        setAccountConfirmed(this.accountId, false)
         this.save()
     }
 
@@ -389,7 +390,7 @@ class Wallet {
 
     clearAccountState() {
         delete this.accounts[this.accountId]
-        removeAccountConfirmed(this.accountId, NETWORK_ID)
+        removeAccountConfirmed(this.accountId)
         this.accountId = ''
         this.save()
     }

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -271,7 +271,7 @@ class Wallet {
             }
             await this.saveAndSelectAccount(accountId, keyPair);
         } catch(e) {
-            if (e.toString().indexOf('send_tx_commit has timed out') !== -1 || e instanceof TypeError) {
+            if (e.type === 'TimeoutError' || e.type === 'RetriesExceeded' || e instanceof TypeError) {
                 await this.saveAndSelectAccount(accountId, keyPair)
             }
             else {

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -140,7 +140,10 @@ class Wallet {
                 const accountIdNotConfirmed = !getAccountConfirmed(accountId, NETWORK_ID)
                 
                 this.clearAccountState()
-                this.selectAccount(Object.keys(this.accounts)[0])
+                const nextAccountId = Object.keys(this.accounts).find((account) => (
+                    getAccountConfirmed(account, NETWORK_ID)
+                )) || Object.keys(this.accounts)[0]
+                this.selectAccount(nextAccountId)
 
                 return {
                     loginResetAccount: true,

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -247,18 +247,25 @@ class Wallet {
         this.checkNewAccount(accountId);
         const keyPair = KeyPair.fromRandom('ed25519');
 
-        if (fundingKey && fundingContract) {
-            await this.createNewAccountLinkdrop(accountId, fundingKey, fundingContract, keyPair);
-            await this.keyStore.removeKey(NETWORK_ID, fundingContract)
-
-        } else {
-            await sendJson('POST', CONTRACT_CREATE_ACCOUNT_URL, {
-                newAccountId: accountId,
-                newAccountPublicKey: keyPair.publicKey.toString()
-            })
+        try {
+            if (fundingKey && fundingContract) {
+                await this.createNewAccountLinkdrop(accountId, fundingKey, fundingContract, keyPair)
+                await this.keyStore.removeKey(NETWORK_ID, fundingContract)
+            } else {
+                await sendJson('POST', CONTRACT_CREATE_ACCOUNT_URL, {
+                    newAccountId: accountId,
+                    newAccountPublicKey: keyPair.publicKey.toString()
+                })
+            }
+            await this.saveAndSelectAccount(accountId, keyPair);
+        } catch(e) {
+            if (e.toString().indexOf('send_tx_commit has timed out') !== -1 || e instanceof TypeError) {
+                await this.saveAndSelectAccount(accountId, keyPair)
+            }
+            else {
+                throw e
+            }
         }
-
-        await this.saveAndSelectAccount(accountId, keyPair);
     }
 
     async createNewAccountLinkdrop(accountId, fundingKey, fundingContract, keyPair) {

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -122,35 +122,8 @@ class Wallet {
         await this.getAccount(this.accountId).sendMoney(receiverId, amount)
     }
 
-    redirectToCreateAccount(options = {}, history) {
-        const param = {
-            next_url: window.location.search
-        }
-        if (options.reset_accounts) {
-            param.reset_accounts = true
-        }
-        //  let url = WALLET_CREATE_NEW_ACCOUNT_URL + "?" + $.param(param)
-        let url =
-            '/' +
-            WALLET_CREATE_NEW_ACCOUNT_URL +
-            '/?' +
-            Object.keys(param).map(
-                (p, i) =>
-                    `${i ? '&' : ''}${encodeURIComponent(p)}=${encodeURIComponent(
-                        param[p]
-                    )}`
-            )
-        history ? history.push(url) : window.location.replace(url)
-    }
-
     isEmpty() {
         return !this.accounts || !Object.keys(this.accounts).length
-    }
-
-    redirectIfEmpty(history) {
-        if (this.isEmpty()) {
-            this.redirectToCreateAccount({}, history)
-        }
     }
 
     async refreshAccount() {

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -153,6 +153,26 @@ class Wallet {
         }
     }
 
+    async refreshAccount() {
+        try {
+            return await this.loadAccount()
+        } catch (error) {
+            console.error('Error loading account:', error)
+
+            if (error.toString().indexOf('does not exist while viewing') !== -1) {
+                this.clearAccountState()
+                this.selectAccount(Object.keys(this.accounts)[0])
+                return {
+                    loginResetAccount: true,
+                    globalAlertPreventClear: this.isEmpty(),
+                    ...(!this.isEmpty() && await this.loadAccount())
+                }
+            }
+
+            throw error
+        }
+    }
+
     async loadAccount() {
         if (this.isEmpty()) {
             throw new Error('No account.')
@@ -377,6 +397,12 @@ class Wallet {
 
     clearState() {
         this.accounts = {}
+        this.accountId = ''
+        this.save()
+    }
+
+    clearAccountState() {
+        delete this.accounts[this.accountId]
         this.accountId = ''
         this.save()
     }

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -387,12 +387,6 @@ class Wallet {
         return availableKeys
     }
 
-    clearState() {
-        this.accounts = {}
-        this.accountId = ''
-        this.save()
-    }
-
     clearAccountState() {
         delete this.accounts[this.accountId]
         removeAccountConfirmed(this.accountId, NETWORK_ID)

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -128,17 +128,25 @@ class Wallet {
 
     async refreshAccount() {
         try {
-            return await this.loadAccount()
+            const account = await this.loadAccount()
+            localStorage.setItem(`wallet.account:${this.accountId}:${NETWORK_ID}:confirmed`, true)
+            return account
         } catch (error) {
             console.error('Error loading account:', error)
 
             if (error.toString().indexOf('does not exist while viewing') !== -1) {
+                const accountId = this.accountId
+                const accountIdConfirmed = localStorage.getItem(`wallet.account:${accountId}:${NETWORK_ID}:confirmed`) === 'false'
+                
                 this.clearAccountState()
                 this.selectAccount(Object.keys(this.accounts)[0])
+
                 return {
                     loginResetAccount: true,
-                    globalAlertPreventClear: this.isEmpty(),
-                    ...(!this.isEmpty() && await this.loadAccount())
+                    loginResetAccountPreventClear: accountIdConfirmed,
+                    loginResetAccountNotConfirmed: accountId,
+                    globalAlertPreventClear: accountIdConfirmed || this.isEmpty(),
+                    ...(!this.isEmpty() && !accountIdConfirmed && await this.loadAccount())
                 }
             }
 
@@ -283,6 +291,7 @@ class Wallet {
     async saveAndSelectAccount(accountId, keyPair) {
         await this.saveAccount(accountId, keyPair)
         this.accountId = accountId
+        localStorage.setItem(`wallet.account:${this.accountId}:${NETWORK_ID}:confirmed`, false)
         this.save()
     }
 
@@ -376,6 +385,7 @@ class Wallet {
 
     clearAccountState() {
         delete this.accounts[this.accountId]
+        localStorage.removeItem(`wallet.account:${this.accountId}:${NETWORK_ID}:confirmed`)
         this.accountId = ''
         this.save()
     }

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -9,6 +9,7 @@ import { getAccessKeys } from '../actions/account'
 import { generateSeedPhrase } from 'near-seed-phrase';
 import { getAccountIds } from './explorer-api'
 import { WalletError } from './walletError'
+import { setAccountConfirmed, getAccountConfirmed, removeAccountConfirmed} from './localStorage'
 
 export const WALLET_CREATE_NEW_ACCOUNT_URL = 'create'
 export const WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS = ['create', 'set-recovery', 'setup-seed-phrase', 'recover-account', 'recover-seed-phrase', 'sign-in-ledger']
@@ -129,24 +130,24 @@ class Wallet {
     async refreshAccount() {
         try {
             const account = await this.loadAccount()
-            localStorage.setItem(`wallet.account:${this.accountId}:${NETWORK_ID}:confirmed`, true)
+            setAccountConfirmed(this.accountId, NETWORK_ID, true)
             return account
         } catch (error) {
             console.error('Error loading account:', error)
 
             if (error.toString().indexOf('does not exist while viewing') !== -1) {
                 const accountId = this.accountId
-                const accountIdConfirmed = localStorage.getItem(`wallet.account:${accountId}:${NETWORK_ID}:confirmed`) === 'false'
+                const accountIdNotConfirmed = !getAccountConfirmed(accountId, NETWORK_ID)
                 
                 this.clearAccountState()
                 this.selectAccount(Object.keys(this.accounts)[0])
 
                 return {
                     loginResetAccount: true,
-                    loginResetAccountPreventClear: accountIdConfirmed,
+                    loginResetAccountPreventClear: accountIdNotConfirmed,
                     loginResetAccountNotConfirmed: accountId,
-                    globalAlertPreventClear: accountIdConfirmed || this.isEmpty(),
-                    ...(!this.isEmpty() && !accountIdConfirmed && await this.loadAccount())
+                    globalAlertPreventClear: accountIdNotConfirmed || this.isEmpty(),
+                    ...(!this.isEmpty() && !accountIdNotConfirmed && await this.loadAccount())
                 }
             }
 
@@ -291,7 +292,7 @@ class Wallet {
     async saveAndSelectAccount(accountId, keyPair) {
         await this.saveAccount(accountId, keyPair)
         this.accountId = accountId
-        localStorage.setItem(`wallet.account:${this.accountId}:${NETWORK_ID}:confirmed`, false)
+        setAccountConfirmed(this.accountId, NETWORK_ID, false)
         this.save()
     }
 
@@ -385,7 +386,7 @@ class Wallet {
 
     clearAccountState() {
         delete this.accounts[this.accountId]
-        localStorage.removeItem(`wallet.account:${this.accountId}:${NETWORK_ID}:confirmed`)
+        removeAccountConfirmed(this.accountId, NETWORK_ID)
         this.accountId = ''
         this.save()
     }

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -149,7 +149,7 @@ class Wallet {
                     resetAccount: {
                         reset: true,
                         preventClear: accountIdNotConfirmed,
-                        accountIdNotConfirmed: accountId
+                        accountIdNotConfirmed: accountIdNotConfirmed ? accountId : ''
                     },
                     globalAlertPreventClear: accountIdNotConfirmed || this.isEmpty(),
                     globalAlert: {


### PR DESCRIPTION
This is the second attempt for #349 changes, with a different flow. 

With these changes when the account exists in local storage but does not exist in the blockchain, we will clear the account (only this one) from local storage. Next:
1. If the user has another account we will load the account, leave him on the same page and show GlobalAlert with info. 
2. If the user does not have another account he will be redirected to Create Account and we will show the same globalAlert.

#349 can be closed.

<a href="https://gitpod.io/#https://github.com/nearprotocol/near-wallet/pull/443"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nearprotocol/near-wallet.git/198ea3838fc5e55710926d19701780a7514e3d57.svg" /></a>

