### PR TITLE
Fix 2fa not showing as active on profile

### DIFF
--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -679,7 +679,8 @@ class Wallet {
         let recoveryMethods = await this.postSignedJson('/account/recoveryMethods', { accountId }, account)
         const accessKeys =  await this.getAccessKeys()
         const publicKeys = accessKeys.map(key => key.public_key)
-        recoveryMethods = recoveryMethods.filter(({ publicKey }) => publicKeys.includes(publicKey))
+        console.log('all methods', recoveryMethods)
+        recoveryMethods = recoveryMethods.filter(({ confirmed }) => confirmed === true)
         return {
             accountId,
             data: recoveryMethods

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -677,9 +677,6 @@ class Wallet {
     async getRecoveryMethods(account) {
         const accountId = account ? account.accountId : this.accountId
         let recoveryMethods = await this.postSignedJson('/account/recoveryMethods', { accountId }, account)
-        const accessKeys =  await this.getAccessKeys()
-        const publicKeys = accessKeys.map(key => key.public_key)
-        console.log('all methods', recoveryMethods)
         recoveryMethods = recoveryMethods.filter(({ confirmed }) => confirmed === true)
         return {
             accountId,

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -677,10 +677,15 @@ class Wallet {
     async getRecoveryMethods(account) {
         const accountId = account ? account.accountId : this.accountId
         let recoveryMethods = await this.postSignedJson('/account/recoveryMethods', { accountId }, account)
-        recoveryMethods = recoveryMethods.filter(({ confirmed }) => confirmed === true)
+        const accessKeys =  await this.getAccessKeys()
+        const publicKeys = accessKeys.map(key => key.public_key)
+        const confirmedNoPublicKeyMethods = recoveryMethods.filter(({ publicKey, confirmed }) => publicKey === null && confirmed === true)
+        const publicKeyMethods = recoveryMethods.filter(({ publicKey }) => publicKeys.includes(publicKey))
+        const allMethods = [...confirmedNoPublicKeyMethods, ...publicKeyMethods]
+
         return {
             accountId,
-            data: recoveryMethods
+            data: allMethods
         }
     }
 


### PR DESCRIPTION
For recovery methods that DO NOT have a `publicKey`, check that the methods `confirm` flag is `true`