### PR TITLE
Fixes setup seed phrase - start over turns into new account creation

### DIFF
--- a/src/components/accounts/SetupSeedPhrase.js
+++ b/src/components/accounts/SetupSeedPhrase.js
@@ -183,7 +183,7 @@ const mapStateToProps = ({ account }, { match }) => ({
     ...account,
     verify: match.params.verify,
     accountId: match.params.accountId,
-    isNew: !!parseInt(match.params.isNew),
+    isNew: match.params.isNew === '1',
     fundingContract: match.params.fundingContract,
     fundingKey: match.params.fundingKey,
 })

--- a/src/components/accounts/SetupSeedPhraseForm.js
+++ b/src/components/accounts/SetupSeedPhraseForm.js
@@ -48,6 +48,7 @@ const SetupSeedPhraseForm = ({
     handleCopyPhrase,
     match: { params: { isNew, accountId, fundingContract, fundingKey } }
 }) => {
+
     return (
         <CustomDiv>
             <div id='seed-phrase'>
@@ -66,7 +67,7 @@ const SetupSeedPhraseForm = ({
                     <IconMCopy color='#6ad1e3' />
                 </FormButton>
                 <FormButton
-                    linkTo={`/setup-seed-phrase/${accountId}/verify/${isNew ? '1' : '0'}/${fundingContract ? `${fundingContract}/${fundingKey}/` : ``}`}
+                    linkTo={`/setup-seed-phrase/${accountId}/verify/${ isNew }/${fundingContract ? `${fundingContract}/${fundingKey}/` : ``}`}
                     color='blue'
                 >
                     <Translate id='button.continue' />

--- a/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
+++ b/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
@@ -291,7 +291,7 @@ const mapStateToProps = ({ account, router, recoveryMethods }, { match }) => ({
     router,
     accountId: match.params.accountId,
     activeAccountId: account.accountId,
-    isNew: !!parseInt(match.params.isNew),
+    isNew: match.params.isNew === '1',
     fundingContract: match.params.fundingContract,
     fundingKey: match.params.fundingKey,
     recoveryMethods

--- a/src/components/profile/Recovery/InactiveMethod.js
+++ b/src/components/profile/Recovery/InactiveMethod.js
@@ -32,7 +32,7 @@ const InactiveMethod = ({ method, accountId }) => (
     <NotEnabledContainer>
         <Translate id={`recoveryMgmt.methodTitle.${method}`}/>
         <Button to={{
-            pathname: `${method !== 'phrase' ? `/set-recovery/${accountId}` : `/setup-seed-phrase/${accountId}/phrase`}`,
+            pathname: `${method !== 'phrase' ? `/set-recovery/${accountId}` : `/setup-seed-phrase/${accountId}/phrase/0`}`,
             method: method
         }}>
             <Translate id='button.enable'/>


### PR DESCRIPTION
PR fixes adding seed phrase as a "second" recovery option.

Issue: "start over" button flips bit on isNew to true so wallet thinks it's setting up a new account.