### PR TITLE
Pass explicit storage prefix for BrowserLocalStorageKeyStore

### DIFF
--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -43,7 +43,7 @@ async function getKeyMeta(publicKey) {
 
 class Wallet {
     constructor() {
-        this.keyStore = new nearlib.keyStores.BrowserLocalStorageKeyStore()
+        this.keyStore = new nearlib.keyStores.BrowserLocalStorageKeyStore(window.localStorage, 'nearlib')
         const inMemorySigner = new nearlib.InMemorySigner(this.keyStore)
 
         async function getLedgerKey(accountId) {

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -43,7 +43,7 @@ async function getKeyMeta(publicKey) {
 
 class Wallet {
     constructor() {
-        this.keyStore = new nearlib.keyStores.BrowserLocalStorageKeyStore(window.localStorage, 'nearlib')
+        this.keyStore = new nearlib.keyStores.BrowserLocalStorageKeyStore(window.localStorage, 'nearlib:')
         const inMemorySigner = new nearlib.InMemorySigner(this.keyStore)
 
         async function getLedgerKey(accountId) {


### PR DESCRIPTION
near/near-api-js@a69016a needed to avoid troubles with keys after near-api-js rename