### PR TITLE
Hotfix: mitigate ways to lose account

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -277,6 +277,19 @@ export const { addAccessKey, addAccessKeySeedPhrase, clearAlert } = createAction
     ],
     ADD_ACCESS_KEY_SEED_PHRASE: [
         async (accountId, recoveryKeyPair, isNew, fundingContract, fundingKey) => {
+            // TODO: Should this be 2 different actions when you add to existing account / create new one?
+            // TODO: Refactor to "create with public key" action which will save metadata in CH in generic way for all methods?
+
+            // TODO: Remove isNew parameter from everywhere. Stuff available on chain should be queried from chain.
+            try {
+                await wallet.getAccount(accountId).state();
+                isNew = false;
+            } catch (e) {
+                if (e.toString().includes(`does not exist while viewing`)) {
+                    isNew = true;
+                }
+            }
+
             if (isNew) {
                 await wallet.saveAccount(accountId, recoveryKeyPair);
                 await wallet.createNewAccount(accountId, fundingContract, fundingKey, recoveryKeyPair.publicKey)

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -651,6 +651,16 @@ class Wallet {
         const { secretKey } = parseSeedPhrase(recoverySeedPhrase)
         const recoveryKeyPair = KeyPair.fromString(secretKey)
 
+        // TODO: Remove isNew parameter from everywhere. Stuff available on chain should be queried from chain.
+        try {
+            await wallet.getAccount(accountId).state();
+            isNew = false;
+        } catch (e) {
+            if (e.toString().includes(`does not exist while viewing`)) {
+                isNew = true;
+            }
+        }
+
         let securityCodeResult = await this.validateSecurityCode(accountId, method, securityCode, isNew);
         if (!securityCodeResult || securityCodeResult.length === 0) {
             console.log('INVALID CODE', securityCodeResult)


### PR DESCRIPTION
Account created through linkdrop can be fully lost if minor error happens during recovery setup: account still gets created, but users often don't keep original seed phrase.

This change makes sure that in such case there is at least key in localStorage.