### PR TITLE
2FA Modal Promise Should Reject With Error

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -169,12 +169,12 @@ export const { initializeRecoveryMethod, validateSecurityCode, initTwoFactor, re
             let promise
             if (requestPending !== null) {
                 promise = new Promise((resolve, reject) => {
-                    requestPending = (verified) => {
+                    requestPending = (verified, error) => {
                         resolve(verified)
                         // if the user was recovering, they should start over
                         wallet.tempTwoFactorAccount = null
                         if (!verified) {
-                            reject('user closed or unverified code')
+                            reject(error)
                         }
                     }
                 })

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -170,12 +170,13 @@ export const { initializeRecoveryMethod, validateSecurityCode, initTwoFactor, re
             if (requestPending !== null) {
                 promise = new Promise((resolve, reject) => {
                     requestPending = (verified, error) => {
-                        resolve(verified)
-                        // if the user was recovering, they should start over
-                        wallet.tempTwoFactorAccount = null
-                        if (!verified) {
+                        if (verified) {
+                            resolve(verified)
+                        } else {
                             reject(error)
                         }
+                        // if the user was recovering, they should start over
+                        wallet.tempTwoFactorAccount = null
                     }
                 })
             }

--- a/src/components/Routing.js
+++ b/src/components/Routing.js
@@ -169,10 +169,10 @@ class Routing extends Component {
                         { 
                             this.props.account.requestPending !== null &&
                             <TwoFactorVerifyModal
-                                onClose={(verified) => {
+                                onClose={(verified, error) => {
                                     const { account, promptTwoFactor } = this.props
                                     // requestPending will resolve (verified == true) or reject the Promise being awaited in the method that dispatched promptTwoFactor
-                                    account.requestPending(verified)
+                                    account.requestPending(verified, error)
                                     // clears requestPending and closes the modal
                                     promptTwoFactor(null)
                                 }}

--- a/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -42,11 +42,12 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
     const handleVerifyCode = async () => {
         try {
             await dispatch(verifyTwoFactor(account.accountId, code))
-        } catch(e) {
-            throw(e)
-        } finally {
             if (onClose) {
                 onClose(true)
+            }
+        } catch(e) {
+            if (onClose) {
+                onClose(false, e)
             }
         }
     }

--- a/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -41,12 +41,8 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
     }, []);
 
     const handleVerifyCode = async () => {
-        try {
-            await dispatch(verifyTwoFactor(account.accountId, code))
-            onClose(true)
-        } catch(e) {
-            onClose(false, e)
-        }
+        await dispatch(verifyTwoFactor(account.accountId, code))
+        onClose(true)
     }
 
     const handleChange = (code) => {

--- a/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -70,7 +70,6 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
         }
     }
     
-    // TODO @patrick please update messaging/translation
     const handleCancelClose = () => onClose(false, new WalletError('Request was cancelled.', 'errors.twoFactor.userCancelled'))
     
     return (
@@ -97,7 +96,7 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
                     <Translate id='button.verifyCode'/>
                 </FormButton>
             </Form>
-            <button onClick={handleCancelClose} className='link color-red' id='close-button'><Translate id='button.cancel'/></button>
+            <button onClick={handleCancelClose} className='link color-red'><Translate id='button.cancel'/></button>
         </Modal>
     );
 }

--- a/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -7,6 +7,7 @@ import MobileActionSheet from '../../common/modal/MobileActionSheet';
 import FormButton from '../../common/FormButton';
 import { Translate } from 'react-localize-redux';
 import TwoFactorVerifyInput from './TwoFactorVerifyInput';
+import { WalletError } from '../../../utils/walletError'
 import { verifyTwoFactor, clearAlert, resendTwoFactor, get2faMethod } from '../../../actions/account';
 
 const Form = styled.form`
@@ -42,13 +43,9 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
     const handleVerifyCode = async () => {
         try {
             await dispatch(verifyTwoFactor(account.accountId, code))
-            if (onClose) {
-                onClose(true)
-            }
+            onClose(true)
         } catch(e) {
-            if (onClose) {
-                onClose(false, e)
-            }
+            onClose(false, e)
         }
     }
 
@@ -73,11 +70,14 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
         }
     }
     
+    // TODO @patrick please update messaging/translation
+    const handleCancelClose = () => onClose(false, new WalletError('Request was cancelled.', 'errors.twoFactor.userCancelled'))
+    
     return (
         <Modal
             id='two-factor-verify-modal'
             isOpen={open}
-            onClose={() => onClose(false, 'The action has been cancelled')}
+            onClose={handleCancelClose}
             closeButton='desktop'
         >
             <ModalTheme/>
@@ -96,8 +96,8 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
                 <FormButton type='submit' disabled={code.length !== 6 || loading} sending={loading}>
                     <Translate id='button.verifyCode'/>
                 </FormButton>
-                <button className='link color-red' id='close-button'><Translate id='button.cancel'/></button>
             </Form>
+            <button onClick={handleCancelClose} className='link color-red' id='close-button'><Translate id='button.cancel'/></button>
         </Modal>
     );
 }

--- a/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -77,7 +77,7 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
         <Modal
             id='two-factor-verify-modal'
             isOpen={open}
-            onClose={() => onClose(false)}
+            onClose={() => onClose(false, 'The action has been cancelled')}
             closeButton='desktop'
         >
             <ModalTheme/>

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -692,7 +692,8 @@
             "lastMethod": "Cannot delete your last recovery method. Unless you have Ledger enabled, you need to keep at least one recovery method active to ensure recoverability of your account."
         },
         "twoFactor": {
-            "userCancelled": "The action was cancelled."
+            "userCancelled": "2FA code was not verified correctly.",
+            "invalidCode": "Invalid 2FA code. Please try again."
         }
     },
 

--- a/src/utils/twoFactor.js
+++ b/src/utils/twoFactor.js
@@ -166,7 +166,6 @@ export class TwoFactor {
                 return await store.dispatch(promptTwoFactor(true)).payload.promise
             } catch (e) {
                 if (e.message.indexOf('not valid') > -1) {
-                    // TODO @patrick please update messaging/translation for invalid 2fa code
                     throw new WalletError(e.message, 'errors.twoFactor.invalidCode')
                 }
                 throw e

--- a/src/utils/twoFactor.js
+++ b/src/utils/twoFactor.js
@@ -163,12 +163,7 @@ export class TwoFactor {
         })
         if (requestId !== -1 && !store.getState().account.requestPending) {
             try {
-                const result = await store.dispatch(promptTwoFactor(true)).payload.promise
-                console.log('result', result)
-                if (!result) {
-                    throw new WalletError('Request was cancelled.', 'errors.twoFactor.userCancelled')
-                }
-                return result
+                return await store.dispatch(promptTwoFactor(true)).payload.promise
             } catch (e) {
                 throw new WalletError('Request was cancelled.', 'errors.twoFactor.userCancelled')
             }

--- a/src/utils/twoFactor.js
+++ b/src/utils/twoFactor.js
@@ -167,7 +167,7 @@ export class TwoFactor {
             } catch (e) {
                 if (e.message.indexOf('not valid') > -1) {
                     // TODO @patrick please update messaging/translation for invalid 2fa code
-                    throw new WalletError(e.message, 'errors.twoFactor.userCancelled')
+                    throw new WalletError(e.message, 'errors.twoFactor.invalidCode')
                 }
                 throw e
             }

--- a/src/utils/twoFactor.js
+++ b/src/utils/twoFactor.js
@@ -165,7 +165,11 @@ export class TwoFactor {
             try {
                 return await store.dispatch(promptTwoFactor(true)).payload.promise
             } catch (e) {
-                throw new WalletError('Request was cancelled.', 'errors.twoFactor.userCancelled')
+                if (e.message.indexOf('not valid') > -1) {
+                    // TODO @patrick please update messaging/translation for invalid 2fa code
+                    throw new WalletError(e.message, 'errors.twoFactor.userCancelled')
+                }
+                throw e
             }
         }
     }

--- a/src/utils/twoFactor.js
+++ b/src/utils/twoFactor.js
@@ -156,21 +156,22 @@ export class TwoFactor {
         if (!method) method = await this.get2faMethod()
         // add request to local storage
         setRequest({ accountId, requestId })
-        try {
-            await this.wallet.postSignedJson('/2fa/send', {
-                accountId,
-                method,
-                requestId,
-            })
-        } catch (e) {
-            throw(e)
-        }
+        await this.wallet.postSignedJson('/2fa/send', {
+            accountId,
+            method,
+            requestId,
+        })
         if (requestId !== -1 && !store.getState().account.requestPending) {
-            const result = await store.dispatch(promptTwoFactor(true)).payload.promise
-            if (!result) {
+            try {
+                const result = await store.dispatch(promptTwoFactor(true)).payload.promise
+                console.log('result', result)
+                if (!result) {
+                    throw new WalletError('Request was cancelled.', 'errors.twoFactor.userCancelled')
+                }
+                return result
+            } catch (e) {
                 throw new WalletError('Request was cancelled.', 'errors.twoFactor.userCancelled')
             }
-            return result
         }
     }
 

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -111,8 +111,6 @@ class Wallet {
         this.accountId = localStorage.getItem(KEY_ACTIVE_ACCOUNT_ID) || ''
 
         this.twoFactor = new TwoFactor(this)
-
-        console.log(this)
     }
 
     async getLocalAccessKey(accountId, accessKeys) {

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -111,6 +111,8 @@ class Wallet {
         this.accountId = localStorage.getItem(KEY_ACTIVE_ACCOUNT_ID) || ''
 
         this.twoFactor = new TwoFactor(this)
+
+        console.log(this)
     }
 
     async getLocalAccessKey(accountId, accessKeys) {


### PR DESCRIPTION
This PR fixes the 2FA modal that was previously reporting success and not throwing errors properly.

It will now reject in the modal promise with the errors from contract helperand for no code / incorrect code and also reject with error if the user cancels the modal.

@Patrick1904 you may want to dive in and customize the error messaging in the UI.

See code changes for where/how errors are being thrown and potential spots to customize by throwing your own WalletError.