### PR TITLE
Show UI error for stake, unstake, withdraw

### DIFF
--- a/src/components/staking/StakingContainer.js
+++ b/src/components/staking/StakingContainer.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { updateStaking, switchAccount, stake, unstake, withdraw } from '../../actions/staking'
+import { clearAlert } from '../../actions/account';
 import styled from 'styled-components'
 import Container from '../common/styled/Container.css'
 import { Switch, Route } from 'react-router-dom'
@@ -171,6 +172,7 @@ export function StakingContainer({ history, match }) {
         } else if (action === 'unstake') {
             await dispatch(unstake(currentAccount.accountId, selectedValidator || validator, amount))
         }
+        await dispatch(clearAlert())
         await dispatch(updateStaking(currentAccount.accountId, [validator]))
     }
 

--- a/src/components/staking/components/ValidatorBox.js
+++ b/src/components/staking/components/ValidatorBox.js
@@ -53,7 +53,7 @@ const Container = styled.div`
                 }
 
                 @media (min-width: 500px) {
-                    max-width: 220px;
+                    max-width: 175px;
                 }
             }
         }

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -30,6 +30,12 @@ import {
     createAccountWithSeedPhrase
 } from '../../actions/account'
 
+import {
+    stake,
+    unstake,
+    withdraw,
+} from '../../actions/staking'
+
 const initialState = {
     formLoader: false,
     sentMessage: false,
@@ -56,7 +62,7 @@ const loaderReducer = (state, { type, ready }) => {
 const globalAlertReducer = handleActions({
     // TODO: Reset state before action somehow. On navigate / start of other action?
     // TODO: Make this generic to avoid listing actions
-    [combineActions(addAccessKey, addAccessKeySeedPhrase, setupRecoveryMessage, saveAndSelectLedgerAccounts, deleteRecoveryMethod, recoverAccountSeedPhrase, deployMultisig, sendMoney, removeAccessKey, signAndSendTransactions, addLedgerAccessKey, createAccountWithSeedPhrase)]: (state, { error, ready, payload, meta }) => ({
+    [combineActions(addAccessKey, addAccessKeySeedPhrase, setupRecoveryMessage, saveAndSelectLedgerAccounts, deleteRecoveryMethod, recoverAccountSeedPhrase, deployMultisig, sendMoney, removeAccessKey, signAndSendTransactions, addLedgerAccessKey, createAccountWithSeedPhrase, stake, unstake, withdraw)]: (state, { error, ready, payload, meta }) => ({
         ...state,
         globalAlert: ready ? {
             success: !error,

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -883,7 +883,7 @@
     "errors": {
         "type": {
             "RetriesExceeded": "Exceeded maximum attempts for this transaction.",
-            "LackBalanceForState": "Your balance is too low to perform any actions on your account. Please send NEAR to your account, then import your account again."
+            "LackBalanceForState": "Your available balance is too low to perform any actions on your account. Please send NEAR to your account and then try again."
         },
         "ledger": {
             "U2FNotSupported": "U2F browser support is needed for Ledger. Please use Chrome, Opera or Firefox with a U2F extension. Also make sure you're on an HTTPS connection.",


### PR DESCRIPTION
We now show any potential error from trying to stake, unstake, and withdraw on the UI using the GlobalAlert. Fixes a common case where users don't have enough tokens to cover the TX cost.