### PR TITLE
TEST: Create Account Flow on Testnet

### DIFF
--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -695,6 +695,7 @@ class Wallet {
         await this.validateSecurityCode(accountId, method, securityCode);
         await this.saveAccount(accountId, recoveryKeyPair);
 
+        // TODO DISABLE_CREATE_ACCOUNT make this true on testnet
         if (DISABLE_CREATE_ACCOUNT && !fundingOptions) {
             await store.dispatch(fundCreateAccount(accountId, recoveryKeyPair, fundingOptions, method))
             return


### PR DESCRIPTION
This instance is to open the create account flow on testnet so @corwinharrell and others can test it.

It disables the developer account creation flow and instead you MUST fund the implicit account and claim your named account as you would do on mainnet with NO linkdrop.