### PR TITLE
Keyboard related fixes to Send, Stake, Recovery, 2FA

### DIFF
--- a/src/components/accounts/EnterVerificationCode.js
+++ b/src/components/accounts/EnterVerificationCode.js
@@ -48,9 +48,15 @@ const EnterVerificationCode = ({
 
     const invalidCode = requestStatus && requestStatus.messageCode === 'account.setupRecoveryMessage.error';
 
+    const handleConfirm = () => {
+        if (code.length === 6 && !loading) {
+            onConfirm(code)
+        }
+    }
+
     return (
         <StyledContainer className='small-centered'>
-            <form onSubmit={e => {onConfirm(code); e.preventDefault();}} autoComplete='off'>
+            <form onSubmit={e => {handleConfirm(); e.preventDefault();}} autoComplete='off'>
                 <h1><Translate id='setRecoveryConfirm.title'/></h1>
                 <h2><Translate id='setRecoveryConfirm.pageText'/> <Translate id={useEmail ? 'setRecoveryConfirm.email': 'setRecoveryConfirm.phone'}/> <span>{useEmail ? email : phoneNumber}</span></h2>
                 <h4><Translate id='setRecoveryConfirm.inputHeader'/></h4>

--- a/src/components/accounts/SetupSeedPhrase.js
+++ b/src/components/accounts/SetupSeedPhrase.js
@@ -27,7 +27,8 @@ class SetupSeedPhrase extends Component {
         enterWord: '',
         wordId: null,
         requestStatus: null,
-        successSnackbar: false
+        successSnackbar: false,
+        submitting: false
     }
 
     componentDidMount = () => {
@@ -77,15 +78,9 @@ class SetupSeedPhrase extends Component {
         history.push(`/setup-seed-phrase/${accountId}/phrase${location.search}`)
     }
 
-    handleSubmit = async () => {
-        const { 
-            accountId,
-            handleAddAccessKeySeedPhrase,
-            handleCreateAccountWithSeedPhrase,
-            checkIsNew,
-            location
-        } = this.props
-        const { seedPhrase, enterWord, wordId, recoveryKeyPair } = this.state
+    handleVerifyPhrase = () => {
+        const { seedPhrase, enterWord, wordId, submitting } = this.state
+
         if (enterWord !== seedPhrase.split(' ')[wordId]) {
             this.setState(() => ({
                 requestStatus: {
@@ -95,6 +90,21 @@ class SetupSeedPhrase extends Component {
             }))
             return false
         }
+
+        if (!submitting) {
+            this.setState({ submitting: true }, this.handleSetupSeedPhrase)
+        }
+    }
+
+    handleSetupSeedPhrase = async () => {
+        const { 
+            accountId,
+            handleAddAccessKeySeedPhrase,
+            handleCreateAccountWithSeedPhrase,
+            checkIsNew,
+            location
+        } = this.props
+        const { recoveryKeyPair } = this.state
 
         const isNew = await checkIsNew(accountId)
 
@@ -155,7 +165,7 @@ class SetupSeedPhrase extends Component {
                             path={`/setup-seed-phrase/:accountId/verify`}
                             render={() => (
                                 <Container className='small-centered'>
-                                    <form onSubmit={e => {this.handleSubmit(); e.preventDefault();}} autoComplete='off'>
+                                    <form onSubmit={e => {this.handleVerifyPhrase(); e.preventDefault();}} autoComplete='off'>
                                     <h1><Translate id='setupSeedPhraseVerify.pageTitle'/></h1>
                                     <h2><Translate id='setupSeedPhraseVerify.pageText'/></h2>
                                         <SetupSeedPhraseVerify
@@ -166,6 +176,7 @@ class SetupSeedPhrase extends Component {
                                             formLoader={this.props.formLoader}
                                             requestStatus={this.state.requestStatus}
                                             globalAlert={this.props.globalAlert}
+                                            submitting={this.state.submitting}
                                         />
                                     </form>
                                 </Container>

--- a/src/components/accounts/SetupSeedPhrase.js
+++ b/src/components/accounts/SetupSeedPhrase.js
@@ -173,10 +173,9 @@ class SetupSeedPhrase extends Component {
                                             wordId={this.state.wordId}
                                             handleChangeWord={this.handleChangeWord}
                                             handleStartOver={this.handleStartOver}
-                                            formLoader={this.props.formLoader}
+                                            formLoader={this.props.formLoader || this.state.submitting}
                                             requestStatus={this.state.requestStatus}
                                             globalAlert={this.props.globalAlert}
-                                            submitting={this.state.submitting}
                                         />
                                     </form>
                                 </Container>

--- a/src/components/accounts/SetupSeedPhraseVerify.js
+++ b/src/components/accounts/SetupSeedPhraseVerify.js
@@ -44,11 +44,8 @@ const SetupSeedPhraseVerify = ({
     enterWord,
     wordId,
     handleChangeWord,
-    handleStartOver,
     formLoader,
-    requestStatus,
-    globalAlert,
-    submitting
+    requestStatus
 }) => (
     <CustomDiv>
         <h4><Translate id='input.enterWord.title' data={{ wordId: wordId + 1 }} /></h4>
@@ -63,7 +60,7 @@ const SetupSeedPhraseVerify = ({
                     tabIndex='1'
                     pattern='[a-zA-Z ]*'
                     className={requestStatus ? (requestStatus.success ? 'success' : 'problem') : ''}
-                    disabled={submitting || formLoader}
+                    disabled={formLoader}
                 />
             )}
         </Translate>
@@ -71,7 +68,7 @@ const SetupSeedPhraseVerify = ({
         <FormButton
             type='submit'
             color='blue'
-            disabled={!enterWord || formLoader || submitting}
+            disabled={!enterWord || formLoader}
             sending={formLoader}
         >
             <Translate id='button.verify' />

--- a/src/components/accounts/SetupSeedPhraseVerify.js
+++ b/src/components/accounts/SetupSeedPhraseVerify.js
@@ -47,7 +47,8 @@ const SetupSeedPhraseVerify = ({
     handleStartOver,
     formLoader,
     requestStatus,
-    globalAlert
+    globalAlert,
+    submitting
 }) => (
     <CustomDiv>
         <h4><Translate id='input.enterWord.title' data={{ wordId: wordId + 1 }} /></h4>
@@ -62,6 +63,7 @@ const SetupSeedPhraseVerify = ({
                     tabIndex='1'
                     pattern='[a-zA-Z ]*'
                     className={requestStatus ? (requestStatus.success ? 'success' : 'problem') : ''}
+                    disabled={submitting || formLoader}
                 />
             )}
         </Translate>
@@ -69,7 +71,7 @@ const SetupSeedPhraseVerify = ({
         <FormButton
             type='submit'
             color='blue'
-            disabled={!enterWord || formLoader}
+            disabled={!enterWord || formLoader || submitting}
             sending={formLoader}
         >
             <Translate id='button.verify' />

--- a/src/components/accounts/SetupSeedPhraseVerify.js
+++ b/src/components/accounts/SetupSeedPhraseVerify.js
@@ -69,7 +69,7 @@ const SetupSeedPhraseVerify = ({
         <FormButton
             type='submit'
             color='blue'
-            disabled={enterWord ? (globalAlert && globalAlert.success) : true}
+            disabled={!enterWord || formLoader}
             sending={formLoader}
         >
             <Translate id='button.verify' />

--- a/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
+++ b/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
@@ -86,14 +86,15 @@ class SetupRecoveryMethod extends Component {
     }
 
     handleNext = async () => {
-        const { option } = this.state;
+        const { option, success } = this.state;
         const {
             accountId,
             location,
-            redirectTo
+            redirectTo,
+            formLoader
         } = this.props
 
-        if (this.isValidInput) {
+        if (this.isValidInput && !formLoader && !success) {
             if (option === 'email' || option === 'phone') {
                 await this.handleSendCode()
                 window.scrollTo(0, 0);
@@ -244,7 +245,7 @@ class SetupRecoveryMethod extends Component {
                         <FormButton
                             color='blue'
                             type='submit'
-                            disabled={!this.isValidInput}
+                            disabled={!this.isValidInput || formLoader}
                             sending={formLoader}
                         >
                             <Translate id={`button.${option !== 'phrase' ? 'protectAccount' : 'setupPhrase'}`}/>

--- a/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
+++ b/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
@@ -132,12 +132,14 @@ class SetupRecoveryMethod extends Component {
             location,
         } = this.props;
 
-        const isNew = await checkIsNew(accountId)
-        if (isNew) {
-            const fundingOptions = JSON.parse(parseQuery(location.search).fundingOptions || 'null')
-            await setupRecoveryMessageNewAccount(accountId, this.method, securityCode, fundingOptions, this.state.recoverySeedPhrase)
-        } else {
-            await setupRecoveryMessage(accountId, this.method, securityCode, this.state.recoverySeedPhrase)
+        if (this.state.success) {
+            const isNew = await checkIsNew(accountId)
+            if (isNew) {
+                const fundingOptions = JSON.parse(parseQuery(location.search).fundingOptions || 'null')
+                await setupRecoveryMessageNewAccount(accountId, this.method, securityCode, fundingOptions, this.state.recoverySeedPhrase)
+            } else {
+                await setupRecoveryMessage(accountId, this.method, securityCode, this.state.recoverySeedPhrase)
+            }
         }
     }
 

--- a/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
+++ b/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
@@ -10,7 +10,8 @@ import {
     initializeRecoveryMethod, 
     setupRecoveryMessage,
     setupRecoveryMessageNewAccount, 
-    redirectToApp, 
+    redirectToApp,
+    redirectTo,
     loadRecoveryMethods, 
     getAccessKeys, 
     getLedgerKey,
@@ -84,23 +85,23 @@ class SetupRecoveryMethod extends Component {
         }
     }
 
-    handleNext = () => {
+    handleNext = async () => {
         const { option } = this.state;
-
         const {
             accountId,
             location,
+            redirectTo
         } = this.props
-        const phraseUrl = `/setup-seed-phrase/${accountId}/phrase${location.search}`
 
-        if (option === 'email' || option === 'phone') {
-            this.handleSendCode()
-            window.scrollTo(0, 0);
-        } else if (option === 'phrase') {
-            this.props.history.push(phraseUrl);
-        } else if (option === 'ledger') {
-            const ledgerUrl = `/setup-ledger/${accountId}${location.search}`
-            this.props.history.push(ledgerUrl);
+        if (this.isValidInput) {
+            if (option === 'email' || option === 'phone') {
+                await this.handleSendCode()
+                window.scrollTo(0, 0);
+            } else if (option === 'phrase') {
+                redirectTo(`/setup-seed-phrase/${accountId}/phrase${location.search}`)
+            } else if (option === 'ledger') {
+                redirectTo(`/setup-ledger/${accountId}${location.search}`)
+            }
         }
     }
 
@@ -277,7 +278,8 @@ const mapDispatchToProps = {
     getAccessKeys,
     getLedgerKey,
     get2faMethod,
-    checkIsNew
+    checkIsNew,
+    redirectTo
 }
 
 const mapStateToProps = ({ account, router, recoveryMethods }, { match }) => ({

--- a/src/components/accounts/two_factor/EnableTwoFactor.js
+++ b/src/components/accounts/two_factor/EnableTwoFactor.js
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { Translate } from 'react-localize-redux';
 import TwoFactorOption from './TwoFactorOption';
 import PhoneInput, { isValidPhoneNumber } from 'react-phone-number-input';
-import { utils } from 'near-api-js'
 import { validateEmail } from '../../../utils/account';
 import { MULTISIG_MIN_AMOUNT } from '../../../utils/wallet'
 import FormButton from '../../common/FormButton';
@@ -13,12 +12,12 @@ import {
     initTwoFactor,
     verifyTwoFactor,
     deployMultisig,
-    redirectToApp
+    redirectToApp,
+    clearAlert
 } from '../../../actions/account';
 import { useRecoveryMethods } from '../../../hooks/recoveryMethods';
 import EnterVerificationCode from '../EnterVerificationCode'
 import Container from '../../common/styled/Container.css'
-import { onKeyDown } from '../../../hooks/eventListeners'
 
 const StyledContainer = styled(Container)`
 
@@ -56,12 +55,6 @@ export function EnableTwoFactor(props) {
     const recoveryMethods = useRecoveryMethods(accountId);
     const loading = formLoader
 
-    onKeyDown(e => {
-        if (e.keyCode === 13 && isValidInput() && !loading) {
-            handleNext()
-        }
-    });
-
     const method = {
         kind: `2fa-${option}`,
         detail: option === 'email' ? email : phoneNumber
@@ -82,26 +75,35 @@ export function EnableTwoFactor(props) {
     }, [recoveryMethods]);
 
     const handleNext = async () => {
-        let response;
-        try {
-            response = await dispatch(initTwoFactor(accountId, method))
-        } finally {
-            if (response && response.confirmed) {
-                handleDeployMultisig()
-            } else {
-                setInitiated(true)
+        if (!initiated && !loading && !has2fa && isValidInput()) {
+            let response;
+            try {
+                response = await dispatch(initTwoFactor(accountId, method))
+            } finally {
+                if (response && response.confirmed) {
+                    await handleDeployMultisig()
+                } else {
+                    setInitiated(true)
+                }
             }
         }
     }
 
+    const handleResendCode = async () => {
+        await dispatch(initTwoFactor(accountId, method))
+    }
+
     const handleConfirm = async (securityCode) => {
-        await dispatch(verifyTwoFactor(securityCode))
-        handleDeployMultisig()
+        if (initiated && securityCode.length === 6) {
+            await dispatch(verifyTwoFactor(securityCode))
+            await dispatch(clearAlert())
+            await handleDeployMultisig()
+        }
     }
 
     const handleDeployMultisig = async () => {
         await dispatch(deployMultisig())
-        dispatch(redirectToApp('/profile'))
+        await dispatch(redirectToApp('/profile'))
     }
 
     const handleGoBack = () => {
@@ -146,6 +148,7 @@ export function EnableTwoFactor(props) {
                                     value={email}
                                     onChange={e => setEmail(e.target.value)}
                                     tabIndex='1'
+                                    disabled={loading}
                                 />
                             )}
                         </Translate>
@@ -162,19 +165,20 @@ export function EnableTwoFactor(props) {
                                     value={phoneNumber}
                                     onChange={value => setPhoneNumber(value)}
                                     tabIndex='1'
+                                    disabled={loading}
                                 />
                             )}
                         </Translate>
                     </TwoFactorOption>
                     <FormButton
                         color='blue'
+                        disabled={!isValidInput() || loading || has2fa || initiated}
                         type='submit'
-                        disabled={!isValidInput() || loading || has2fa}
                         sending={loading}
                     >
                         <Translate id={`button.continue`} />
                     </FormButton>
-                    <FormButton className='link' linkTo='/profile'><Translate id='button.skip' /></FormButton>
+                    <FormButton className='link' type='button' linkTo='/profile'><Translate id='button.skip' /></FormButton>
                 </form>
             </StyledContainer>
         )
@@ -186,7 +190,7 @@ export function EnableTwoFactor(props) {
                 email={email}
                 onConfirm={handleConfirm}
                 onGoBack={handleGoBack}
-                onResend={handleNext}
+                onResend={handleResendCode}
                 loading={loading}
                 requestStatus={props.requestStatus}
             />

--- a/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -41,7 +41,9 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
     }, []);
 
     const handleVerifyCode = async () => {
-        onClose(code)
+        if (code.length === 6 && !loading) {
+            onClose(code)
+        }
     }
 
     const handleChange = (code) => {

--- a/src/components/send/SendContainer.js
+++ b/src/components/send/SendContainer.js
@@ -50,7 +50,7 @@ export function SendContainer({ match }) {
     const [success, setSuccess] = useState(null)
     const amountAvailableToSend = new BN(balance.available).sub(new BN(parseNearAmount(WALLET_APP_MIN_AMOUNT)))
     const sufficientBalance = !new BN(parseNearAmount(amount)).isZero() && (new BN(parseNearAmount(amount)).lte(amountAvailableToSend) || useMax) && isDecimalString(amount)
-    const sendAllowed = ((requestStatus && requestStatus.success !== false) || id.length === 64) && sufficientBalance && amount && !formLoader
+    const sendAllowed = ((requestStatus && requestStatus.success !== false) || id.length === 64) && sufficientBalance && amount && !formLoader && !success
 
     onKeyDown(e => {
         if (e.keyCode === 13 && sendAllowed) {

--- a/src/components/staking/components/StakingAction.js
+++ b/src/components/staking/components/StakingAction.js
@@ -39,7 +39,7 @@ export default function StakingAction({
     const displayAmount = useMax ? formatNearAmount(amount, 5) : amount
     const availableToStake = stakeFromAccount ? new BN(availableBalance).sub(new BN(utils.format.parseNearAmount(WALLET_APP_MIN_AMOUNT))).toString() : availableBalance
     const invalidStakeActionAmount = new BN(useMax ? amount : parseNearAmount(amount)).sub(new BN(stake ? availableToStake : staked)).gt(new BN(STAKING_AMOUNT_DEVIATION)) || !isDecimalString(amount)
-    const stakeActionAllowed = hasStakeActionAmount && !invalidStakeActionAmount
+    const stakeActionAllowed = hasStakeActionAmount && !invalidStakeActionAmount && !success
 
     onKeyDown(e => {
         if (e.keyCode === 13 && stakeActionAllowed) {

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -19,6 +19,7 @@ import {
     recoverAccountSeedPhrase,
     removeAccessKey,
     deployMultisig,
+    verifyTwoFactor,
     checkCanEnableTwoFactor,
     get2faMethod,
     getLedgerKey,
@@ -62,7 +63,24 @@ const loaderReducer = (state, { type, ready }) => {
 const globalAlertReducer = handleActions({
     // TODO: Reset state before action somehow. On navigate / start of other action?
     // TODO: Make this generic to avoid listing actions
-    [combineActions(addAccessKey, addAccessKeySeedPhrase, setupRecoveryMessage, saveAndSelectLedgerAccounts, deleteRecoveryMethod, recoverAccountSeedPhrase, deployMultisig, sendMoney, removeAccessKey, signAndSendTransactions, addLedgerAccessKey, createAccountWithSeedPhrase, stake, unstake, withdraw)]: (state, { error, ready, payload, meta }) => ({
+    [combineActions(
+        addAccessKey,
+        addAccessKeySeedPhrase,
+        setupRecoveryMessage,
+        saveAndSelectLedgerAccounts,
+        deleteRecoveryMethod,
+        recoverAccountSeedPhrase,
+        verifyTwoFactor,
+        deployMultisig,
+        sendMoney,
+        removeAccessKey,
+        signAndSendTransactions,
+        addLedgerAccessKey,
+        createAccountWithSeedPhrase,
+        stake,
+        unstake,
+        withdraw
+    )]: (state, { error, ready, payload, meta }) => ({
         ...state,
         globalAlert: ready ? {
             success: !error,


### PR DESCRIPTION
- Guard against attempts to 're-submit' action related to: send, stake, recovery, 2FA. Any click or key press (enter).
- Guard against submitting incomplete forms or while things are loading
- Clean up and use dispatch vs history.push
- Add missing await(s)
- Show globalAlert for incorrect code during 2FA setup

Note: most fixes above are for **Safari** browser.