### PR TITLE
Turn "Receive" arrow icon into a "down arrow" instead of a "left arrow"

### DIFF
--- a/src/components/navigation/NavLinks.js
+++ b/src/components/navigation/NavLinks.js
@@ -41,7 +41,13 @@ const NavLink = styled(Link)`
         background-size: contain;
     }
 
-    &.rotate {
+    &.rotate-up {
+        &:before {
+            transform: rotate(-90deg);
+        }
+    }
+
+    &.rotate-down {
         &:before {
             transform: rotate(90deg);
         }
@@ -88,9 +94,9 @@ const NavLinks = () => (
     <Container className='nav-links'>
         <NavLink icon={summaryIcon} to='/'><Translate id='link.summary'/></NavLink>
         {!DISABLE_SEND_MONEY &&
-            <NavLink icon={arrowIcon} to='/send-money'><Translate id='link.send'/></NavLink>
+            <NavLink icon={arrowIcon} className='rotate-up' to='/send-money'><Translate id='link.send'/></NavLink>
         }
-        <NavLink icon={arrowIcon} className='rotate' to='/receive-money'><Translate id='link.receive'/></NavLink>
+        <NavLink icon={arrowIcon} className='rotate-down' to='/receive-money'><Translate id='link.receive'/></NavLink>
         <NavLink icon={stakingIcon} to='/staking'><Translate id='link.staking'/></NavLink>
     </Container>
 )

--- a/src/components/navigation/NavLinks.js
+++ b/src/components/navigation/NavLinks.js
@@ -43,7 +43,7 @@ const NavLink = styled(Link)`
 
     &.rotate {
         &:before {
-            transform: rotate(180deg);
+            transform: rotate(90deg);
         }
     }
 


### PR DESCRIPTION
Hey team!

I started using the wallet and noticed that the "receive" icon points "outside", and this is kinda counter-intuitive. I suggest rotating it by `90deg` instead of `180deg` (so the arrow would point "down").

Before:
<img width="687" alt="Screen Shot 2020-10-22 at 3 14 10 pm" src="https://user-images.githubusercontent.com/254095/96823933-57b4d800-1479-11eb-8753-a8e74f1cdc81.png">

After:
<img width="705" alt="Screen Shot 2020-10-22 at 3 14 37 pm" src="https://user-images.githubusercontent.com/254095/96823941-5d122280-1479-11eb-9399-8d633c60ce10.png">

Let me know what you think!