### PR TITLE
recovery methods: verify that public key exists on account

### DIFF
--- a/src/components/profile/Recovery/RecoveryContainer.js
+++ b/src/components/profile/Recovery/RecoveryContainer.js
@@ -80,7 +80,8 @@ const RecoveryContainer = () => {
     const dispatch = useDispatch();
     const account = useSelector(({ account }) => account);
     const accountId = account.accountId;
-    const activeMethods = useRecoveryMethods(accountId).filter(method => method.confirmed && method.publicKey && method.kind !== 'ledger');
+    const fullAccessKeys = account.fullAccessKeys.map(key => key.public_key)
+    const activeMethods = useRecoveryMethods(accountId).filter(method => fullAccessKeys.includes(method.publicKey) && method.kind !== 'ledger');
     const allKinds = ['email', 'phone', 'phrase'];
     const currentActiveKinds = new Set(activeMethods.map(method => method.kind));
     const missingKinds = allKinds.filter(kind => !currentActiveKinds.has(kind))


### PR DESCRIPTION
Verify that public key for a recovery method exists on chain before displaying the method as 'active' on profile