### PR TITLE
Allow skipping 2FA setup

### DIFF
--- a/src/components/accounts/two_factor/EnableTwoFactor.js
+++ b/src/components/accounts/two_factor/EnableTwoFactor.js
@@ -30,6 +30,15 @@ const StyledContainer = styled(Container)`
     button {
         margin-top: 50px !important;
         width: 100% !important;
+
+        &.link {
+            text-transform: none !important;
+            margin-top: 30px !important;
+            text-decoration: none !important;
+            width: auto !important;
+            margin: 30px auto 0 auto !important;
+            display: block !important;
+        }
     }
 `
 
@@ -157,6 +166,7 @@ export function EnableTwoFactor(props) {
                     >
                         <Translate id={`button.continue`} />
                     </FormButton>
+                    <FormButton className='link' linkTo='/profile'>Skip</FormButton>
                 </form>
             </StyledContainer>
         )

--- a/src/components/accounts/two_factor/EnableTwoFactor.js
+++ b/src/components/accounts/two_factor/EnableTwoFactor.js
@@ -166,7 +166,7 @@ export function EnableTwoFactor(props) {
                     >
                         <Translate id={`button.continue`} />
                     </FormButton>
-                    <FormButton className='link' linkTo='/profile'>Skip</FormButton>
+                    <FormButton className='link' linkTo='/profile'><Translate id='button.skip' /></FormButton>
                 </form>
             </StyledContainer>
         )

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -36,6 +36,7 @@ export const DISABLE_CREATE_ACCOUNT = process.env.DISABLE_CREATE_ACCOUNT === 'tr
 export const DISABLE_SEND_MONEY = process.env.DISABLE_SEND_MONEY === 'true' || process.env.DISABLE_SEND_MONEY === 'yes'
 export const ACCOUNT_ID_SUFFIX = process.env.REACT_APP_ACCOUNT_ID_SUFFIX || 'testnet'
 export const MULTISIG_MIN_AMOUNT = process.env.REACT_APP_MULTISIG_MIN_AMOUNT || '40'
+export const MULTISIG_MIN_PROMPT_AMOUNT = process.env.REACT_APP_MULTISIG_MIN_AMOUNT || '200'
 export const LOCKUP_ACCOUNT_ID_SUFFIX = process.env.LOCKUP_ACCOUNT_ID_SUFFIX || 'lockup.near'
 export const MIN_BALANCE_FOR_GAS = process.env.REACT_APP_MIN_BALANCE_FOR_GAS || nearApiJs.utils.format.parseNearAmount('2')
 export const ACCESS_KEY_FUNDING_AMOUNT = process.env.REACT_APP_ACCESS_KEY_FUNDING_AMOUNT || nearApiJs.utils.format.parseNearAmount('0.01')

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -36,7 +36,7 @@ export const DISABLE_CREATE_ACCOUNT = process.env.DISABLE_CREATE_ACCOUNT === 'tr
 export const DISABLE_SEND_MONEY = process.env.DISABLE_SEND_MONEY === 'true' || process.env.DISABLE_SEND_MONEY === 'yes'
 export const ACCOUNT_ID_SUFFIX = process.env.REACT_APP_ACCOUNT_ID_SUFFIX || 'testnet'
 export const MULTISIG_MIN_AMOUNT = process.env.REACT_APP_MULTISIG_MIN_AMOUNT || '40'
-export const MULTISIG_MIN_PROMPT_AMOUNT = process.env.REACT_APP_MULTISIG_MIN_AMOUNT || '200'
+export const MULTISIG_MIN_PROMPT_AMOUNT = process.env.REACT_APP_MULTISIG_MIN_PROMPT_AMOUNT || '200'
 export const LOCKUP_ACCOUNT_ID_SUFFIX = process.env.LOCKUP_ACCOUNT_ID_SUFFIX || 'lockup.near'
 export const MIN_BALANCE_FOR_GAS = process.env.REACT_APP_MIN_BALANCE_FOR_GAS || nearApiJs.utils.format.parseNearAmount('2')
 export const ACCESS_KEY_FUNDING_AMOUNT = process.env.REACT_APP_ACCESS_KEY_FUNDING_AMOUNT || nearApiJs.utils.format.parseNearAmount('0.01')


### PR DESCRIPTION
Changes:
1. Added a 'Skip' button to `/enable-two-factor`
2. Require that user has at least 200N available balance before prompting 2FA setup