### PR TITLE
fix referencing full access keys

### DIFF
--- a/src/components/profile/Recovery/RecoveryContainer.js
+++ b/src/components/profile/Recovery/RecoveryContainer.js
@@ -80,7 +80,7 @@ const RecoveryContainer = () => {
     const dispatch = useDispatch();
     const account = useSelector(({ account }) => account);
     const accountId = account.accountId;
-    const fullAccessKeys = account.fullAccessKeys.map(key => key.public_key)
+    const fullAccessKeys = account.fullAccessKeys && account.fullAccessKeys.map(key => key.public_key)
     const activeMethods = useRecoveryMethods(accountId).filter(method => fullAccessKeys.includes(method.publicKey) && method.kind !== 'ledger');
     const allKinds = ['email', 'phone', 'phrase'];
     const currentActiveKinds = new Set(activeMethods.map(method => method.kind));


### PR DESCRIPTION
Error is sometimes thrown when re-directing to profile post creating an account. Now checking that `fullAccessKeys` exists before mapping.