### PR TITLE
hotfix: total - deposits vs. staked - deposits

### DIFF
--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -225,8 +225,8 @@ export class Staking {
                 const deposit = new BN(validatorDepositMap[validator.accountId] || '0')
                 validator.staked = await validator.contract.get_account_staked_balance({ account_id })
 
-                // rewards (lifetime) = staked - deposits
-                validator.unclaimed = new BN(validator.staked).sub(deposit).toString()
+                // rewards (lifetime) = total - deposits
+                validator.unclaimed = total.sub(deposit).toString()
                 if (!deposit.gt(ZERO) || new BN(validator.unclaimed).lt(MIN_DISPLAY_YOCTO)) {
                     validator.unclaimed = ZERO.clone().toString()
                 }

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -40,7 +40,7 @@ export const MULTISIG_MIN_AMOUNT = process.env.REACT_APP_MULTISIG_MIN_AMOUNT || 
 export const MULTISIG_MIN_PROMPT_AMOUNT = process.env.REACT_APP_MULTISIG_MIN_PROMPT_AMOUNT || '200'
 export const LOCKUP_ACCOUNT_ID_SUFFIX = process.env.LOCKUP_ACCOUNT_ID_SUFFIX || 'lockup.near'
 export const MIN_BALANCE_FOR_GAS = process.env.REACT_APP_MIN_BALANCE_FOR_GAS || nearApiJs.utils.format.parseNearAmount('0.1')
-export const ACCESS_KEY_FUNDING_AMOUNT = process.env.REACT_APP_ACCESS_KEY_FUNDING_AMOUNT || nearApiJs.utils.format.parseNearAmount('0.01')
+export const ACCESS_KEY_FUNDING_AMOUNT = process.env.REACT_APP_ACCESS_KEY_FUNDING_AMOUNT || nearApiJs.utils.format.parseNearAmount('0.25')
 export const LINKDROP_GAS = process.env.LINKDROP_GAS || '100000000000000'
 export const ENABLE_FULL_ACCESS_KEYS = process.env.ENABLE_FULL_ACCESS_KEYS === 'yes'
 export const HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL = process.env.HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL


### PR DESCRIPTION
Updated the rewards calc.

Additional:
Access key amount bumped to the default from our ENV vars, 0.1 is too low for staking txs