### PR TITLE
Fix staking max

### DIFF
--- a/src/components/staking/components/AmountInput.js
+++ b/src/components/staking/components/AmountInput.js
@@ -48,7 +48,10 @@ const Container = styled.div`
     }
 `
 
-export default function AmountInput({ value, onChange, valid, loading, availableBalance, insufficientBalance }) {
+export default function AmountInput({
+    value, onChange, valid, loading, insufficientBalance,
+    availableBalance, availableClick = null
+}) {
     let validationStatus
     if (valid) {
         validationStatus = '#6AD1E3'
@@ -69,7 +72,7 @@ export default function AmountInput({ value, onChange, valid, loading, available
                     onChange={e => onChange(e.target.value)}
                 />
             </div>
-            <div className='available-balance'>{insufficientBalance && <span><Translate id='staking.stake.input.insufficientFunds' /> </span>}<Translate id='staking.stake.input.availableBalance' /> <Balance amount={availableBalance} noSymbol={true}/> <Translate id='staking.stake.input.near' /></div>
+            <div className='available-balance' onClick={availableClick}>{insufficientBalance && <span><Translate id='staking.stake.input.insufficientFunds' /> </span>}<Translate id='staking.stake.input.availableBalance' /> <Balance amount={availableBalance} noSymbol={true}/> <Translate id='staking.stake.input.near' /></div>
         </Container>
     )
 }

--- a/src/components/staking/components/AmountInput.js
+++ b/src/components/staking/components/AmountInput.js
@@ -42,6 +42,7 @@ const Container = styled.div`
     }
 
     .available-balance {
+        cursor: pointer;
         margin-top: 10px;
         font-size: 13px;
         color: ${props => props.status === '#ff585d' ? props.status : ''};

--- a/src/components/staking/components/Stake.js
+++ b/src/components/staking/components/Stake.js
@@ -20,7 +20,10 @@ export default function Stake({ match, validators, useLockup, loading, handleGet
     const [amount, setAmount] = useState('')
     const [success, setSuccess] = useState()
     const validator = validators.filter(validator => validator.accountId === match.params.validator)[0]
-    const insufficientBalance = new BN(availableBalance).lt(new BN(utils.format.parseNearAmount(amount)))
+
+    const insufficientBalance = new BN(utils.format.parseNearAmount(amount))
+        .sub(new BN(availableBalance))
+        .gt(new BN(utils.format.parseNearAmount('0.00001')))
     const invalidAmount = insufficientBalance || !isDecimalString(amount)
     const stakeAllowed = !loading && amount.length && amount !== '0' && !invalidAmount
 

--- a/src/components/staking/components/Stake.js
+++ b/src/components/staking/components/Stake.js
@@ -14,6 +14,10 @@ import isDecimalString from '../../../utils/isDecimalString'
 import { onKeyDown } from '../../../hooks/eventListeners'
 import { toNear } from '../../../utils/amounts'
 
+const {
+    parseNearAmount, formatNearAmount
+} = utils.format
+
 export default function Stake({ match, validators, useLockup, loading, handleGetValidators, availableBalance, hasLedger }) {
     const dispatch = useDispatch()
     const [confirm, setConfirm] = useState()
@@ -21,9 +25,9 @@ export default function Stake({ match, validators, useLockup, loading, handleGet
     const [success, setSuccess] = useState()
     const validator = validators.filter(validator => validator.accountId === match.params.validator)[0]
 
-    const insufficientBalance = new BN(utils.format.parseNearAmount(amount))
+    const insufficientBalance = new BN(parseNearAmount(amount))
         .sub(new BN(availableBalance))
-        .gt(new BN(utils.format.parseNearAmount('0.00001')))
+        .gt(new BN(parseNearAmount('0.00001')))
     const invalidAmount = insufficientBalance || !isDecimalString(amount)
     const stakeAllowed = !loading && amount.length && amount !== '0' && !invalidAmount
 
@@ -55,6 +59,7 @@ export default function Stake({ match, validators, useLockup, loading, handleGet
                     onChange={setAmount} 
                     valid={stakeAllowed}
                     availableBalance={availableBalance}
+                    availableClick={() => setAmount(formatNearAmount(availableBalance, 5))}
                     insufficientBalance={insufficientBalance} 
                     loading={loading}
                 />

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -74,7 +74,7 @@ export class Staking {
             .sub(deposited)
 
         // minimum displayable for totalUnstaked 
-        if (totalUnstaked.lt(new BN(parseNearAmount('0.001'), 10))) {
+        if (totalUnstaked.lt(new BN(parseNearAmount('0.002'), 10))) {
             totalUnstaked = new BN('0', 10)
         }
 

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -66,7 +66,7 @@ export class Staking {
         const { contract, lockupId: account_id } = await this.getLockup()
 
         const lockupState = await (new nearApiJs.Account(this.wallet.connection, account_id)).state()
-        const lockupStorage = this.NEAR_PER_BYTE.mul(new BN(lockupState.storage_usage))
+        const lockupStorage = this.NEAR_PER_BYTE.mul(new BN(lockupState.storage_usage).add(new BN('1', 10)))
         const deposited = new BN(await contract.get_known_deposited_balance(), 10)
         let totalUnstaked = new BN(await contract.get_owners_balance(), 10)
             .add(new BN(await contract.get_locked_amount(), 10))
@@ -171,14 +171,16 @@ export class Staking {
         return await this.lockupStake(lockupId, validatorId, amount)
     }
 
-    async unstake(useLockup) {
+    // helpers for lockup
+
+    async unstake(useLockup, amount) {
         const { lockupId } = await this.getLockup()
         await this.signAndSendTransaction(lockupId, [
             functionCall('unstake_all', {}, STAKING_GAS_BASE * 5, '0')
         ])
     }
 
-    async withdraw(useLockup) {
+    async withdraw(useLockup, amount) {
         const { lockupId } = await this.getLockup()
         const withdraw_all_from_staking_pool = await this.signAndSendTransaction(lockupId, [
             functionCall('withdraw_all_from_staking_pool', {}, STAKING_GAS_BASE * 7, '0')
@@ -190,8 +192,6 @@ export class Staking {
             functionCall('unselect_staking_pool', {}, STAKING_GAS_BASE)
         ])
     }
-
-    // helpers for lockup
 
     async lockupStake(lockupId, validatorId, amount) {
         return await this.signAndSendTransaction(lockupId, [

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -67,7 +67,7 @@ export class Staking {
 
         const lockupState = await (new nearApiJs.Account(this.wallet.connection, account_id)).state()
         // add 1 N to storage cost to always leave 1 N in lockup
-        const lockupStorage = this.NEAR_PER_BYTE.mul(new BN(lockupState.storage_usage)).add(new BN(parseNearAmount(1), 10))
+        const lockupStorage = this.NEAR_PER_BYTE.mul(new BN(lockupState.storage_usage)).add(new BN(parseNearAmount('1'), 10))
         const deposited = new BN(await contract.get_known_deposited_balance(), 10)
         let totalUnstaked = new BN(await contract.get_owners_balance(), 10)
             .add(new BN(await contract.get_locked_amount(), 10))

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -66,7 +66,8 @@ export class Staking {
         const { contract, lockupId: account_id } = await this.getLockup()
 
         const lockupState = await (new nearApiJs.Account(this.wallet.connection, account_id)).state()
-        const lockupStorage = this.NEAR_PER_BYTE.mul(new BN(lockupState.storage_usage).add(new BN('1', 10)))
+        // add 1 N to storage cost to always leave 1 N in lockup
+        const lockupStorage = this.NEAR_PER_BYTE.mul(new BN(lockupState.storage_usage)).add(new BN(parseNearAmount(1), 10))
         const deposited = new BN(await contract.get_known_deposited_balance(), 10)
         let totalUnstaked = new BN(await contract.get_owners_balance(), 10)
             .add(new BN(await contract.get_locked_amount(), 10))


### PR DESCRIPTION
1. Cap the min displayed "Available lockup balance" at 0.001
2. Allow user to type in exactly what "Available Balance" says and still have staking succeed
3. Included 35N strict reserve vs. storage calculation

Fix for #1006 