### PR TITLE
Fix displaying modal if a new account is being created with email, phone or seed phrase recovery

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -204,7 +204,10 @@ export const { initializeRecoveryMethod, validateSecurityCode, initTwoFactor, re
     ],
     SETUP_RECOVERY_MESSAGE: [
         wallet.setupRecoveryMessage.bind(wallet),
-        () => defaultCodesFor('account.setupRecoveryMessage')
+        (accountId, method, securityCode, isNew) => ({
+            ...defaultCodesFor('account.setupRecoveryMessage'),
+            isNew
+        })
     ],
     DELETE_RECOVERY_METHOD: [
         wallet.deleteRecoveryMethod.bind(wallet),

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -279,7 +279,10 @@ export const { addAccessKey, addAccessKeySeedPhrase, clearAlert } = createAction
 
             await wallet.postSignedJson('/account/seedPhraseAdded', { accountId, publicKey })
         },
-        () => defaultCodesFor('account.setupSeedPhrase')
+        (accountId, recoveryKeyPair, isNew) => ({
+            ...defaultCodesFor('account.setupSeedPhrase'),
+            isNew
+        })
     ],
     CLEAR_ALERT: null,
 })

--- a/src/components/accounts/ledger/SignInLedger.js
+++ b/src/components/accounts/ledger/SignInLedger.js
@@ -24,7 +24,7 @@ export function SignInLedger(props) {
     const accountsApproved = signInWithLedgerKeys.reduce((a, accountId) => signInWithLedgerState[accountId].status === 'success' ? a + 1 : a, 0)
     const totalAccounts = signInWithLedgerKeys.length
     
-    const signingIn = signInWithLedgerState !== undefined
+    const signingIn = signInWithLedgerState !== undefined || txSigned
 
     const handleSignIn = async () => {
         const { error } = await dispatch(signInWithLedger())

--- a/src/reducers/ledger/index.js
+++ b/src/reducers/ledger/index.js
@@ -27,7 +27,7 @@ const ledgerModalReducer = handleActions({
     [combineActions(sendMoney, addAccessKey, signAndSendTransactions, removeAccessKey, addAccessKeySeedPhrase, deleteRecoveryMethod, setupRecoveryMessage, addLedgerAccessKey, getLedgerPublicKey)]: (state, { ready, meta, type }) => ({
         ...state,
         modal: {
-            show: !ready && (state.hasLedger || type === 'ADD_LEDGER_ACCESS_KEY' || type === 'GET_LEDGER_PUBLIC_KEY'),
+            show: !meta.isNew && !ready && (state.hasLedger || type === 'ADD_LEDGER_ACCESS_KEY' || type === 'GET_LEDGER_PUBLIC_KEY'),
             textId: !ready ? `${meta.prefix}.modal` : undefined
         }
     })

--- a/src/reducers/ledger/index.js
+++ b/src/reducers/ledger/index.js
@@ -24,10 +24,10 @@ const initialState = {
 
 // TODO: Avoid listing all individual actions. Two approaches possible: 1) use meta to set a flag 2) dispatch action from Signer when signing is actually requested
 const ledgerModalReducer = handleActions({
-    [combineActions(sendMoney, addAccessKey, signAndSendTransactions, removeAccessKey, addAccessKeySeedPhrase, deleteRecoveryMethod, setupRecoveryMessage, addLedgerAccessKey, getLedgerPublicKey)]: (state, { ready, meta, type }) => ({
+    [combineActions(sendMoney, addAccessKey, signAndSendTransactions, removeAccessKey, addAccessKeySeedPhrase, deleteRecoveryMethod, setupRecoveryMessage, addLedgerAccessKey, getLedgerPublicKey, createNewAccount)]: (state, { ready, meta, type }) => ({
         ...state,
         modal: {
-            show: !meta.isNew && !ready && (state.hasLedger || type === 'ADD_LEDGER_ACCESS_KEY' || type === 'GET_LEDGER_PUBLIC_KEY'),
+            show: !meta.isNew && !ready && (state.hasLedger || type === 'ADD_LEDGER_ACCESS_KEY' || type === 'GET_LEDGER_PUBLIC_KEY' || type === 'CREATE_NEW_ACCOUNT'),
             textId: !ready ? `${meta.prefix}.modal` : undefined
         }
     })

--- a/src/reducers/ledger/index.js
+++ b/src/reducers/ledger/index.js
@@ -28,7 +28,7 @@ const ledgerModalReducer = handleActions({
     [combineActions(sendMoney, addAccessKey, signAndSendTransactions, removeAccessKey, addAccessKeySeedPhrase, deleteRecoveryMethod, setupRecoveryMessage, addLedgerAccessKey, getLedgerPublicKey, createNewAccount)]: (state, { ready, meta, type }) => ({
         ...state,
         modal: {
-            show: !meta.isNew && !ready && (state.hasLedger || type === 'ADD_LEDGER_ACCESS_KEY' || type === 'GET_LEDGER_PUBLIC_KEY' || type === 'CREATE_NEW_ACCOUNT'),
+            show: !meta.isNew && !ready && (state.hasLedger || type === 'ADD_LEDGER_ACCESS_KEY' || type === 'GET_LEDGER_PUBLIC_KEY'),
             textId: !ready ? `${meta.prefix}.modal` : undefined
         },
         txSigned: ready ? undefined : state.txSigned

--- a/src/reducers/ledger/index.js
+++ b/src/reducers/ledger/index.js
@@ -90,14 +90,16 @@ const ledger = handleActions({
         }
     },
     [setLedgerTxSigned]: (state, { payload, meta }) => {
-        const signInWithLedger = Object.keys(state.signInWithLedger).length && {
-            ...state.signInWithLedger,
-            [meta.accountId]: {
-                status: (state.signInWithLedger[meta.accountId].status === 'confirm' && payload.status)
-                    ? 'pending'
-                    : state.signInWithLedger[meta.accountId].status
+        const signInWithLedger = (meta.accountId && Object.keys(state.signInWithLedger || {}).length )
+            ? {
+                ...state.signInWithLedger,
+                [meta.accountId]: {
+                    status: (state.signInWithLedger[meta.accountId].status === 'confirm' && payload.status)
+                        ? 'pending'
+                        : state.signInWithLedger[meta.accountId].status
+                }
             }
-        }
+            : undefined
 
         return {
             ...state,

--- a/src/reducers/ledger/index.js
+++ b/src/reducers/ledger/index.js
@@ -15,7 +15,8 @@ import {
     setupRecoveryMessage,
     addLedgerAccessKey,
     getLedgerPublicKey,
-    setLedgerTxSigned
+    setLedgerTxSigned,
+    createNewAccount
 } from '../../actions/account'
 
 const initialState = {
@@ -29,7 +30,8 @@ const ledgerModalReducer = handleActions({
         modal: {
             show: !meta.isNew && !ready && (state.hasLedger || type === 'ADD_LEDGER_ACCESS_KEY' || type === 'GET_LEDGER_PUBLIC_KEY' || type === 'CREATE_NEW_ACCOUNT'),
             textId: !ready ? `${meta.prefix}.modal` : undefined
-        }
+        },
+        txSigned: ready ? undefined : state.txSigned
     })
 }, initialState)
 

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -17,7 +17,8 @@
                 "create": "Checking availability",
                 "check": "Checking"
             },
-            "errorAccountNotExist": "There was a problem creating your account. Please try again!"
+            "errorAccountNotExist": "There was a problem creating your account. Please try again!",
+            "modal": "You will need to confirm add a key for new account on your Ledger."
         },
         "available": {
             "success": "User found.",


### PR DESCRIPTION
This fixes the issue when `ledger confirm action modal` was displayed while creating a new account if current account had Ledger recovery enabled.