### PR TITLE
Deduct 2N from available staking balance to align with profile page

### DIFF
--- a/src/utils/account-with-lockup.js
+++ b/src/utils/account-with-lockup.js
@@ -3,11 +3,10 @@ import sha256 from 'js-sha256'
 import { Account } from 'near-api-js'
 import { parseNearAmount } from 'near-api-js/lib/utils/format'
 import { BinaryReader } from 'near-api-js/lib/utils/serialize'
-import { LOCKUP_ACCOUNT_ID_SUFFIX } from './wallet'
+import { LOCKUP_ACCOUNT_ID_SUFFIX, MIN_BALANCE_FOR_GAS } from './wallet'
 import { WalletError } from './walletError'
 
 // TODO: Should gas allowance be dynamically calculated
-const MIN_BALANCE_FOR_GAS = new BN(parseNearAmount('2'));
 const LOCKUP_MIN_BALANCE = new BN(parseNearAmount('35'));
 
 export function decorateWithLockup(account) {
@@ -28,7 +27,7 @@ async function signAndSendTransaction(receiverId, actions) {
         .map(str => new BN(str))
         .reduce((a, b) => a.add(b), new BN("0"));
 
-    const missingAmount = total.sub(new BN(balance)).add(MIN_BALANCE_FOR_GAS);
+    const missingAmount = total.sub(new BN(balance)).add(new BN(MIN_BALANCE_FOR_GAS));
     const lockupAccountId = getLockupAccountId(this.accountId)
     if (missingAmount.gt(new BN(0)) && (await accountExists(this.connection, lockupAccountId))) {
         console.warn('Not enough balance on main account, checking lockup account', lockupAccountId);
@@ -112,7 +111,7 @@ async function getAccountBalance() {
             }
         }
 
-        const available = BN.max(new BN(0), new BN(balance.available).add(new BN(liquidOwnersBalance)).sub(MIN_BALANCE_FOR_GAS))
+        const available = BN.max(new BN(0), new BN(balance.available).add(new BN(liquidOwnersBalance)).sub(new BN(MIN_BALANCE_FOR_GAS)))
         return {
             ...balance,
             available,

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -3,6 +3,7 @@ import BN from 'bn.js'
 import { WalletError } from './walletError'
 import { getLockupAccountId } from './account-with-lockup'
 import { queryExplorer } from './explorer-api'
+import { MIN_BALANCE_FOR_GAS } from './wallet'
 
 const {
     transactions: {
@@ -203,7 +204,7 @@ export class Staking {
             validators = await this.getValidators()
         }
 
-        let totalUnstaked = new BN(balance.available, 10).sub(new BN(parseNearAmount('2'), 10))
+        let totalUnstaked = new BN(balance.available, 10).sub(new BN(MIN_BALANCE_FOR_GAS))
         if (totalUnstaked.lt(new BN(STAKING_AMOUNT_DEVIATION, 10))) {
             totalUnstaked = ZERO.clone();
         }

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -196,8 +196,6 @@ export class Staking {
         const account = this.wallet.getAccount(this.wallet.accountId)
         const balance = await account.getAccountBalance()
 
-        console.log('HERE IS THE RAW BALANCE', balance)
-
         let { deposits, validators } = (await getStakingTransactions(account_id))
         validators = await this.getValidators([...new Set(validators.concat(recentlyStakedValidators))])
         if (!validators.length || this.wallet.has2fa) {

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -196,6 +196,8 @@ export class Staking {
         const account = this.wallet.getAccount(this.wallet.accountId)
         const balance = await account.getAccountBalance()
 
+        console.log('HERE IS THE RAW BALANCE', balance)
+
         let { deposits, validators } = (await getStakingTransactions(account_id))
         validators = await this.getValidators([...new Set(validators.concat(recentlyStakedValidators))])
         if (!validators.length || this.wallet.has2fa) {
@@ -203,7 +205,7 @@ export class Staking {
             validators = await this.getValidators()
         }
 
-        let totalUnstaked = new BN(balance.available, 10).sub(new BN(parseNearAmount('1'), 10))
+        let totalUnstaked = new BN(balance.available, 10).sub(new BN(parseNearAmount('2'), 10))
         if (totalUnstaked.lt(new BN(STAKING_AMOUNT_DEVIATION, 10))) {
             totalUnstaked = ZERO.clone();
         }


### PR DESCRIPTION
For non-lockup accounts, we were only deducting 1N from available balance to stake. This deducts 2N from available balance, so that users see the same 'Available Balance' on the staking dashboard and /profile