### PR TITLE
Fix Activity Feed - uses new CH endpoint

### DIFF
--- a/src/components/dashboard/ActionsList.js
+++ b/src/components/dashboard/ActionsList.js
@@ -124,7 +124,7 @@ const CustomGridRow = styled(Grid.Row)`
 const ActionsList = ({ transaction, wide, accountId, getTransactionStatus }) => (
     <ActionRow 
         transaction={transaction} 
-        actionArgs={JSON.parse(transaction.args)} 
+        actionArgs={transaction.args} 
         actionKind={transaction.kind}  
         wide={wide}
         accountId={accountId}
@@ -225,7 +225,7 @@ const translateData = (transaction, actionArgs, actionKind) => ({
     methodName: actionKind === "FunctionCall" ? actionArgs.method_name : '', 
     deposit: actionKind === "Transfer" ? <Balance amount={actionArgs.deposit} /> : '',
     stake: actionKind === "Stake" ? <Balance amount={actionArgs.stake} />  : '',
-    permissionReceiverId: (actionKind === "AddKey" && actionArgs.access_key && typeof actionArgs.access_key.permission === 'object') ? actionArgs.access_key.permission.FunctionCall.receiver_id : ''
+    permissionReceiverId: (actionKind === "AddKey" && actionArgs.access_key && typeof actionArgs.access_key.permission.permission_kind === 'FUNCTION_CALL') ? actionArgs.access_key.permission.permission_details.receiver_id : ''
 })
 
 const ActionIcon = ({ actionKind }) => (

--- a/src/components/dashboard/ActionsList.js
+++ b/src/components/dashboard/ActionsList.js
@@ -225,7 +225,7 @@ const translateData = (transaction, actionArgs, actionKind) => ({
     methodName: actionKind === "FunctionCall" ? actionArgs.method_name : '', 
     deposit: actionKind === "Transfer" ? <Balance amount={actionArgs.deposit} /> : '',
     stake: actionKind === "Stake" ? <Balance amount={actionArgs.stake} />  : '',
-    permissionReceiverId: (actionKind === "AddKey" && actionArgs.access_key && typeof actionArgs.access_key.permission.permission_kind === 'FUNCTION_CALL') ? actionArgs.access_key.permission.permission_details.receiver_id : ''
+    permissionReceiverId: (actionKind === "AddKey" && actionArgs.access_key && actionArgs.access_key.permission.permission_kind === 'FUNCTION_CALL') ? actionArgs.access_key.permission.permission_details.receiver_id : ''
 })
 
 const ActionIcon = ({ actionKind }) => (

--- a/src/components/dashboard/ActionsList.js
+++ b/src/components/dashboard/ActionsList.js
@@ -207,7 +207,7 @@ const ActionMessage = ({ transaction, actionArgs, actionKind, accountId }) => (
 const translateId = (transaction, actionArgs, actionKind, accountId) => (
     `actions.${actionKind
         }${actionKind === `AddKey`
-            ? actionArgs.access_key && typeof actionArgs.access_key.permission === 'object'
+            ? actionArgs.access_key && actionArgs.access_key.permission.permission_details
                 ? `.forContract`
                 : `.forReceiver`
             : ''

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -107,8 +107,8 @@
         },
         "Stake": "Staked ${stake}",
         "AddKey": {
-            "forContract": "Access key added for contract: ${permissionReceiverId}",
-            "forReceiver": "New key added for ${receiverId}"
+            "forContract": "Access Key added for: ${permissionReceiverId}",
+            "forReceiver": "Full Access Key added for: ${receiverId}"
         },
         "DeleteKey": "Key deleted"
     },

--- a/src/utils/explorer-api.js
+++ b/src/utils/explorer-api.js
@@ -1,5 +1,5 @@
 import { Wampy } from 'wampy'
-import { wallet } from './wallet'
+import { wallet, ACCOUNT_HELPER_URL } from './wallet'
 
 const WAMP_NEAR_EXPLORER_URL = process.env.WAMP_NEAR_EXPLORER_URL || 'wss://near-explorer-wamp.onrender.com/ws'
 const WAMP_NEAR_EXPLORER_TOPIC_PREFIX = process.env.WAMP_NEAR_EXPLORER_TOPIC_PREFIX || 'com.nearprotocol.testnet.explorer'
@@ -23,7 +23,7 @@ export const queryExplorer = (sql, params) => new Promise((resolve, reject) => w
 export async function getTransactions(accountId) {
     if (!accountId) return {}
 
-    const txs = await fetch(`https://near-contract-helper-2fa.onrender.com/account/${accountId}/activity`).then((res) => res.json())
+    const txs = await fetch(`${ACCOUNT_HELPER_URL}/account/${accountId}/activity`).then((res) => res.json())
 
     return {
         [accountId]: txs.map((t, i) => ({

--- a/src/utils/explorer-api.js
+++ b/src/utils/explorer-api.js
@@ -23,40 +23,15 @@ export const queryExplorer = (sql, params) => new Promise((resolve, reject) => w
 export async function getTransactions(accountId) {
     if (!accountId) return {}
 
-    const sql = `
-        SELECT
-            transactions.hash, 
-            transactions.signer_id, 
-            transactions.receiver_id, 
-            transactions.block_hash, 
-            transactions.block_timestamp, 
-            actions.action_type as kind, 
-            actions.action_args as args,
-            actions.action_index || ':' || transactions.hash as hash_with_index
-        FROM 
-            transactions
-        LEFT JOIN actions ON actions.transaction_hash = transactions.hash
-        WHERE 
-            transactions.signer_id = :accountId 
-            OR transactions.receiver_id = :accountId
-        ORDER BY 
-            block_timestamp DESC
-        LIMIT 
-            :offset, :count
-    `
-
-    const params = {
-        accountId, 
-        offset: 0, 
-        count: 5
-    }
-
-    const tx = await queryExplorer(sql, params)
+    const txs = await fetch(`https://near-contract-helper-2fa.onrender.com/account/${accountId}/activity`).then((res) => res.json())
 
     return {
-        [accountId]: tx.map((t, i) => ({
+        [accountId]: txs.map((t, i) => ({
             ...t,
-            checkStatus: !(i && t.hash === tx[i - 1].hash)
+            kind: t.action_kind.split('_').map(s => s.substr(0, 1) + s.substr(1).toLowerCase()).join(''),
+            block_timestamp: parseInt(t.block_timestamp.substr(0, 13), 10),
+            hash_with_index: t.action_index + ':' + t.hash,
+            checkStatus: !(i && t.hash === txs[i - 1].hash)
         }))
     }
 }


### PR DESCRIPTION
Uses a new endpoint from indexer to fix issues with activity feed not showing 2FA and other contract runtime actions (e.g. transfers that a contract does to your account)

CH PR:
https://github.com/near/near-contract-helper/pull/303

**Relies on: REACT_APP_ACCOUNT_HELPER_URL="https://near-contract-helper-2fa.onrender.com" until PR is merged.**