### PR TITLE
phrase recovery: remove input regex

### DIFF
--- a/src/components/accounts/RecoverAccountSeedPhraseForm.js
+++ b/src/components/accounts/RecoverAccountSeedPhraseForm.js
@@ -42,7 +42,6 @@ const RecoverAccountSeedPhraseForm = ({
                             value={seedPhrase}
                             required
                             tabIndex='2'
-                            pattern='[a-zA-Z ]*'
                             style={{ width: '100%' }}
                         />
                     )}


### PR DESCRIPTION
We've had reports of users encountering "Please match the requested format" when trying to recover with seed phrase. Reproducibility is unpredictable but I've encountered it myself sometimes when copying phrase from Apple notes app.

`pattern='[a-zA-Z ]*'`

https://github.com/near/near-wallet/issues/653