### PR TITLE
Send bug: do not allow to send when formLoader is true

### DIFF
--- a/src/components/common/styled/Container.css.js
+++ b/src/components/common/styled/Container.css.js
@@ -34,7 +34,6 @@ const Container = styled.div`
         font-size: 16px !important;
         color: #999 !important;
         font-weight: 400 !important;
-        line-break: anywhere;
     }
 
     &.ledger-theme {

--- a/src/components/send/SendContainer.js
+++ b/src/components/send/SendContainer.js
@@ -31,6 +31,10 @@ const StyledContainer = styled(Container)`
         .sub-title {
             span {
                 color: #292526;
+
+                &.receiver {
+                    line-break: anywhere;
+                }
             }
         }
     }
@@ -142,7 +146,7 @@ export function SendContainer({ match }) {
             <StyledContainer className='small-centered send-theme success'>
                 <TransferMoneyIcon/>
                 <h1>Success!</h1>
-                <div className='sub-title success'>You have successfully sent <span><Balance amount={utils.format.parseNearAmount(amount) || '0'} symbol='near'/></span> to <span>{id}</span></div>
+                <div className='sub-title success'>You have successfully sent <span><Balance amount={utils.format.parseNearAmount(amount) || '0'} symbol='near'/></span> to <span className='receiver'>{id}</span></div>
                 <FormButton linkTo='/'>
                     <Translate id='button.goToDashboard' />
                 </FormButton>

--- a/src/components/send/SendContainer.js
+++ b/src/components/send/SendContainer.js
@@ -46,7 +46,7 @@ export function SendContainer({ match }) {
     const [success, setSuccess] = useState(null)
     const amountAvailableToSend = new BN(balance.available).sub(new BN(parseNearAmount(WALLET_APP_MIN_AMOUNT)))
     const sufficientBalance = !new BN(parseNearAmount(amount)).isZero() && (new BN(parseNearAmount(amount)).lte(amountAvailableToSend) || useMax) && isDecimalString(amount)
-    const sendAllowed = ((requestStatus && requestStatus.success !== false) || id.length === 64) && sufficientBalance && amount
+    const sendAllowed = ((requestStatus && requestStatus.success !== false) || id.length === 64) && sufficientBalance && amount && !formLoader
 
     onKeyDown(e => {
         if (e.keyCode === 13 && sendAllowed) {


### PR DESCRIPTION
Fixes scenario where user with 2FA is on `/send-money` -> enters amount and receiver -> clicks 'submit' -> clicks 'confirm' on the confirmation modal -> 2FA modal shows up and user hits 'enter' on their keyboard without entering the 2FA code -> this triggers another 'send' request