### PR TITLE
adding gh validators to validators list

### DIFF
--- a/src/components/staking/components/Validators.js
+++ b/src/components/staking/components/Validators.js
@@ -4,9 +4,11 @@ import ListWrapper from './ListWrapper'
 import ValidatorBox from './ValidatorBox'
 
 export default function Validators({ validators }) {
+    const currentValidators = validators.filter((v) => v.current)
+
     const [validator, setValidator] = useState('')
 
-    const validValidator = validators.map(validator => validator.accountId).includes(validator)
+    const validValidator = currentValidators.map(validator => validator.accountId).includes(validator)
 
     return (
         <>
@@ -30,7 +32,7 @@ export default function Validators({ validators }) {
                 <div className='input-validation-label success'><Translate id='staking.validators.search.success' /></div>
             }
             <ListWrapper>
-                {validators.filter(v => v.accountId.includes(validator)).map((validator, i) => 
+                {currentValidators.filter(v => v.accountId.includes(validator)).map((validator, i) => 
                     <ValidatorBox
                         key={i}
                         validator={validator.accountId}

--- a/src/components/staking/components/Validators.js
+++ b/src/components/staking/components/Validators.js
@@ -4,7 +4,7 @@ import ListWrapper from './ListWrapper'
 import ValidatorBox from './ValidatorBox'
 
 export default function Validators({ validators }) {
-    const currentValidators = validators.filter((v) => v.current)
+    const currentValidators = validators.filter((v) => v.current || v.next)
 
     const [validator, setValidator] = useState('')
 

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -280,6 +280,7 @@ export class Staking {
     async getValidators(accountIds) {
         const { current_validators, next_validators, current_proposals } = await this.provider.validators()
         const currentValidators = current_validators.map(({ account_id }) => account_id)
+        const nextValidators = current_proposals.map(({ account_id }) => account_id)
         
         if (!accountIds) {
             const rpcValidators = [...current_validators, ...next_validators, ...current_proposals].map(({ account_id }) => account_id)
@@ -301,6 +302,7 @@ export class Staking {
                     const validator = {
                         accountId: account_id,
                         current: currentValidators.includes(account_id),
+                        next: nextValidators.includes(account_id),
                         contract: await this.getContractInstance(account_id, stakingMethods)
                     }
                     const fee = validator.fee = await validator.contract.get_reward_fee_fraction()

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -290,7 +290,7 @@ export class Staking {
                 ghValidators = (await fetch(`https://raw.githubusercontent.com/frol/near-validators-scoreboard/scoreboard-${networkId}/validators_scoreboard.json`).then((r) => r.json()))
                 .map(({ account_id }) => account_id)
             }
-            
+
             accountIds = [...new Set([...rpcValidators, ...ghValidators])]
                 .filter((v) => v.indexOf('nfvalidator') === -1 && v.indexOf(networkId === 'mainnet' ? '.near' : '.m0') > -1)
         }
@@ -308,9 +308,8 @@ export class Staking {
                     fee.percentage = fee.numerator / fee.denominator * 100
                     return validator
                 } catch (e) {
-                    console.log('error with', account_id)
                     if (!/No contract for account|cannot find contract code|wasm execution failed/.test(e.message)) {
-                        throw(e)
+                        throw e
                     }
                 }
             })

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -3,7 +3,7 @@ import BN from 'bn.js'
 import { WalletError } from './walletError'
 import { getLockupAccountId } from './account-with-lockup'
 import { queryExplorer } from './explorer-api'
-import { MIN_BALANCE_FOR_GAS } from './wallet'
+import { MIN_BALANCE_FOR_GAS, NETWORK_ID } from './wallet'
 
 const {
     transactions: {
@@ -283,9 +283,9 @@ export class Staking {
         
         if (!accountIds) {
             const rpcValidators = [...current_validators, ...next_validators, ...current_proposals].map(({ account_id }) => account_id)
-
+            
             // TODO use indexer - getting all historic validators from raw GH script .json
-            const networkId = this.provider.connection.url.indexOf('mainnet') > -1 ? 'mainnet' : 'testnet'
+            const networkId = NETWORK_ID === 'mainnet' ? 'mainnet' : 'testnet'
             if (!ghValidators) {
                 ghValidators = (await fetch(`https://raw.githubusercontent.com/frol/near-validators-scoreboard/scoreboard-${networkId}/validators_scoreboard.json`).then((r) => r.json()))
                 .map(({ account_id }) => account_id)

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -3,7 +3,7 @@ import BN from 'bn.js'
 import { WalletError } from './walletError'
 import { getLockupAccountId } from './account-with-lockup'
 import { queryExplorer } from './explorer-api'
-import { MIN_BALANCE_FOR_GAS, NETWORK_ID } from './wallet'
+import { MIN_BALANCE_FOR_GAS } from './wallet'
 
 const {
     transactions: {
@@ -284,10 +284,8 @@ export class Staking {
         if (!accountIds) {
             const rpcValidators = [...current_validators, ...next_validators, ...current_proposals].map(({ account_id }) => account_id)
 
-            console.log('NETWORK_ID', NETWORK_ID)
-
             // TODO use indexer - getting all historic validators from raw GH script .json
-            const networkId = NETWORK_ID === 'mainnet' ? 'mainnet' : 'testnet'
+            const networkId = this.provider.connection.url.indexOf('mainnet') > -1 ? 'mainnet' : 'testnet'
             if (!ghValidators) {
                 ghValidators = (await fetch(`https://raw.githubusercontent.com/frol/near-validators-scoreboard/scoreboard-${networkId}/validators_scoreboard.json`).then((r) => r.json()))
                 .map(({ account_id }) => account_id)

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -283,7 +283,9 @@ export class Staking {
         
         if (!accountIds) {
             const rpcValidators = [...current_validators, ...next_validators, ...current_proposals].map(({ account_id }) => account_id)
-            
+
+            console.log('NETWORK_ID', NETWORK_ID)
+
             // TODO use indexer - getting all historic validators from raw GH script .json
             const networkId = NETWORK_ID === 'mainnet' ? 'mainnet' : 'testnet'
             if (!ghValidators) {

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -286,7 +286,7 @@ export class Staking {
             const rpcValidators = [...current_validators, ...next_validators, ...current_proposals].map(({ account_id }) => account_id)
 
             // TODO use indexer - getting all historic validators from raw GH script .json
-            const networkId = NETWORK_ID === 'default' ? 'testnet' : 'mainnet'
+            const networkId = this.provider.connection.url.indexOf('mainnet') > -1 ? 'mainnet' : 'testnet'
             if (!ghValidators) {
                 ghValidators = (await fetch(`https://raw.githubusercontent.com/frol/near-validators-scoreboard/scoreboard-${networkId}/validators_scoreboard.json`).then((r) => r.json()))
                 .map(({ account_id }) => account_id)
@@ -309,6 +309,7 @@ export class Staking {
                     fee.percentage = fee.numerator / fee.denominator * 100
                     return validator
                 } catch (e) {
+                    console.log('error with', account_id)
                     if (!/No contract for account|cannot find contract code|wasm execution failed/.test(e.message)) {
                         throw(e)
                     }

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -3,7 +3,7 @@ import BN from 'bn.js'
 import { WalletError } from './walletError'
 import { getLockupAccountId } from './account-with-lockup'
 import { queryExplorer } from './explorer-api'
-import { MIN_BALANCE_FOR_GAS, NETWORK_ID } from './wallet'
+import { MIN_BALANCE_FOR_GAS } from './wallet'
 
 const {
     transactions: {
@@ -202,7 +202,6 @@ export class Staking {
         let { deposits, validators } = (await getStakingTransactions(account_id))
         validators = await this.getValidators([...new Set(validators.concat(recentlyStakedValidators))])
         if (!validators.length || this.wallet.has2fa) {
-            console.log('has2fa: checking all validators', this.wallet.has2fa)
             validators = await this.getValidators()
         }
 


### PR DESCRIPTION
pulls more validators (historic) from GH list:
`https://raw.githubusercontent.com/frol/near-validators-scoreboard/scoreboard-${networkId}/validators_scoreboard.json`

streamlines validator list to currentValidators only when user is staking