### PR TITLE
Validator page: disable onKeyDown while loading and cleanup

### DIFF
--- a/src/components/staking/components/Validator.js
+++ b/src/components/staking/components/Validator.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { useDispatch } from 'react-redux'
 import FormButton from '../../common/FormButton'
 import { Translate } from 'react-localize-redux'
 import BalanceBox from './BalanceBox'
@@ -7,34 +8,31 @@ import AlertBanner from './AlertBanner'
 import StakeConfirmModal from './StakeConfirmModal'
 import { onKeyDown } from '../../../hooks/eventListeners'
 import BN from 'bn.js'
+import { redirectTo } from '../../../actions/account'
 
 export default function Validator({
     match,
     validator,
-    onUnstake,
     onWithdraw,
     loading,
     selectedValidator,
-    history,
     currentValidators,
     unableToCalcRewards
 }) {
     const [confirm, setConfirm] = useState(null)
-
+    const dispatch = useDispatch()
     const stakeNotAllowed = selectedValidator && selectedValidator !== match.params.validator && currentValidators.length
     const currentValidator = currentValidators.filter(validator => validator.accountId === match.params.validator)[0]
     const showRewardsBanner = unableToCalcRewards && currentValidator && !new BN(currentValidator.staked).isZero()
 
     onKeyDown(e => {
-        if (e.keyCode === 13 && confirm === 'withdraw') {
+        if (e.keyCode === 13 && confirm === 'withdraw' && !loading) {
             handleStakeAction()
         }
     })
 
     const handleStakeAction = async () => {
-        if (confirm === 'unstake') {
-           await onUnstake()
-        } else if (confirm === 'withdraw') {
+        if (confirm === 'withdraw') {
            await onWithdraw()
         }
         setConfirm('done')
@@ -58,7 +56,7 @@ export default function Validator({
                         title='staking.balanceBox.staked.title'
                         info='staking.balanceBox.staked.info'
                         amount={validator.staked || '0'}
-                        onClick={() => history.push(`/staking/${match.params.validator}/unstake`)}
+                        onClick={() => dispatch(redirectTo(`/staking/${match.params.validator}/unstake`))}
                         button='staking.balanceBox.staked.button'
                         buttonColor='gray-red'
                         loading={loading}
@@ -88,7 +86,7 @@ export default function Validator({
                             title={`staking.validator.${confirm}`}
                             label='staking.stake.from'
                             validator={validator}
-                            amount={confirm === 'unstake' ? validator.staked : validator.available}
+                            amount={validator.available}
                             open={confirm}
                             onConfirm={handleStakeAction}
                             onClose={() => setConfirm(null)}


### PR DESCRIPTION
Protects against attempt to initiate withdrawal while withdrawal is already in progress (by pressing enter)