### PR TITLE
hot fix: twoFactorVerifyModal not returning success with empty return value from rpc

### DIFF
--- a/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -42,11 +42,10 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
 
     const handleVerifyCode = async () => {
         const { success, res } = await dispatch(verifyTwoFactor(code))
-        if (success && typeof res !== 'boolean' && res !== false) {
-            onClose(true)
-        } else {
-            onClose(false, new WalletError('Transaction failed with return value: ' + res))
+        if (success === false || res === false) {
+            return onClose(false, new WalletError('Transaction failed with return value: ' + res))
         }
+        onClose(true)
     }
 
     const handleChange = (code) => {


### PR DESCRIPTION
This fixes the issue with the 2FA modal erroring on close and subsequently the staking modal not closing as a result. 