### PR TITLE
Allow importing remaining Ledger accounts if one fails

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -140,9 +140,14 @@ export const signInWithLedger = () => async (dispatch, getState) => {
 }
 
 export const signInWithLedgerAddAndSaveAccounts = (accountIds) => async (dispatch, getState) => {
-    for (let i = 0; i < accountIds.length; i++) {
-        await dispatch(addLedgerAccountId(accountIds[i]))
-        await dispatch(setLedgerTxSigned(false, accountIds[i]))
+    for (let accountId of accountIds) {
+        try {
+            await dispatch(addLedgerAccountId(accountId))
+            await dispatch(setLedgerTxSigned(false, accountId))
+        } catch (e) {
+            console.warn('Error importing Ledger-based account', accountId, e)
+            // NOTE: We still continue importing other accounts
+        }
     }
 
     return dispatch(saveAndSelectLedgerAccounts(getState().ledger.signInWithLedger))

--- a/src/components/accounts/ledger/LedgerSignInModal.js
+++ b/src/components/accounts/ledger/LedgerSignInModal.js
@@ -125,7 +125,8 @@ const LedgerSignInModal = ({
     open, 
     onClose, 
     ledgerAccounts, 
-    accountsApproved, 
+    accountsApproved,
+    accountsError,
     totalAccounts, 
     txSigned, 
     handleAdditionalAccountId, 
@@ -142,7 +143,7 @@ const LedgerSignInModal = ({
     clearSignInWithLedgerModalState
 }) => {
     
-    const animationScope = Math.min(Math.max(accountsApproved - 1, 0), totalAccounts - 3)
+    const animationScope = Math.min(Math.max((accountsApproved + accountsError) - 1, 0), totalAccounts - 3)
 
     return (
         <Modal

--- a/src/components/accounts/ledger/LedgerSignInModal.js
+++ b/src/components/accounts/ledger/LedgerSignInModal.js
@@ -121,6 +121,7 @@ const AnimateList = styled.div`
             border-radius: 12px;
             text-align: center;
             font-size: 12px;
+            line-height: 24px;
         }
     }
 `

--- a/src/components/accounts/ledger/LedgerSignInModal.js
+++ b/src/components/accounts/ledger/LedgerSignInModal.js
@@ -132,6 +132,7 @@ const LedgerSignInModal = ({
     ledgerAccounts, 
     accountsApproved,
     accountsError,
+    accountsRejected,
     totalAccounts, 
     txSigned, 
     handleAdditionalAccountId, 
@@ -148,7 +149,7 @@ const LedgerSignInModal = ({
     clearSignInWithLedgerModalState
 }) => {
     
-    const animationScope = Math.min(Math.max((accountsApproved + accountsError) - 1, 0), totalAccounts - 3)
+    const animationScope = Math.min(Math.max((accountsApproved + accountsError + accountsRejected) - 1, 0), totalAccounts - 3)
 
     return (
         <Modal

--- a/src/components/accounts/ledger/LedgerSignInModal.js
+++ b/src/components/accounts/ledger/LedgerSignInModal.js
@@ -61,6 +61,10 @@ const AnimateList = styled.div`
             background: #ff898c;
             color: #cb2d30;
         }
+        &.rejected .status {
+            background: #ff898c;
+            color: #cb2d30;
+        }
         &.confirm .status {
             background: #6ad1e3;
             color: #14889d;

--- a/src/components/accounts/ledger/LedgerSignInModal.js
+++ b/src/components/accounts/ledger/LedgerSignInModal.js
@@ -57,6 +57,10 @@ const AnimateList = styled.div`
         &.success .status {
             text-align: right;
         }
+        &.error .status {
+            background: #ff898c;
+            color: #cb2d30;
+        }
         &.confirm .status {
             background: #6ad1e3;
             color: #14889d;

--- a/src/components/accounts/ledger/SignInLedger.js
+++ b/src/components/accounts/ledger/SignInLedger.js
@@ -36,6 +36,7 @@ export function SignInLedger(props) {
     
     const accountsApproved = signInWithLedgerKeys.reduce((a, accountId) => signInWithLedgerState[accountId].status === 'success' ? a + 1 : a, 0)
     const accountsError = signInWithLedgerKeys.reduce((a, accountId) => signInWithLedgerState[accountId].status === 'error' ? a + 1 : a, 0)
+    const accountsRejected = signInWithLedgerKeys.reduce((a, accountId) => signInWithLedgerState[accountId].status === 'rejected' ? a + 1 : a, 0)
     const totalAccounts = signInWithLedgerKeys.length
     
     const signingIn = !!signInWithLedgerStatus
@@ -100,6 +101,7 @@ export function SignInLedger(props) {
                     ledgerAccounts={ledgerAccounts} 
                     accountsApproved={accountsApproved}
                     accountsError={accountsError}
+                    accountsRejected={accountsRejected}
                     totalAccounts={totalAccounts}
                     txSigned={txSigned}
                     handleAdditionalAccountId={handleAdditionalAccountId}

--- a/src/components/accounts/ledger/SignInLedger.js
+++ b/src/components/accounts/ledger/SignInLedger.js
@@ -35,6 +35,7 @@ export function SignInLedger(props) {
     }))
     
     const accountsApproved = signInWithLedgerKeys.reduce((a, accountId) => signInWithLedgerState[accountId].status === 'success' ? a + 1 : a, 0)
+    const accountsError = signInWithLedgerKeys.reduce((a, accountId) => signInWithLedgerState[accountId].status === 'error' ? a + 1 : a, 0)
     const totalAccounts = signInWithLedgerKeys.length
     
     const signingIn = !!signInWithLedgerStatus
@@ -98,6 +99,7 @@ export function SignInLedger(props) {
                     onClose={onClose}
                     ledgerAccounts={ledgerAccounts} 
                     accountsApproved={accountsApproved}
+                    accountsError={accountsError}
                     totalAccounts={totalAccounts}
                     txSigned={txSigned}
                     handleAdditionalAccountId={handleAdditionalAccountId}

--- a/src/reducers/ledger/index.js
+++ b/src/reducers/ledger/index.js
@@ -55,14 +55,16 @@ const ledgerActions = handleActions({
                 : {}
         }
     },
-    [addLedgerAccountId]: (state, { error, ready, meta }) => {
+    [addLedgerAccountId]: (state, { error, ready, meta, payload }) => {
         return {
             ...state,
             signInWithLedgerStatus: 'confirm-accounts',
             signInWithLedger: {
                 ...state.signInWithLedger,
                 [meta.accountId]: {
-                    status: error ? 'error' : (ready ? 'success' : 'confirm')
+                    status: error
+                        ? payload.type === 'RequiresFullAccess' ? 'error' : 'rejected'
+                        : (ready ? 'success' : 'confirm')
                 }
             }
         }

--- a/src/reducers/ledger/index.js
+++ b/src/reducers/ledger/index.js
@@ -29,7 +29,8 @@ const ledgerModalReducer = (state, { error, ready, type }) => {
     return state
 }
 
-const ledger = handleActions({
+// TODO: Extract actions related to signInWithLedger so that all state is automatically scoped there. Is txSigned ledger-specific?
+const ledgerActions = handleActions({
     [getLedgerAccountIds]: (state, { error, payload, ready }) => {
         if (error) {
             return {
@@ -55,22 +56,13 @@ const ledger = handleActions({
         }
     },
     [addLedgerAccountId]: (state, { error, ready, meta }) => {
-        if (error) {
-            return {
-                ...state,
-                signInWithLedgerStatus: undefined,
-                signInWithLedger: undefined,
-                txSigned: undefined
-            }
-        }
-
         return {
             ...state,
             signInWithLedgerStatus: 'confirm-accounts',
             signInWithLedger: {
                 ...state.signInWithLedger,
                 [meta.accountId]: {
-                    status: ready ? 'success' : 'confirm'
+                    status: error ? 'error' : (ready ? 'success' : 'confirm')
                 }
             }
         }
@@ -124,6 +116,7 @@ const ledger = handleActions({
             signInWithLedger: undefined
         }
     },
+    // TODO: Make it clear how this interacts with ledgerModalReducer
     [showLedgerModal]: (state, { payload }) => {
         return {
             ...state,
@@ -140,6 +133,6 @@ const ledger = handleActions({
 
 export default reduceReducers(
     initialState,
-    ledger,
+    ledgerActions,
     ledgerModalReducer
 )

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -823,6 +823,7 @@
             "status": {
                 "success": "Approved",
                 "error": "Error",
+                "rejected": "Rejected",
                 "pending": "Pending",
                 "waiting": "Up next",
                 "confirm": "Confirm"

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -822,6 +822,7 @@
             "accountsApproved": "account(s) approved",
             "status": {
                 "success": "Approved",
+                "error": "Error",
                 "pending": "Pending",
                 "waiting": "Up next",
                 "confirm": "Confirm"

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -565,7 +565,7 @@ class Wallet {
     }
 
     async saveAndSelectLedgerAccounts(accounts) {
-        const accountIds = Object.keys(accounts)
+        const accountIds = Object.keys(accounts).filter(accountId => accounts[accountId].status === 'success')
 
         for (let i = 0; i < accountIds.length; i++) {
             const accountId = accountIds[i]


### PR DESCRIPTION
Context: whoever added 2FA after Ledger (e.g. by importing account using other recovery method) has troubles recovering any accounts connected to the same Ledger (so this is relatively urgent fix for people in such situation).

As a drive-by it also allows to press "Reject" for some accounts and skip them (seems like more desired behavior than restarting whole process).

Known issues:
- missing translations
- need design for Error/Rejected state @corwinharrell 
- need to distinguish Error/Rejected (just shows Error now)
- account list doesn't scroll after rejection (not sure whether regression here)
- there seem to be Ledger UI issues which weren't introduced in this PR https://github.com/near/near-wallet/issues/1124