### PR TITLE
remove 2fa methods from recovery methods list

### DIFF
--- a/src/components/profile/Recovery/RecoveryContainer.js
+++ b/src/components/profile/Recovery/RecoveryContainer.js
@@ -82,7 +82,7 @@ const RecoveryContainer = () => {
     const dispatch = useDispatch();
     const account = useSelector(({ account }) => account);
     const accountId = account.accountId;
-    const activeMethods = useRecoveryMethods(accountId).filter(method => method.confirmed);
+    const activeMethods = useRecoveryMethods(accountId).filter(method => method.publicKey);
 
     const allKinds = ['email', 'phone', 'phrase'];
     const currentActiveKinds = new Set(activeMethods.map(method => method.kind));

--- a/src/components/profile/Recovery/RecoveryContainer.js
+++ b/src/components/profile/Recovery/RecoveryContainer.js
@@ -82,7 +82,7 @@ const RecoveryContainer = () => {
     const dispatch = useDispatch();
     const account = useSelector(({ account }) => account);
     const accountId = account.accountId;
-    const activeMethods = useRecoveryMethods(accountId).filter(method => method.publicKey);
+    const activeMethods = useRecoveryMethods(accountId).filter(method => method.confirmed && method.publicKey);
 
     const allKinds = ['email', 'phone', 'phrase'];
     const currentActiveKinds = new Set(activeMethods.map(method => method.kind));


### PR DESCRIPTION
Bug: List of recovery methods was showing 2FA methods too. Updated filter to exclude any method that doesn't have a publicKey.