### PR TITLE
small update to filter out 2fa methods from recoveryMethods

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -9,7 +9,6 @@ import {
     setKeyMeta, MULTISIG_MIN_PROMPT_AMOUNT
 } from '../utils/wallet'
 import { PublicKey, KeyType } from 'near-api-js/lib/utils/key_pair'
-import { KeyPair } from 'near-api-js'
 import { WalletError } from '../utils/walletError'
 import { utils } from 'near-api-js'
 import { BN } from 'bn.js'

--- a/src/components/profile/Profile.js
+++ b/src/components/profile/Profile.js
@@ -17,7 +17,10 @@ export function Profile({ match }) {
     const isOwner = accountId === loginAccountId
     const account = useAccount(accountId)
     const dispatch = useDispatch();
+    
     const twoFactor = account.has2fa && recoveryMethods[account.accountId] && recoveryMethods[account.accountId].filter(m => m.kind.includes('2fa'))[0]
+
+    console.log('twoFactor', twoFactor)
 
     useEffect(() => { 
         if (isOwner) {

--- a/src/components/profile/Profile.js
+++ b/src/components/profile/Profile.js
@@ -20,8 +20,6 @@ export function Profile({ match }) {
     
     const twoFactor = account.has2fa && recoveryMethods[account.accountId] && recoveryMethods[account.accountId].filter(m => m.kind.includes('2fa'))[0]
 
-    console.log('twoFactor', twoFactor)
-
     useEffect(() => { 
         if (isOwner) {
             dispatch(getAccessKeys(accountId))

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -674,7 +674,8 @@ class Wallet {
         const publicKeys = accessKeys.map(key => key.public_key)
         const confirmedNoPublicKeyMethods = recoveryMethods.filter(({ publicKey, confirmed }) => publicKey === null && confirmed === true)
         const publicKeyMethods = recoveryMethods.filter(({ publicKey }) => publicKeys.includes(publicKey))
-        const allMethods = [...confirmedNoPublicKeyMethods, ...publicKeyMethods]
+        const twoFactorMethods = recoveryMethods.filter(({ kind }) => kind.indexOf('2fa-') === 0)
+        const allMethods = [...confirmedNoPublicKeyMethods, ...publicKeyMethods, ...twoFactorMethods]
 
         return {
             accountId,

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -672,10 +672,9 @@ class Wallet {
         let recoveryMethods = await this.postSignedJson('/account/recoveryMethods', { accountId }, account)
         const accessKeys =  await this.getAccessKeys()
         const publicKeys = accessKeys.map(key => key.public_key)
-        const confirmedNoPublicKeyMethods = recoveryMethods.filter(({ publicKey, confirmed }) => publicKey === null && confirmed === true)
         const publicKeyMethods = recoveryMethods.filter(({ publicKey }) => publicKeys.includes(publicKey))
         const twoFactorMethods = recoveryMethods.filter(({ kind }) => kind.indexOf('2fa-') === 0)
-        const allMethods = [...confirmedNoPublicKeyMethods, ...publicKeyMethods, ...twoFactorMethods]
+        const allMethods = [...publicKeyMethods, ...twoFactorMethods]
 
         return {
             accountId,


### PR DESCRIPTION
fixes when user doesn't confirm 2fa their 2fa method will disappear from profile

now it won't