### PR TITLE
Add more gas to linkdrop call

### DIFF
--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -330,7 +330,7 @@ class Wallet {
         await contract.create_account_and_claim({
             new_account_id: accountId,
             new_public_key: publicKey
-        });
+        }, "100000000000000");
     }
 
     async saveAndSelectAccount(accountId, keyPair) {


### PR DESCRIPTION
Fixes an issue with not enough gas attached: https://explorer.near.org/transactions/2BUbseT5tzG56kNhzHumQFaPTKc4PfdHGC2TuobGgFBC 