### PR TITLE
Lockup staking: fix stakeAllowed flag

### DIFF
--- a/src/components/staking/StakingContainer.js
+++ b/src/components/staking/StakingContainer.js
@@ -204,6 +204,7 @@ export function StakingContainer({ history, match }) {
                                 onWithdraw={handleWithDraw}
                                 loading={loading}
                                 selectedValidator={selectedValidator}
+                                currentValidators={currentValidators}
                             />
                         )}
                     />

--- a/src/components/staking/components/Validator.js
+++ b/src/components/staking/components/Validator.js
@@ -8,10 +8,10 @@ import AlertBanner from './AlertBanner'
 import StakeConfirmModal from './StakeConfirmModal'
 import { onKeyDown } from '../../../hooks/eventListeners'
 
-export default function Validator({ match, validator, onUnstake, onWithdraw, loading, selectedValidator, history }) {
+export default function Validator({ match, validator, onUnstake, onWithdraw, loading, selectedValidator, history, currentValidators }) {
     const [confirm, setConfirm] = useState(null)
 
-    const stakeNotAllowed = selectedValidator && selectedValidator !== match.params.validator
+    const stakeNotAllowed = selectedValidator && selectedValidator !== match.params.validator && currentValidators.length
 
     onKeyDown(e => {
         if (e.keyCode === 13 && confirm === 'withdraw') {


### PR DESCRIPTION
Since we do not call `unselect_staking_pool` until user stakes with a new validator, we need to check if the user is staking. The `currentValidators` array should be empty if there's no balance.