### PR TITLE
Verify 2fa hash before showing 2fa as enabled

### DIFF
--- a/src/components/profile/Profile.js
+++ b/src/components/profile/Profile.js
@@ -17,7 +17,7 @@ export function Profile({ match }) {
     const isOwner = accountId === loginAccountId
     const account = useAccount(accountId)
     const dispatch = useDispatch();
-    const twoFactor = recoveryMethods[account.accountId] && recoveryMethods[account.accountId].filter(m => m.kind.includes('2fa'))[0]
+    const twoFactor = account.has2fa && recoveryMethods[account.accountId] && recoveryMethods[account.accountId].filter(m => m.kind.includes('2fa'))[0]
 
     useEffect(() => { 
         if (isOwner) {


### PR DESCRIPTION
Verify hash in combination with contract helper before showing 2fa as enabled. One of my accounts had a 2fa entry in contract helper, but there was no contract deployed on account, which lead to false positive.