### PR TITLE
add refresh_staking_pool_balance call

### DIFF
--- a/src/utils/account-with-lockup.js
+++ b/src/utils/account-with-lockup.js
@@ -57,11 +57,7 @@ async function signAndSendTransaction(receiverId, actions) {
         } else {
             let liquidBalance = new BN(await this.wrappedAccount.viewFunction(lockupAccountId, 'get_liquid_owners_balance'))
             if (!liquidBalance.gt(missingAmount)) {
-                await this.wrappedAccount.functionCall(lockupAccountId, 'refresh_staking_pool_balance', {}, BASE_GAS.mul(new BN(3)))
-                liquidBalance = new BN(await this.wrappedAccount.viewFunction(lockupAccountId, 'get_liquid_owners_balance'))
-                if (!liquidBalance.gt(missingAmount)) {
-                    throw new WalletError('Not enough tokens.', 'sendMoney.amountStatusId.notEnoughTokens')
-                }
+                throw new WalletError('Not enough tokens.', 'sendMoney.amountStatusId.notEnoughTokens')
             }
 
             await this.wrappedAccount.functionCall(lockupAccountId, 'transfer', {

--- a/src/utils/account-with-lockup.js
+++ b/src/utils/account-with-lockup.js
@@ -55,7 +55,7 @@ async function signAndSendTransaction(receiverId, actions) {
             const lockupAccount = new Account(tmpConnection, lockupAccountId)
             await lockupAccount.deleteAccount(this.accountId)
         } else {
-            let liquidBalance = new BN(await this.wrappedAccount.viewFunction(lockupAccountId, 'get_liquid_owners_balance'))
+            const liquidBalance = new BN(await this.wrappedAccount.viewFunction(lockupAccountId, 'get_liquid_owners_balance'))
             if (!liquidBalance.gt(missingAmount)) {
                 throw new WalletError('Not enough tokens.', 'sendMoney.amountStatusId.notEnoughTokens')
             }

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -346,9 +346,14 @@ export class Staking {
     /********************************
     Lockup
     ********************************/
-
     async lockupWithdraw(lockupId, amount) {
         let result
+        result = await this.signAndSendTransaction(lockupId, [
+            functionCall('refresh_staking_pool_balance', {}, STAKING_GAS_BASE * 3, '0')
+        ])
+        if (result === false) {
+            throw new WalletError('Unable to refresh staking pool balance', 'staking.errors.noWithdraw')
+        }
         if (amount) {
             result = await this.signAndSendTransaction(lockupId, [
                 functionCall('withdraw_from_staking_pool', { amount }, STAKING_GAS_BASE * 5, '0')

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -346,7 +346,9 @@ export class Staking {
     /********************************
     Lockup
     ********************************/
+   
     async lockupWithdraw(lockupId, amount) {
+        let result
         if (amount) {
             result = await this.signAndSendTransaction(lockupId, [
                 functionCall('withdraw_from_staking_pool', { amount }, STAKING_GAS_BASE * 5, '0')

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -347,13 +347,6 @@ export class Staking {
     Lockup
     ********************************/
     async lockupWithdraw(lockupId, amount) {
-        let result
-        result = await this.signAndSendTransaction(lockupId, [
-            functionCall('refresh_staking_pool_balance', {}, STAKING_GAS_BASE * 3, '0')
-        ])
-        if (result === false) {
-            throw new WalletError('Unable to refresh staking pool balance', 'staking.errors.noWithdraw')
-        }
         if (amount) {
             result = await this.signAndSendTransaction(lockupId, [
                 functionCall('withdraw_from_staking_pool', { amount }, STAKING_GAS_BASE * 5, '0')

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -346,7 +346,7 @@ export class Staking {
     /********************************
     Lockup
     ********************************/
-   
+
     async lockupWithdraw(lockupId, amount) {
         let result
         if (amount) {


### PR DESCRIPTION
call refresh_staking_pool_balance and get liquid before throwing not enough tokens error

for users unstaking their rewards:
https://github.com/near/core-contracts/tree/master/lockup#refresh-the-current-total-balance-on-the-staking-pool