### PR TITLE
Add /create-implicit route and page to create implicit accounts with seed phrase

### DIFF
--- a/src/components/Routing.js
+++ b/src/components/Routing.js
@@ -50,6 +50,7 @@ import LedgerConfirmActionModal from './accounts/ledger/LedgerConfirmActionModal
 
 import GlobalStyle from './GlobalStyle'
 import { SetupSeedPhraseWithRouter } from './accounts/SetupSeedPhrase'
+import { SetupImplicitWithRouter } from './accounts/SetupImplicit'
 const theme = {}
 
 const PATH_PREFIX = process.env.PUBLIC_URL
@@ -205,6 +206,11 @@ class Routing extends Component {
                                     exact
                                     path='/setup-seed-phrase/:accountId/:phrase/:fundingContract?/:fundingKey?'
                                     component={SetupSeedPhraseWithRouter}
+                                />
+                                <Route
+                                    exact
+                                    path='/create-implicit/:state?'
+                                    component={SetupImplicitWithRouter}
                                 />
                                 <Route
                                     exact

--- a/src/components/accounts/SetupImplicit.js
+++ b/src/components/accounts/SetupImplicit.js
@@ -1,10 +1,7 @@
 import React, { Component, Fragment } from 'react'
 
 import * as nearApiJs from 'near-api-js' 
-import { parseSeedPhrase } from 'near-seed-phrase'
 import BN from 'bn.js'
-const NETWORK_ID = process.env.REACT_APP_NETWORK_ID || 'default'
-const NODE_URL = process.env.REACT_APP_NODE_URL || 'https://rpc.nearprotocol.com'
 
 import { withRouter, Route } from 'react-router-dom'
 import { connect } from 'react-redux'
@@ -21,6 +18,8 @@ import Container from '../common/styled/Container.css'
 import { KeyPair } from 'near-api-js'
 import FormButton from '../common/FormButton'
 import IconMCopy from '../../images/IconMCopy'
+const NETWORK_ID = process.env.REACT_APP_NETWORK_ID || 'default'
+const NODE_URL = process.env.REACT_APP_NODE_URL || 'https://rpc.nearprotocol.com'
 
 const IMPLICIT_ACCOUNT_KEY = '__IMPLICIT_ACCOUNT_KEY'
 
@@ -58,7 +57,8 @@ class SetupImplicit extends Component {
     componentDidUpdate = (props, state) => {
         const recoveryKeyPair = JSON.parse(localStorage.getItem(IMPLICIT_ACCOUNT_KEY) || '{}')
         if (this.props.location.pathname !== '/create-implicit/fund' && recoveryKeyPair.publicKey) {
-            if (confirm('WARNING! If you have funded your account, press "Cancel".\n\nIf you would like to start over with a new account, press "OK".')) {
+            const confirm = confirm('WARNING! If you have funded your account, press "Cancel".\n\nIf you would like to start over with a new account, press "OK".')
+            if (confirm) {
                 localStorage.removeItem(IMPLICIT_ACCOUNT_KEY)
                 this.refreshData()
                 this.props.history.push('/create-implicit')

--- a/src/components/accounts/SetupImplicit.js
+++ b/src/components/accounts/SetupImplicit.js
@@ -278,7 +278,7 @@ class SetupImplicit extends Component {
                                         !!balance &&
                                         <>
                                             <p style={{marginTop: 16}}>
-                                                Once funded, click "Continue". You will be redirected to a page titled "Restore Account". Click "Continue" again.
+                                                Click "Continue". You will be redirected to a page titled "Restore Account". Click "Continue" again.
                                             </p>
                                             <FormButton
                                                 onClick={() => this.handleContinue()}

--- a/src/components/accounts/SetupImplicit.js
+++ b/src/components/accounts/SetupImplicit.js
@@ -1,0 +1,289 @@
+import React, { Component, Fragment } from 'react'
+
+import * as nearApiJs from 'near-api-js' 
+import { parseSeedPhrase } from 'near-seed-phrase'
+import BN from 'bn.js'
+const NETWORK_ID = process.env.REACT_APP_NETWORK_ID || 'default'
+const NODE_URL = process.env.REACT_APP_NODE_URL || 'https://rpc.nearprotocol.com'
+
+import { withRouter, Route } from 'react-router-dom'
+import { connect } from 'react-redux'
+import { Translate } from 'react-localize-redux'
+
+import { redirectToApp, handleAddAccessKeySeedPhrase, clearAlert, refreshAccount, checkCanEnableTwoFactor, checkIsNew, handleCreateAccountWithSeedPhrase } from '../../actions/account'
+import { generateSeedPhrase } from 'near-seed-phrase'
+import SetupSeedPhraseVerify from './SetupSeedPhraseVerify'
+import SetupSeedPhraseForm from './SetupSeedPhraseForm'
+import copyText from '../../utils/copyText'
+import isMobile from '../../utils/isMobile'
+import { Snackbar, snackbarDuration } from '../common/Snackbar'
+import Container from '../common/styled/Container.css'
+import { KeyPair } from 'near-api-js'
+import FormButton from '../common/FormButton'
+import IconMCopy from '../../images/IconMCopy'
+
+const IMPLICIT_ACCOUNT_KEY = '__IMPLICIT_ACCOUNT_KEY'
+
+class SetupImplicit extends Component {
+    state = {
+        seedPhrase: '',
+        enterWord: '',
+        wordId: null,
+        requestStatus: null,
+        successSnackbar: false,
+        sending: false,
+        snackBarMessage: 'setupSeedPhrase.snackbarCopySuccess'
+    }
+
+    async checkBalance() {
+        const recoveryKeyPair = JSON.parse(localStorage.getItem(IMPLICIT_ACCOUNT_KEY) || '{}')
+        this.setState({ sending: true })
+        const account = new nearApiJs.Account(this.connection, recoveryKeyPair.implicitAccountId)
+        try {
+            const state = await account.state()
+            if (new BN(state.amount).gte(new BN('1000000000000000000000000', 10))) {
+                window.removeEventListener('beforeunload')
+                window.location.href = `${window.location.origin}/recover-with-link/${recoveryKeyPair.implicitAccountId}/${recoveryKeyPair.seedPhrase}`
+            }
+        } catch (e) {
+            if (e.message.indexOf('exist while viewing') > -1) {
+                console.warn('account does not exist yet')
+            } else {
+                throw(e)
+            }
+        }
+        setTimeout(() => this.setState({ sending: false }), 1000)
+    }
+
+    componentDidUpdate = (props, state) => {
+        const recoveryKeyPair = JSON.parse(localStorage.getItem(IMPLICIT_ACCOUNT_KEY) || '{}')
+        if (this.props.location.pathname !== '/create-implicit/fund' && recoveryKeyPair.publicKey) {
+            if (confirm('WARNING! If you have funded your account, press "Cancel".\n\nIf you would like to start over with a new account, press "OK".')) {
+                localStorage.removeItem(IMPLICIT_ACCOUNT_KEY)
+                this.refreshData()
+                this.props.history.push('/create-implicit')
+            } else {
+                this.props.history.push('/create-implicit/fund')
+            }
+        }
+        if (this.props.location.pathname === '/create-implicit/fund' && state.snackBarMessage !== 'setupSeedPhrase.snackbarCopyImplicitAccountId') {
+            this.setState({
+                snackBarMessage: 'setupSeedPhrase.snackbarCopyImplicitAccountId'
+            })
+        }
+    }
+
+    componentDidMount = () => {
+        this.connection = nearApiJs.Connection.fromConfig({
+            networkId: NETWORK_ID,
+            provider: { type: 'JsonRpcProvider', args: { url: NODE_URL + '/' } },
+            signer: {},
+        })
+
+        const recoveryKeyPair = JSON.parse(localStorage.getItem(IMPLICIT_ACCOUNT_KEY) || '{}')
+
+        if (!recoveryKeyPair.publicKey) {
+            if (this.props.location.pathname === '/create-implicit') {
+                this.refreshData()
+            }
+        } else {
+            this.setState({ recoveryKeyPair })
+        }
+    }
+
+    refreshData = () => {
+        const { seedPhrase, publicKey, secretKey } = generateSeedPhrase()
+        const recoveryKeyPair = KeyPair.fromString(secretKey)
+        const wordId = Math.floor(Math.random() * 12)
+
+        this.setState((prevState) => ({
+            ...prevState,
+            seedPhrase,
+            publicKey,
+            wordId,
+            enterWord: '',
+            requestStatus: null,
+            recoveryKeyPair
+        }))
+    }
+
+    handleChangeWord = (e, { name, value }) => {
+        if (value.match(/[^a-zA-Z]/)) {
+            return false
+        }
+
+        this.setState((state) => ({
+           [name]: value.trim().toLowerCase(),
+           requestStatus: null
+        }))
+    }
+
+    handleStartOver = e => {
+        const {
+            history
+        } = this.props
+
+        this.refreshData()
+        history.push(`/create-implicit`)
+    }
+
+    handleSubmit = async () => {
+        const {
+            history
+        } = this.props
+        const { seedPhrase, enterWord, wordId, recoveryKeyPair } = this.state
+        if (enterWord !== seedPhrase.split(' ')[wordId]) {
+            this.setState(() => ({
+                requestStatus: {
+                    success: false,
+                    messageCode: 'account.verifySeedPhrase.error'
+                }
+            }))
+            return false
+        }
+        console.log('verified', recoveryKeyPair)
+        recoveryKeyPair.seedPhrase = seedPhrase
+        recoveryKeyPair.implicitAccountId = Buffer.from(recoveryKeyPair.publicKey.data).toString('hex')
+        localStorage.setItem(IMPLICIT_ACCOUNT_KEY, JSON.stringify(recoveryKeyPair))
+        history.push(`/create-implicit/fund`)
+    }
+
+    handleCopyPhrase = (textToCopy) => {
+        if (typeof textToCopy !== 'string') {
+            textToCopy = null
+        }
+        if (navigator.share && isMobile()) {
+            navigator.share({
+                text: textToCopy ? textToCopy : this.state.seedPhrase
+            }).catch(err => {
+                console.log(err.message);
+            });
+        } else {
+            this.handleCopyDesktop(textToCopy);
+        }
+    }
+
+    handleCopyDesktop = (textToCopy) => {
+        copyText(textToCopy ? document.getElementById('implicit-account-id') : document.getElementById('seed-phrase'));
+        this.setState({ successSnackbar: true }, () => {
+            setTimeout(() => {
+                this.setState({ successSnackbar: false });
+            }, snackbarDuration)
+        });
+    }
+
+    render() {
+        if (!this.state.recoveryKeyPair) return null
+
+        return (
+            <Translate>
+                {({ translate }) => (
+                    <Fragment>
+                        <Route 
+                            exact
+                            path={`/create-implicit`}
+                            render={() => (
+                                <Container className='small-centered'>
+                                    <h1><Translate id='setupSeedPhrase.pageTitle'/></h1>
+                                    <h2><Translate id='setupSeedPhrase.pageText'/></h2>
+                                    <SetupSeedPhraseForm
+                                        linkTo="/create-implicit/verify"
+                                        seedPhrase={this.state.seedPhrase}
+                                        handleCopyPhrase={this.handleCopyPhrase}
+                                    />
+                                </Container>
+                            )}
+                        />
+                        <Route 
+                            exact
+                            path={`/create-implicit/verify`}
+                            render={() => (
+                                <Container className='small-centered'>
+                                    <form onSubmit={e => {this.handleSubmit(); e.preventDefault();}} autoComplete='off'>
+                                    <h1><Translate id='setupSeedPhraseVerify.pageTitle'/></h1>
+                                    <h2><Translate id='setupSeedPhraseVerify.pageText'/></h2>
+                                        <SetupSeedPhraseVerify
+                                            enterWord={this.state.enterWord}
+                                            wordId={this.state.wordId}
+                                            handleChangeWord={this.handleChangeWord}
+                                            handleStartOver={this.handleStartOver}
+                                            formLoader={this.props.formLoader}
+                                            requestStatus={this.state.requestStatus}
+                                            globalAlert={this.props.globalAlert}
+                                        />
+                                    </form>
+                                </Container>
+                            )}
+                        />
+                        <Route 
+                            exact
+                            path={`/create-implicit/fund`}
+                            render={() => (
+                                <Container style={{ textAlign: 'center' }} className='small-centered'>
+                                    <h1>Fund Account</h1>
+                                    <p>This is your account name (64 characters). Send at least 1 NEAR to your account to continue.</p>
+                                    <textarea 
+                                        style={{
+                                            width: '100%',
+                                            border: '2px solid #eee',
+                                            borderRadius: 4,
+                                            padding: 16,
+                                            fontSize: 18,
+                                            resize: 'none',
+                                            outline: 'none',
+                                            textAlign: 'center',
+                                        }}
+                                        defaultValue={this.state.recoveryKeyPair.implicitAccountId} 
+                                    />
+                                    <FormButton
+                                        onClick={() => this.handleCopyPhrase(this.state.recoveryKeyPair.implicitAccountId)}
+                                        color='seafoam-blue-white'
+                                    >
+                                        <Translate id='button.copyImplicitAccountId' />
+                                        <IconMCopy color='#6ad1e3' />
+                                    </FormButton>
+                                    <p id="implicit-account-id" style={{display: 'none'}}>
+                                        <span>{this.state.recoveryKeyPair.implicitAccountId}</span>
+                                    </p>
+                                    <p style={{marginTop: 16}}>
+                                        Once funded, you will be automatically redirected to a "Restore Account" page where you can sign into the wallet by clicking "Continue".
+                                    </p>
+                                    <FormButton
+                                        onClick={() => this.checkBalance()}
+                                        color='green'
+                                        sending={this.state.sending}
+                                        sendingString="implicitBalanceCheck">
+                                        Check Balance
+                                    </FormButton>
+                                </Container>
+                            )}
+                        />
+                        <Snackbar
+                            theme='success'
+                            message={translate(this.state.snackBarMessage)}
+                            show={this.state.successSnackbar}
+                            onHide={() => this.setState({ successSnackbar: false })}
+                        />
+                    </Fragment>
+                )}
+            </Translate>
+        )
+    }
+}
+
+const mapDispatchToProps = {
+    redirectToApp,
+    handleAddAccessKeySeedPhrase,
+    clearAlert,
+    refreshAccount,
+    checkCanEnableTwoFactor,
+    checkIsNew,
+    handleCreateAccountWithSeedPhrase
+}
+
+const mapStateToProps = ({ account }, { match }) => ({
+    ...account,
+    verify: match.params.verify,
+})
+
+export const SetupImplicitWithRouter = connect(mapStateToProps, mapDispatchToProps)(withRouter(SetupImplicit))

--- a/src/components/accounts/SetupImplicit.js
+++ b/src/components/accounts/SetupImplicit.js
@@ -60,9 +60,7 @@ class SetupImplicit extends Component {
                 return this.setState({ balance: nearApiJs.utils.format.formatNearAmount(state.amount, 2) })
             }
         } catch (e) {
-            if (e.message.indexOf('exist while viewing') > -1) {
-                console.warn('account does not exist yet')
-            } else {
+            if (e.message.indexOf('exist while viewing') === -1) {
                 throw(e)
             }
             this.setState({ hasBalance: false })
@@ -270,16 +268,25 @@ class SetupImplicit extends Component {
                                     <p id="implicit-account-id" style={{display: 'none'}}>
                                         <span>{accountId}</span>
                                     </p>
-                                    <p style={{marginTop: 16}}>
-                                        Once funded, click "Continue". You will be redirected to a page titled "Restore Account". Click "Continue" again.
-                                    </p>
-                                    {   !!balance &&
-                                        <FormButton
-                                            onClick={() => this.handleContinue()}
-                                            color='green'
-                                        >
-                                            Continue
-                                        </FormButton>
+                                    {
+                                        !balance &&
+                                            <p style={{marginTop: 16}}>
+                                                Once funded, return to this page.
+                                            </p>
+                                    }
+                                    {
+                                        !!balance &&
+                                        <>
+                                            <p style={{marginTop: 16}}>
+                                                Once funded, click "Continue". You will be redirected to a page titled "Restore Account". Click "Continue" again.
+                                            </p>
+                                            <FormButton
+                                                onClick={() => this.handleContinue()}
+                                                color='green'
+                                            >
+                                                Continue
+                                            </FormButton>
+                                        </>
                                     }
                                 </Container>
                             )}

--- a/src/components/accounts/SetupSeedPhraseForm.js
+++ b/src/components/accounts/SetupSeedPhraseForm.js
@@ -46,6 +46,7 @@ const Number = styled(`span`)`
 const SetupSeedPhraseForm = ({
     seedPhrase,
     handleCopyPhrase,
+    linkTo,
     match: { params: { accountId, fundingContract, fundingKey } }
 }) => {
 
@@ -67,7 +68,7 @@ const SetupSeedPhraseForm = ({
                     <IconMCopy color='#6ad1e3' />
                 </FormButton>
                 <FormButton
-                    linkTo={`/setup-seed-phrase/${accountId}/verify/${fundingContract ? `${fundingContract}/${fundingKey}/` : ``}`}
+                    linkTo={linkTo ? linkTo : `/setup-seed-phrase/${accountId}/verify/${fundingContract ? `${fundingContract}/${fundingKey}/` : ``}`}
                     color='blue'
                 >
                     <Translate id='button.continue' />

--- a/src/components/navigation/Navigation.js
+++ b/src/components/navigation/Navigation.js
@@ -58,8 +58,12 @@ class Navigation extends Component {
     }
 
     render() {
-
         const { menuOpen } = this.state;
+
+        let showNavLinks = this.showNavLinks
+        if (this.props.location.pathname.indexOf('/create-implicit') > -1) {
+            showNavLinks = false
+        }
 
         return (
             <>
@@ -67,14 +71,14 @@ class Navigation extends Component {
                     menuOpen={menuOpen}
                     toggleMenu={this.toggleMenu}
                     selectAccount={this.handleSelectAccount}
-                    showNavLinks={this.showNavLinks}
+                    showNavLinks={showNavLinks}
                     {...this.props}
                 />
                 <MobileContainer
                     menuOpen={menuOpen}
                     toggleMenu={this.toggleMenu}
                     selectAccount={this.handleSelectAccount}
-                    showNavLinks={this.showNavLinks}
+                    showNavLinks={showNavLinks}
                     {...this.props}
                 />
             </>

--- a/src/components/navigation/Navigation.js
+++ b/src/components/navigation/Navigation.js
@@ -60,25 +60,20 @@ class Navigation extends Component {
     render() {
         const { menuOpen } = this.state;
 
-        let showNavLinks = this.showNavLinks
-        if (this.props.location.pathname.indexOf('/create-implicit') > -1) {
-            showNavLinks = false
-        }
-
         return (
             <>
                 <DesktopContainer
                     menuOpen={menuOpen}
                     toggleMenu={this.toggleMenu}
                     selectAccount={this.handleSelectAccount}
-                    showNavLinks={showNavLinks}
+                    showNavLinks={this.showNavLinks}
                     {...this.props}
                 />
                 <MobileContainer
                     menuOpen={menuOpen}
                     toggleMenu={this.toggleMenu}
                     selectAccount={this.handleSelectAccount}
-                    showNavLinks={showNavLinks}
+                    showNavLinks={this.showNavLinks}
                     {...this.props}
                 />
             </>

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -721,8 +721,6 @@
         }
     },
 
-    "implicitBalanceCheck": "Checking",
-
     "success": "Success",
     "error": "Error",
     "warning": "Warning",

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -91,7 +91,8 @@
     "setupSeedPhrase": {
         "pageTitle": "Setup Phrase",
         "pageText": "Write down the following words IN ORDER and keep them somewhere safe. You cannot recover your account without them!",
-        "snackbarCopySuccess": "Seed phrase copied!"
+        "snackbarCopySuccess": "Seed phrase copied!",
+        "snackbarCopyImplicitAccountId": "Account ID Copied!"
     },
     "setupSeedPhraseVerify": {
         "pageTitle": "Verify Phrase",
@@ -236,6 +237,7 @@
         "signIn": "Sign In",
         "signingIn": "Signing In",
         "copyPhrase": "COPY PHRASE",
+        "copyImplicitAccountId": "Copy Account ID",
         "continue": "CONTINUE",
         "continueSetup": "Continue to Setup",
         "verify": "VERIFY & COMPLETE",
@@ -718,6 +720,8 @@
             "notAvailable": "Status not available"
         }
     },
+
+    "implicitBalanceCheck": "Checking",
 
     "success": "Success",
     "error": "Error",

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -218,7 +218,13 @@ export class Staking {
         } else {
             lockupId = getLockupAccountId(accountId)
         }
-        await (await new nearApiJs.Account(this.wallet.connection, lockupId)).state()
+        try {
+            await (await new nearApiJs.Account(this.wallet.connection, lockupId)).state()
+        } catch (e) {
+            if (e.message.indexOf('is not valid') === -1) {
+                throw(e)
+            }
+        }
         const contract = await this.getContractInstance(lockupId, lockupMethods)
         return { contract, lockupId, accountId }
     }
@@ -228,7 +234,8 @@ export class Staking {
             await (await new nearApiJs.Account(this.wallet.connection, contractId)).state()
             return await new nearApiJs.Contract(this.wallet.getAccount(), contractId, { ...methods })
         } catch(e) {
-            throw new WalletError('No lockup contract for account', 'staking.errors.noLockup')
+            console.warn('No lockup contract for account')
+            // throw new WalletError('No lockup contract for account', 'staking.errors.noLockup')
         }
     }
 

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -218,13 +218,7 @@ export class Staking {
         } else {
             lockupId = getLockupAccountId(accountId)
         }
-        try {
-            await (await new nearApiJs.Account(this.wallet.connection, lockupId)).state()
-        } catch (e) {
-            if (e.message.indexOf('is not valid') === -1) {
-                throw(e)
-            }
-        }
+        await (await new nearApiJs.Account(this.wallet.connection, lockupId)).state()
         const contract = await this.getContractInstance(lockupId, lockupMethods)
         return { contract, lockupId, accountId }
     }
@@ -234,8 +228,7 @@ export class Staking {
             await (await new nearApiJs.Account(this.wallet.connection, contractId)).state()
             return await new nearApiJs.Contract(this.wallet.getAccount(), contractId, { ...methods })
         } catch(e) {
-            console.warn('No lockup contract for account')
-            // throw new WalletError('No lockup contract for account', 'staking.errors.noLockup')
+            throw new WalletError('No lockup contract for account', 'staking.errors.noLockup')
         }
     }
 

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -213,7 +213,7 @@ export class Staking {
     async getLockup() {
         const accountId = this.wallet.accountId
         let lockupId
-        if (process.env.REACT_APP_USE_TESTINGLOCKUP) {
+        if (process.env.REACT_APP_USE_TESTINGLOCKUP && accountId.length < 64) {
             lockupId = `testinglockup.${accountId}`
         } else {
             lockupId = getLockupAccountId(accountId)


### PR DESCRIPTION
PR creates a new route `/create-implicit` for creating implicit accounts
1. copy seed phrase
2. verify
3. copy accountId
4. fund from somewhere
5. click check balance and redirected to `/recover-with-link/:accountId/:seedPhrase`

Some minor changes to other components were necessary to make UI work
- SeedPhraseForm
- Navigation

TODO
Uses localStorage to store seedPhrase and accountId, which should be cleared after user is recovered into wallet successfully.
