### PR TITLE
[hot fix] 2fa enabling after 2fa refactor

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -194,7 +194,7 @@ export const {
         () => defaultCodesFor('account.resendTwoFactor')
     ],
     VERIFY_TWO_FACTOR: [
-        (...args) => wallet.twoFactor.verifyRequestCode(...args),
+        wallet.twoFactor.verifyRequestCode.bind(wallet.twoFactor),
         () => defaultCodesFor('account.verifyTwoFactor')
     ],
     PROMPT_TWO_FACTOR: [

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -208,8 +208,6 @@ export const {
                         } else {
                             reject(error)
                         }
-                        // if the user was recovering, they should start over
-                        wallet.tempTwoFactorAccount = null
                     }
                 })
             }

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -182,19 +182,19 @@ export const {
         () => defaultCodesFor('account.validateSecurityCode')
     ],
     INIT_TWO_FACTOR: [
-        wallet.twoFactor.initTwoFactor.bind(wallet.twoFactor),
+        (...args) => wallet.twoFactor.initTwoFactor(...args),
         () => defaultCodesFor('account.initTwoFactor')
     ],
     REINIT_TWO_FACTOR: [
-        wallet.twoFactor.reInitTwoFactor.bind(wallet.twoFactor),
+        (...args) => wallet.twoFactor.reInitTwoFactor(...args),
         () => defaultCodesFor('account.reInitTwoFactor')
     ],
     RESEND_TWO_FACTOR: [
-        wallet.twoFactor.resend.bind(wallet.twoFactor),
+        (...args) => wallet.twoFactor.resend(...args),
         () => defaultCodesFor('account.resendTwoFactor')
     ],
     VERIFY_TWO_FACTOR: [
-        wallet.twoFactor.verifyRequestCode.bind(wallet.twoFactor),
+        (...args) => wallet.twoFactor.verifyRequestCode(...args),
         () => defaultCodesFor('account.verifyTwoFactor')
     ],
     PROMPT_TWO_FACTOR: [
@@ -216,15 +216,15 @@ export const {
         () => defaultCodesFor('account.promptTwoFactor')
     ],
     DEPLOY_MULTISIG: [
-        wallet.twoFactor.deployMultisig.bind(wallet.twoFactor),
+        (...args) => wallet.twoFactor.deployMultisig(...args),
         () => defaultCodesFor('account.deployMultisig')
     ],
     CHECK_CAN_ENABLE_TWO_FACTOR: [
-        wallet.twoFactor.checkCanEnableTwoFactor.bind(wallet.twoFactor),
+        (...args) => wallet.twoFactor.checkCanEnableTwoFactor(...args),
         () => defaultCodesFor('account.checkCanEnableTwoFactor')
     ],
     GET_2FA_METHOD: [
-        wallet.twoFactor.get2faMethod.bind(wallet.twoFactor),
+        (...args) => wallet.twoFactor.get2faMethod(...args),
         () => defaultCodesFor('account.get2faMethod')
     ],
     GET_LEDGER_KEY: [

--- a/src/components/accounts/two_factor/EnableTwoFactor.js
+++ b/src/components/accounts/two_factor/EnableTwoFactor.js
@@ -76,6 +76,9 @@ export function EnableTwoFactor(props) {
         let response;
         try {
             response = await dispatch(initTwoFactor(accountId, method))
+
+            console.log(response, accountId, method)
+            
         } finally {
             if (response && response.confirmed) {
                 handleDeployMultisig()

--- a/src/components/accounts/two_factor/EnableTwoFactor.js
+++ b/src/components/accounts/two_factor/EnableTwoFactor.js
@@ -72,13 +72,9 @@ export function EnableTwoFactor(props) {
     }, [recoveryMethods]);
 
     const handleNext = async () => {
-
         let response;
         try {
             response = await dispatch(initTwoFactor(accountId, method))
-
-            console.log(response, accountId, method)
-            
         } finally {
             if (response && response.confirmed) {
                 handleDeployMultisig()

--- a/src/components/accounts/two_factor/EnableTwoFactor.js
+++ b/src/components/accounts/two_factor/EnableTwoFactor.js
@@ -86,7 +86,7 @@ export function EnableTwoFactor(props) {
     }
 
     const handleConfirm = async (securityCode) => {
-        await dispatch(verifyTwoFactor(accountId, securityCode))
+        await dispatch(verifyTwoFactor(securityCode))
         handleDeployMultisig()
     }
 

--- a/src/utils/twoFactor.js
+++ b/src/utils/twoFactor.js
@@ -26,6 +26,7 @@ export class TwoFactor extends AccountMultisig {
     constructor(wallet) {
         super(wallet.connection, wallet.accountId, localStorage)
         this.wallet = wallet
+        this.accountId = wallet.accountId
     }
 
     async isEnabled() {

--- a/src/utils/twoFactor.js
+++ b/src/utils/twoFactor.js
@@ -72,9 +72,6 @@ export class TwoFactor extends AccountMultisig {
     }
 
     async verifyTwoFactor(securityCode) {
-        if (this.wallet.tempTwoFactorAccount) {
-            accountId = this.wallet.tempTwoFactorAccount.accountId
-        }
         return this.verifyRequestCode(securityCode)
     }
 

--- a/src/utils/twoFactor.js
+++ b/src/utils/twoFactor.js
@@ -26,7 +26,6 @@ export class TwoFactor extends AccountMultisig {
     constructor(wallet) {
         super(wallet.connection, wallet.accountId, localStorage)
         this.wallet = wallet
-        this.accountId = wallet.accountId
     }
 
     async isEnabled() {

--- a/src/utils/twoFactor.js
+++ b/src/utils/twoFactor.js
@@ -47,7 +47,7 @@ export class TwoFactor extends AccountMultisig {
 
     async initTwoFactor(accountId, method) {
         // clear any previous requests in localStorage (for verifyTwoFactor)
-        this.setRequest({})
+        this.setRequest({ requestId: -1 })
         return await this.wallet.postSignedJson('/2fa/init', {
             accountId,
             method
@@ -56,7 +56,7 @@ export class TwoFactor extends AccountMultisig {
 
     async reInitTwoFactor(accountId, method) {
         // clear any previous requests in localStorage (for verifyTwoFactor)
-        this.setRequest({})
+        this.setRequest({ requestId: -1 })
         return this.sendRequest(accountId, method)
     }
 
@@ -71,7 +71,7 @@ export class TwoFactor extends AccountMultisig {
         return this.sendRequest(accountId, method, requestId)
     }
 
-    async verifyTwoFactor(accountId, securityCode) {
+    async verifyTwoFactor(securityCode) {
         if (this.wallet.tempTwoFactorAccount) {
             accountId = this.wallet.tempTwoFactorAccount.accountId
         }

--- a/src/utils/twoFactor.js
+++ b/src/utils/twoFactor.js
@@ -24,7 +24,7 @@ const {
 
 export class TwoFactor extends AccountMultisig {
     constructor(wallet) {
-        super(wallet.connection, wallet.accountId)
+        super(wallet.connection, wallet.accountId, localStorage)
         this.wallet = wallet
     }
 

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -768,6 +768,7 @@ class Wallet {
             // set up temp wallet instance
             this.connection = connection
             this.accountId = accountId
+            this.isRecovering = true
             this.twoFactor = new TwoFactor(this)
             this.twoFactor.accountId = accountId
             this.has2fa = await this.twoFactor.isEnabled()

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -768,7 +768,6 @@ class Wallet {
             // set up temp wallet instance
             this.connection = connection
             this.accountId = accountId
-            this.isRecovering = true
             this.twoFactor = new TwoFactor(this)
             this.twoFactor.accountId = accountId
             this.has2fa = await this.twoFactor.isEnabled()


### PR DESCRIPTION
This fixes enabling of 2fa accounts after we merged the 2fa refactor that depends on new near-api-js AccountMultisig