### PR TITLE
hotfix for resend 2fa codes

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -199,11 +199,11 @@ export const {
         () => defaultCodesFor('account.initTwoFactor')
     ],
     REINIT_TWO_FACTOR: [
-        (...args) => wallet.twoFactor.reInitTwoFactor(...args),
+        (...args) => wallet.twoFactor.initTwoFactor(...args),
         () => defaultCodesFor('account.reInitTwoFactor')
     ],
     RESEND_TWO_FACTOR: [
-        (...args) => wallet.twoFactor.resend(...args),
+        () => wallet.twoFactor.sendCode(),
         () => defaultCodesFor('account.resendTwoFactor')
     ],
     VERIFY_TWO_FACTOR: [

--- a/src/utils/twoFactor.js
+++ b/src/utils/twoFactor.js
@@ -60,23 +60,6 @@ export class TwoFactor extends Account2FA {
         });
     }
 
-    async reInitTwoFactor(accountId, method) {
-        // clear any previous requests in localStorage (for verifyTwoFactor)
-        this.setRequest({ requestId: -1 })
-        return this.sendRequest(accountId, method)
-    }
-
-    async resend(accountId, method) {
-        if (!accountId) accountId = this.wallet.accountId
-        if (!method) method = await this.get2faMethod()
-        const requestData = this.getRequest()
-        let { requestId } = requestData
-        if (!requestId && requestId !== 0) {
-            requestId = -1
-        }
-        return this.sendRequest(accountId, method, requestId)
-    }
-
     // TODO deprecate or test this (we removed the send new recovery message option)
     async rotateKeys(account, addPublicKey, removePublicKey) {
         const { accountId } = account


### PR DESCRIPTION
There was a mismatch between twoFactor.js and Account2FA from near-api-js.

Discovered via Sentry this morning.

Reduced code. e2e tested branch for resending 2fa code:
- deploying 2fa account
- sending 2fa tx