### PR TITLE
keep order of recovery methods fixed on profile

### DIFF
--- a/src/components/profile/Profile.js
+++ b/src/components/profile/Profile.js
@@ -27,9 +27,11 @@ export function Profile({ match }) {
             <ProfileSection>
                 <ProfileDetails account={account} />
                 {accountId === loginAccountId && (
-                    <RecoveryContainer />
+                    <>
+                        <RecoveryContainer/>
+                        <HardwareDevices/>
+                    </>
                 )}
-                <HardwareDevices/>
             </ProfileSection>
         </PageContainer>
     )

--- a/src/components/profile/Recovery/ActiveMethod.js
+++ b/src/components/profile/Recovery/ActiveMethod.js
@@ -122,9 +122,7 @@ class ActiveMethod extends Component {
     render() {
 
         const { disable, username } = this.state;
-        const { data, onResend, onDelete, accountId } = this.props;
-        const deletingMethod = this.props.deletingMethod === data.detail;
-        const resendingLink = this.props.resendingLink === data.detail;
+        const { data, onResend, onDelete, accountId, deletingMethod, resendingLink } = this.props;
 
         if (!disable) {
             return (

--- a/src/components/profile/Recovery/InactiveMethod.js
+++ b/src/components/profile/Recovery/InactiveMethod.js
@@ -28,7 +28,7 @@ const Button = styled(Link)`
     }
 `
 
-const InactiveMethod = ({ method, accountId, activeMethods }) => (
+const InactiveMethod = ({ method, accountId }) => (
     <NotEnabledContainer>
         <Translate id={`recoveryMgmt.methodTitle.${method}`}/>
         <Button to={{

--- a/src/components/profile/Recovery/RecoveryContainer.js
+++ b/src/components/profile/Recovery/RecoveryContainer.js
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import RecoveryMethod from './RecoveryMethod';
 import RecoveryIcon from '../../../images/icon-recovery-grey.svg';
 import ErrorIcon from '../../../images/icon-problems.svg';
-import { Snackbar, snackbarDuration } from '../../common/Snackbar';
 import { Translate } from 'react-localize-redux';
 import {
     deleteRecoveryMethod,
@@ -76,8 +75,7 @@ const NoRecoveryMethod = styled.div`
 `
 
 const RecoveryContainer = () => {
-
-    const [successSnackbar, setSuccessSnackbar] = useState(false);
+    
     const [deletingMethod, setDeletingMethod] = useState('');
     const [resendingLink, setResendingLink] = useState('');
 
@@ -111,8 +109,6 @@ const RecoveryContainer = () => {
 
         if (!error) {
             dispatch(loadRecoveryMethods())
-            setSuccessSnackbar(true)
-            setTimeout(() => {setSuccessSnackbar(false)}, snackbarDuration)
         }
 
         setResendingLink('')
@@ -167,12 +163,6 @@ const RecoveryContainer = () => {
                 height='50px'
                 number={3}
                 show={loading}
-            />
-            <Snackbar
-                theme='success'
-                message={<Translate id='recoveryMgmt.recoveryLinkSent' />}
-                show={successSnackbar}
-                onHide={() => setSuccessSnackbar(false)}
             />
         </Container>
     );

--- a/src/components/profile/Recovery/RecoveryContainer.js
+++ b/src/components/profile/Recovery/RecoveryContainer.js
@@ -85,8 +85,9 @@ const RecoveryContainer = () => {
     const activeMethods = useRecoveryMethods(accountId).filter(method => method.confirmed);
 
     const allKinds = ['email', 'phone', 'phrase'];
-    const activeKinds = activeMethods.map(method => method.kind)
-    const uniqueActiveKinds = [...new Set(activeKinds)]
+    const currentActiveKinds = new Set(activeMethods.map(method => method.kind));
+    const missingKinds = allKinds.filter(kind => !currentActiveKinds.has(kind))
+    missingKinds.forEach(element => activeMethods.push({kind: element}));
 
     const loading = account.actionsPending.includes('LOAD_RECOVERY_METHODS') || account.actionsPending.includes('REFRESH_ACCOUNT');
 
@@ -112,18 +113,6 @@ const RecoveryContainer = () => {
         }
 
         setResendingLink('')
-    }
-
-    if (!allKinds.every(i => uniqueActiveKinds.includes(i))) {
-        if (!uniqueActiveKinds.includes('email')) {
-            activeMethods.push({kind:'email'})
-        }
-        if (!uniqueActiveKinds.includes('phone')) {
-            activeMethods.push({kind:'phone'})
-        }
-        if (!uniqueActiveKinds.includes('phrase')) {
-            activeMethods.push({kind:'phrase'})
-        }
     }
 
     const sortedActiveMethods = activeMethods.sort((a, b) => {

--- a/src/components/profile/Recovery/RecoveryContainer.js
+++ b/src/components/profile/Recovery/RecoveryContainer.js
@@ -87,7 +87,7 @@ const RecoveryContainer = () => {
     const allKinds = ['email', 'phone', 'phrase'];
     const currentActiveKinds = new Set(activeMethods.map(method => method.kind));
     const missingKinds = allKinds.filter(kind => !currentActiveKinds.has(kind))
-    missingKinds.forEach(element => activeMethods.push({kind: element}));
+    missingKinds.forEach(kind => activeMethods.push({kind: kind}));
 
     const loading = account.actionsPending.includes('LOAD_RECOVERY_METHODS') || account.actionsPending.includes('REFRESH_ACCOUNT');
 

--- a/src/components/profile/Recovery/RecoveryMethod.js
+++ b/src/components/profile/Recovery/RecoveryMethod.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import ActiveMethod from './ActiveMethod';
+import InactiveMethod from './InactiveMethod';
+
+const RecoveryMethod = ({
+    method,
+    accountId,
+    resendingLink,
+    deletingMethod,
+    onResend,
+    onDelete
+}) => {
+
+    if (method.publicKey) {
+        return (
+            <ActiveMethod
+                data={method}
+                onResend={onResend}
+                onDelete={onDelete}
+                deletingMethod={deletingMethod}
+                resendingLink={resendingLink}
+                accountId={accountId}
+            />
+        )
+    } else {
+        return (
+            <InactiveMethod
+                method={method.kind}
+                accountId={accountId}
+            />
+        )
+    }
+}
+
+export default RecoveryMethod;

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -40,9 +40,9 @@ const loaderReducer = (state, { type, ready }) => {
 const globalAlertReducer = handleActions({
     // TODO: Reset state before action somehow. On navigate / start of other action?
     // TODO: Make this generic to avoid listing actions
-    [combineActions(addAccessKey, addAccessKeySeedPhrase, setupRecoveryMessage, deleteRecoveryMethod, sendNewRecoveryLink)]: (state, { error, payload, meta }) => ({
+    [combineActions(addAccessKey, addAccessKeySeedPhrase, setupRecoveryMessage, deleteRecoveryMethod, sendNewRecoveryLink)]: (state, { error, ready, payload, meta }) => ({
         ...state,
-        globalAlert: !!payload || error ? {
+        globalAlert: ready ? {
             success: !error,
             errorMessage: (error && payload && payload.toString()) || undefined,
             messageCode: error ? payload.messageCode || meta.errorCode || payload.id : meta.successCode,
@@ -52,17 +52,17 @@ const globalAlertReducer = handleActions({
     [clearAlert]: state => Object.keys(state).reduce((obj, key) => key !== 'globalAlert' ? (obj[key] = state[key], obj) : obj, {})
 }, initialState)
 
-const requestResultReducer = (state, { error, payload, meta }) => {
+const requestResultReducer = (state, { error, ready, payload, meta }) => {
     if (!meta || !meta.successCode) {
         return state
     }
     return {
         ...(state || initialState),
-        requestStatus: !!payload || error ? {
+        requestStatus: ready ? {
             success: !error,
             errorMessage: (error && payload && payload.toString()) || undefined,
             messageCode: error ? payload.messageCode || meta.errorCode : meta.successCode,
-            id: payload.id || undefined
+            id: (payload && payload.id) || undefined
         } : undefined
     }
 }

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -14,7 +14,8 @@ import {
     refreshAccount,
     resetAccounts,
     setFormLoader,
-    deleteRecoveryMethod
+    deleteRecoveryMethod,
+    sendNewRecoveryLink
 } from '../../actions/account'
 
 const initialState = {
@@ -39,7 +40,7 @@ const loaderReducer = (state, { type, ready }) => {
 const globalAlertReducer = handleActions({
     // TODO: Reset state before action somehow. On navigate / start of other action?
     // TODO: Make this generic to avoid listing actions
-    [combineActions(addAccessKey, addAccessKeySeedPhrase, setupRecoveryMessage, deleteRecoveryMethod)]: (state, { error, payload, meta }) => ({
+    [combineActions(addAccessKey, addAccessKeySeedPhrase, setupRecoveryMessage, deleteRecoveryMethod, sendNewRecoveryLink)]: (state, { error, payload, meta }) => ({
         ...state,
         globalAlert: !!payload || error ? {
             success: !error,

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -34,6 +34,10 @@
             "success": "Recovery setup is complete.",
             "error": "An error occurred while setting up your recovery method. Please try again!"
         },
+        "sendNewRecoveryLink": {
+            "success": "Recovery link successfully sent!",
+            "error": "Failed to resend. Please try again."
+        },
         "login": {
             "success": "${title} is now authorized to use your account.",
             "error": "An error occurred while approving this action. Please try again!",

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -406,7 +406,7 @@ class Wallet {
     async replaceAccessKey(oldKey, newKey) {
         const accountId = this.accountId;
         await this.getAccount(accountId).addKey(newKey)
-        return await this.removeAccessKey(oldKey)
+        await this.removeAccessKey(oldKey)
     }
 
     async sendNewRecoveryLink(method) {
@@ -418,9 +418,8 @@ class Wallet {
             method,
             seedPhrase,
             publicKey
-        })
-        return await this.replaceAccessKey(method.publicKey, publicKey)
-
+        });
+        await this.replaceAccessKey(method.publicKey, publicKey)
     }
 
     async deleteRecoveryMethod({ kind, publicKey }) {

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -413,13 +413,15 @@ class Wallet {
         const accountId = this.accountId;
         const { seedPhrase, publicKey } = generateSeedPhrase();
 
-        await this.postSignedJson('/account/resendRecoveryLink', {
-            accountId,
-            method,
-            seedPhrase,
-            publicKey
-        });
-        await this.replaceAccessKey(method.publicKey, publicKey);
+        return await Promise.all([
+            this.postSignedJson('/account/resendRecoveryLink', {
+                accountId,
+                method,
+                seedPhrase,
+                publicKey
+            }), 
+            this.replaceAccessKey(method.publicKey, publicKey)
+        ]);
     }
 
     async deleteRecoveryMethod({ kind, publicKey }) {

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -406,22 +406,21 @@ class Wallet {
     async replaceAccessKey(oldKey, newKey) {
         const accountId = this.accountId;
         await this.getAccount(accountId).addKey(newKey)
-        await this.removeAccessKey(oldKey)
+        return await this.removeAccessKey(oldKey)
     }
 
     async sendNewRecoveryLink(method) {
         const accountId = this.accountId;
         const { seedPhrase, publicKey } = generateSeedPhrase();
 
-        return await Promise.all([
-            this.postSignedJson('/account/resendRecoveryLink', {
-                accountId,
-                method,
-                seedPhrase,
-                publicKey
-            }), 
-            this.replaceAccessKey(method.publicKey, publicKey)
-        ]);
+        await this.postSignedJson('/account/resendRecoveryLink', {
+            accountId,
+            method,
+            seedPhrase,
+            publicKey
+        })
+        return await this.replaceAccessKey(method.publicKey, publicKey)
+
     }
 
     async deleteRecoveryMethod({ kind, publicKey }) {


### PR DESCRIPTION
- Keep order of recovery methods fixed
- Refactor `RecoveryContainer` to use the `useRecoveryMethods` hook
- Replace Snackbar with GlobalAlert for recovery link resend success/failure to keep UX consistent with initial recovery method setup.
- Show Ledger module on profile only if you're logged in to account

cc @corwinharrell 