### PR TITLE
(fix) Update README.md - remove mention to https://wallet.nearprotocol.com/ 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/near/near-wallet.svg?branch=master)](https://travis-ci.com/near/near-wallet)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/near/near-wallet) 
 
-This is in-browser web-based wallet for working with NEAR accounts. This wallet stores account keys in open text using the localStorage under https://wallet.nearprotocol.com domain on user's machine.
+This is in-browser web-based wallet for working with NEAR accounts. This wallet stores account keys in open text using the localStorage on user's machine.
 
 WARNING: This wallet shouldn't be used as the only signer for high-value accounts. Make sure to use hardware wallet when substantial amount of NEAR tokens is involved.
 


### PR DESCRIPTION
removed mention to https://wallet.nearprotocol.com/ -- wallet.nearprotocol.com is deprecated
The site and then the local storage can be https://wallet.testnet.near.org/ or https://wallet.near.org/ or others