### PR TITLE
Pass explicit storage prefix for BrowserLocalStorageKeyStore

### DIFF
--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -43,7 +43,7 @@ async function getKeyMeta(publicKey) {
 
 class Wallet {
     constructor() {
-        this.keyStore = new nearlib.keyStores.BrowserLocalStorageKeyStore()
+        this.keyStore = new nearlib.keyStores.BrowserLocalStorageKeyStore(window.localStorage, 'nearlib')
         const inMemorySigner = new nearlib.InMemorySigner(this.keyStore)
 
         async function getLedgerKey(accountId) {


### PR DESCRIPTION
https://github.com/near/near-api-js/commit/a69016a616a8a99052059adbb323c2422ab27200 needed to avoid troubles with keys after near-api-js rename