### PR TITLE
Clear transactions for new accountId (#519)

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -147,10 +147,13 @@ export const { initializeRecoveryMethod, setupRecoveryMessage, deleteRecoveryMet
         wallet.checkAccountAvailable.bind(wallet),
         () => defaultCodesFor('account.available')
     ],
-    GET_TRANSACTIONS: [getTransactionsApi.bind(wallet), () => ({})],
+    GET_TRANSACTIONS: [
+        getTransactionsApi.bind(wallet), 
+        (accountId) => ({ accountId })
+    ],
     GET_TRANSACTION_STATUS: [
         ((transactionExtraInfo.bind(wallet))),
-        (hash) => ({ hash })
+        (hash, signer_id, accountId) => ({ hash, accountId })
     ],
     CLEAR: null,
     CLEAR_CODE: null

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -2,7 +2,6 @@ import sendJson from 'fetch-send-json'
 import { parse, stringify } from 'query-string'
 import { createActions, createAction } from 'redux-actions'
 import { ACCOUNT_HELPER_URL, wallet } from '../utils/wallet'
-import { getTransactions as getTransactionsApi, transactionExtraInfo } from '../utils/explorer-api'
 import { push } from 'connected-react-router'
 import { loadState, saveState, clearState } from '../utils/sessionStorage'
 import { WALLET_CREATE_NEW_ACCOUNT_URL, WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS, WALLET_LOGIN_URL } from '../utils/wallet'
@@ -146,14 +145,6 @@ export const { initializeRecoveryMethod, setupRecoveryMessage, deleteRecoveryMet
     CHECK_ACCOUNT_AVAILABLE: [
         wallet.checkAccountAvailable.bind(wallet),
         () => defaultCodesFor('account.available')
-    ],
-    GET_TRANSACTIONS: [
-        getTransactionsApi.bind(wallet), 
-        (accountId) => ({ accountId })
-    ],
-    GET_TRANSACTION_STATUS: [
-        ((transactionExtraInfo.bind(wallet))),
-        (hash, signer_id, accountId) => ({ hash, accountId })
     ],
     CLEAR: null,
     CLEAR_CODE: null

--- a/src/actions/transactions.js
+++ b/src/actions/transactions.js
@@ -1,0 +1,13 @@
+import { createActions } from 'redux-actions'
+import { getTransactions as getTransactionsApi, transactionExtraInfo } from '../utils/explorer-api'
+
+export const { getTransactions, getTransactionStatus } = createActions({
+    GET_TRANSACTIONS: [
+        getTransactionsApi, 
+        (accountId) => ({ accountId })
+    ],
+    GET_TRANSACTION_STATUS: [
+        transactionExtraInfo,
+        (hash, signer_id, accountId) => ({ hash, accountId })
+    ]
+})

--- a/src/components/dashboard/ActionsList.js
+++ b/src/components/dashboard/ActionsList.js
@@ -130,7 +130,7 @@ const ActionsList = ({ transaction, wide, accountId, getTransactionStatus }) => 
 
 const ActionRow = ({ transaction, actionArgs, actionKind, wide, showSub = false, accountId, getTransactionStatus }) => {
     const { checkStatus, status, hash, signer_id, block_timestamp } = transaction
-    const getTransactionStatusConditions = () => checkStatus && !document.hidden && getTransactionStatus(hash, signer_id)
+    const getTransactionStatusConditions = () => checkStatus && !document.hidden && getTransactionStatus(hash, signer_id, accountId)
 
     useEffect(() => {
         getTransactionStatusConditions()

--- a/src/components/dashboard/DashboardActivity.js
+++ b/src/components/dashboard/DashboardActivity.js
@@ -95,7 +95,7 @@ const DashboardActivity = ({ image, title, to, transactions, accountId, formLoad
             </Grid.Column>
         </Grid.Row>
 
-        {transactions && transactions.map((transaction, i) => (
+        {transactions.map((transaction, i) => (
             <ActionsList
                 key={`a-${i}`}
                 transaction={transaction} 

--- a/src/components/dashboard/DashboardDetail.js
+++ b/src/components/dashboard/DashboardDetail.js
@@ -41,7 +41,9 @@ class DashboardDetail extends Component {
     }
 
     refreshTransactions() {
-        this.props.getTransactions()
+        const { getTransactions, accountId } = this.props
+        
+        getTransactions(accountId)
     }
 
     refreshAccessKeys = () => {

--- a/src/components/dashboard/DashboardDetail.js
+++ b/src/components/dashboard/DashboardDetail.js
@@ -2,7 +2,10 @@ import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
 import { Translate } from 'react-localize-redux'
 import { withRouter } from 'react-router-dom'
-import { getAccessKeys, getTransactions, getTransactionStatus } from '../../actions/account'
+
+import { getAccessKeys } from '../../actions/account'
+import { getTransactions, getTransactionStatus } from '../../actions/transactions'
+
 import DashboardSection from './DashboardSection'
 import DashboardActivity from './DashboardActivity'
 import PageContainer from '../common/PageContainer'
@@ -136,8 +139,9 @@ const mapDispatchToProps = {
     getTransactionStatus
 }
 
-const mapStateToProps = ({ account }) => ({
-    ...account
+const mapStateToProps = ({ account, transactions }) => ({
+    ...account,
+    transactions: transactions[account.accountId] || []
 })
 
 export default connect(

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -92,7 +92,16 @@ const accessKeys = handleActions({
 
 const transactions = handleActions({
     [getTransactions]: (state, { error, payload, ready }) => {
-        const hash = state.transactions && state.transactions.reduce((h, t) => ({
+        const { transactions } = state
+
+        if (!ready && transactions && transactions[0].query_account_id !== state.accountId) {
+            return {
+                ...state,
+                transactions: undefined
+            }
+        }
+
+        const hash = transactions && transactions.reduce((h, t) => ({
             ...h,
             [t.hash_with_index]: t
         }), {})
@@ -109,8 +118,7 @@ const transactions = handleActions({
                         } 
                         : t
                 ))
-                : state.transactions
-
+                : transactions
         })
     },
     [getTransactionStatus]: (state, { error, payload, ready, meta }) => ({

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -91,15 +91,8 @@ const accessKeys = handleActions({
 }, initialState)
 
 const transactions = handleActions({
-    [getTransactions]: (state, { error, payload, ready }) => {
-        const { transactions } = state
-
-        if (!ready && transactions && transactions[0].query_account_id !== state.accountId) {
-            return {
-                ...state,
-                transactions: undefined
-            }
-        }
+    [getTransactions]: (state, { error, payload, ready, meta }) => {
+        const transactions = state.transactions ? state.transactions[meta.accountId] : undefined
 
         const hash = transactions && transactions.reduce((h, t) => ({
             ...h,
@@ -108,36 +101,41 @@ const transactions = handleActions({
         
         return ({
             ...state,
-            transactions: (ready && !error) 
-                ? payload.map((t) => (
-                    (hash && Object.keys(hash).includes(t.hash_with_index))
-                        ? {
-                            ...t,
-                            status: hash[t.hash_with_index].status,
-                            checkStatus: hash[t.hash_with_index].checkStatus
-                        } 
-                        : t
-                ))
-                : transactions
+            transactions: {
+                [meta.accountId]: (ready && !error) 
+                    ? payload[meta.accountId].map((t) => (
+                        (hash && Object.keys(hash).includes(t.hash_with_index))
+                            ? {
+                                ...t,
+                                status: hash[t.hash_with_index].status,
+                                checkStatus: hash[t.hash_with_index].checkStatus
+                            } 
+                            : t
+                    ))
+                    : transactions
+            }
         })
     },
     [getTransactionStatus]: (state, { error, payload, ready, meta }) => ({
         ...state,
-        transactions: state.transactions.map((t) => (
-            t.hash === meta.hash
-                ? {
-                    ...t,
-                    checkStatus: (ready && !error) 
-                        ? !['SuccessValue', 'Failure'].includes(Object.keys(payload.status)[0]) 
-                        : false,
-                    status: (ready && !error) 
-                        ? Object.keys(payload.status)[0] 
-                        : error 
-                            ? 'notAvailable' 
-                            : ''
-                }
-                : t
-        ))
+        transactions: state.transactions 
+            ? {[meta.accountId]: state.transactions[meta.accountId].map((t) => (
+                t.hash === meta.hash
+                    ? {
+                        ...t,
+                        checkStatus: (ready && !error) 
+                            ? !['SuccessValue', 'Failure'].includes(Object.keys(payload.status)[0]) 
+                            : false,
+                        status: (ready && !error) 
+                            ? Object.keys(payload.status)[0] 
+                            : error 
+                                ? 'notAvailable' 
+                                : ''
+                    }
+                    : t
+            ))}
+            : undefined
+        
     })
 }, initialState)
 

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -4,7 +4,6 @@ import reduceReducers from 'reduce-reducers'
 import {
     requestCode,
     getAccessKeys,
-    getTransactions,
     clear,
     clearCode,
     addAccessKey,
@@ -13,7 +12,6 @@ import {
     refreshUrl,
     refreshAccount,
     resetAccounts,
-    getTransactionStatus,
     setFormLoader
 } from '../../actions/account'
 
@@ -90,55 +88,6 @@ const accessKeys = handleActions({
     })
 }, initialState)
 
-const transactions = handleActions({
-    [getTransactions]: (state, { error, payload, ready, meta }) => {
-        const transactions = state.transactions ? state.transactions[meta.accountId] : undefined
-
-        const hash = transactions && transactions.reduce((h, t) => ({
-            ...h,
-            [t.hash_with_index]: t
-        }), {})
-        
-        return ({
-            ...state,
-            transactions: {
-                [meta.accountId]: (ready && !error) 
-                    ? payload[meta.accountId].map((t) => (
-                        (hash && Object.keys(hash).includes(t.hash_with_index))
-                            ? {
-                                ...t,
-                                status: hash[t.hash_with_index].status,
-                                checkStatus: hash[t.hash_with_index].checkStatus
-                            } 
-                            : t
-                    ))
-                    : transactions
-            }
-        })
-    },
-    [getTransactionStatus]: (state, { error, payload, ready, meta }) => ({
-        ...state,
-        transactions: state.transactions 
-            ? {[meta.accountId]: state.transactions[meta.accountId].map((t) => (
-                t.hash === meta.hash
-                    ? {
-                        ...t,
-                        checkStatus: (ready && !error) 
-                            ? !['SuccessValue', 'Failure'].includes(Object.keys(payload.status)[0]) 
-                            : false,
-                        status: (ready && !error) 
-                            ? Object.keys(payload.status)[0] 
-                            : error 
-                                ? 'notAvailable' 
-                                : ''
-                    }
-                    : t
-            ))}
-            : undefined
-        
-    })
-}, initialState)
-
 const url = handleActions({
     [refreshUrl]: (state, { payload }) => ({
         ...state,
@@ -196,7 +145,6 @@ export default reduceReducers(
     requestResultClearReducer,
     recoverCodeReducer,
     accessKeys,
-    transactions,
     account,
     url
 )

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,6 +5,7 @@ import { localizeReducer } from 'react-localize-redux';
 import allAccounts from '../reducers/allAccounts'
 import availableAccounts from './available-accounts'
 import account from './account'
+import transactions from './transactions'
 import sign from './sign'
 import recoveryMethods from '../reducers/recoveryMethods'
 
@@ -13,6 +14,7 @@ export default (history) => combineReducers({
     allAccounts,
     availableAccounts,
     account,
+    transactions,
     sign,
     recoveryMethods,
     router: connectRouter(history)

--- a/src/reducers/transactions/index.js
+++ b/src/reducers/transactions/index.js
@@ -1,0 +1,54 @@
+import { handleActions } from 'redux-actions'
+
+import {
+    getTransactions,
+    getTransactionStatus
+} from '../../actions/transactions'
+
+const initialState = {}
+
+const transactions = handleActions({
+    [getTransactions]: (state, { error, payload, ready, meta }) => {
+        const transactions = state ? state[meta.accountId] : undefined
+
+        const hash = transactions && transactions.reduce((h, t) => ({
+            ...h,
+            [t.hash_with_index]: t
+        }), {})
+        
+        return ({
+            ...state,
+            [meta.accountId]: (ready && !error) 
+                ? payload[meta.accountId].map((t) => (
+                    (hash && Object.keys(hash).includes(t.hash_with_index))
+                        ? {
+                            ...t,
+                            status: hash[t.hash_with_index].status,
+                            checkStatus: hash[t.hash_with_index].checkStatus
+                        } 
+                        : t
+                ))
+                : transactions
+        })
+    },
+    [getTransactionStatus]: (state, { error, payload, ready, meta }) => ({
+        ...state,
+        [meta.accountId]: state[meta.accountId].map((t) => (
+            t.hash === meta.hash
+                ? {
+                    ...t,
+                    checkStatus: (ready && !error) 
+                        ? !['SuccessValue', 'Failure'].includes(Object.keys(payload.status)[0]) 
+                        : false,
+                    status: (ready && !error) 
+                        ? Object.keys(payload.status)[0] 
+                        : error 
+                            ? 'notAvailable' 
+                            : ''
+                }
+                : t
+        ))
+    })
+}, initialState)
+
+export default transactions

--- a/src/utils/explorer-api.js
+++ b/src/utils/explorer-api.js
@@ -22,7 +22,8 @@ export async function getTransactions(accountId = '') {
                     transactions.block_timestamp, 
                     actions.action_type as kind, 
                     actions.action_args as args,
-                    actions.action_index || ':' || transactions.hash as hash_with_index
+                    actions.action_index || ':' || transactions.hash as hash_with_index,
+                    :accountId as query_account_id
                 FROM 
                     transactions
                 LEFT JOIN actions ON actions.transaction_hash = transactions.hash

--- a/src/utils/explorer-api.js
+++ b/src/utils/explorer-api.js
@@ -6,9 +6,8 @@ const WAMP_NEAR_EXPLORER_TOPIC_PREFIX = process.env.WAMP_NEAR_EXPLORER_TOPIC_PRE
 
 const wamp = new Wampy(WAMP_NEAR_EXPLORER_URL, { realm: 'near-explorer' })
 
-export async function getTransactions(accountId = '') {
-    if (!this.accountId) return null
-    if (!accountId) accountId = this.accountId
+export async function getTransactions(accountId) {
+    if (!accountId) return []
 
     const tx = await new Promise((resolve, reject) => wamp.call(
         `${WAMP_NEAR_EXPLORER_TOPIC_PREFIX}.select`,

--- a/src/utils/explorer-api.js
+++ b/src/utils/explorer-api.js
@@ -7,7 +7,7 @@ const WAMP_NEAR_EXPLORER_TOPIC_PREFIX = process.env.WAMP_NEAR_EXPLORER_TOPIC_PRE
 const wamp = new Wampy(WAMP_NEAR_EXPLORER_URL, { realm: 'near-explorer' })
 
 export async function getTransactions(accountId) {
-    if (!accountId) return []
+    if (!accountId) return {}
 
     const tx = await new Promise((resolve, reject) => wamp.call(
         `${WAMP_NEAR_EXPLORER_TOPIC_PREFIX}.select`,
@@ -44,12 +44,13 @@ export async function getTransactions(accountId) {
             }
         }
     ));
-    
-    return tx.map((t, i) => ({
-        ...t,
-        checkStatus: !(i && t.hash === tx[i - 1].hash),
-        query_account_id: accountId
-    }))
+
+    return {
+        [accountId]: tx.map((t, i) => ({
+            ...t,
+            checkStatus: !(i && t.hash === tx[i - 1].hash)
+        }))
+    }
 }
 
 export const transactionExtraInfo = (hash, signer_id) => wallet.connection.provider.sendJsonRpc('tx', [hash, signer_id])

--- a/src/utils/explorer-api.js
+++ b/src/utils/explorer-api.js
@@ -22,8 +22,7 @@ export async function getTransactions(accountId = '') {
                     transactions.block_timestamp, 
                     actions.action_type as kind, 
                     actions.action_args as args,
-                    actions.action_index || ':' || transactions.hash as hash_with_index,
-                    :accountId as query_account_id
+                    actions.action_index || ':' || transactions.hash as hash_with_index
                 FROM 
                     transactions
                 LEFT JOIN actions ON actions.transaction_hash = transactions.hash
@@ -49,7 +48,8 @@ export async function getTransactions(accountId = '') {
     
     return tx.map((t, i) => ({
         ...t,
-        checkStatus: !(i && t.hash === tx[i - 1].hash)
+        checkStatus: !(i && t.hash === tx[i - 1].hash),
+        query_account_id: accountId
     }))
 }
 


### PR DESCRIPTION
Thanks to this change, the transactions list will be cleared (before fetching a new list) if the user will create a new account, recover account, or switch account.

<a href="https://gitpod.io/#https://github.com/nearprotocol/near-wallet/pull/541"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nearprotocol/near-wallet.git/345b8ebbffca3f3c04927f9c61b74fae2c473b61.svg" /></a>

