### PR TITLE
show all validators with active / inactive status

### DIFF
--- a/src/components/staking/components/ValidatorBox.js
+++ b/src/components/staking/components/ValidatorBox.js
@@ -123,7 +123,8 @@ export default function ValidatorBox({
     label = false
 }) {
     const dispatch = useDispatch()
-    const { accountId: validatorId, current, next, fee: { percentage: fee } } = validator
+    const { accountId: validatorId, current, next } = validator
+    const fee = validator.fee && validator.fee.percentage
     const isCurrentOrNext = current || next
     const cta = amount ? <ChevronIcon/> : <FormButton className='gray-blue' linkTo={`/staking/${validator}`}><Translate id='staking.validatorBox.cta' /></FormButton>
     return (

--- a/src/components/staking/components/ValidatorBox.js
+++ b/src/components/staking/components/ValidatorBox.js
@@ -143,9 +143,9 @@ export default function ValidatorBox({
                     <span>
                         {
                         isCurrentOrNext ?
-                        <span class="active">(active)</span>
+                        <span class="active">active</span>
                         :
-                        <span class="inactive">(inactive)</span>
+                        <span class="inactive">inactive</span>
                     }
                     </span>
                 </>}

--- a/src/components/staking/components/ValidatorBox.js
+++ b/src/components/staking/components/ValidatorBox.js
@@ -104,11 +104,18 @@ const Container = styled.div`
         left: 50%;
         transform: translateX(-50%);
     }
+
+    .active {
+        color: #00C08B;
+    }
+
+    .inactive {
+        color: #FF585D;
+    }
 `
 
 export default function ValidatorBox({
     validator,
-    fee,
     amount,
     staking = true,
     clickable = true,
@@ -116,6 +123,8 @@ export default function ValidatorBox({
     label = false
 }) {
     const dispatch = useDispatch()
+    const { accountId: validatorId, current, next, fee: { percentage: fee } } = validator
+    const isCurrentOrNext = current || next
     const cta = amount ? <ChevronIcon/> : <FormButton className='gray-blue' linkTo={`/staking/${validator}`}><Translate id='staking.validatorBox.cta' /></FormButton>
     return (
         <Container 
@@ -126,11 +135,19 @@ export default function ValidatorBox({
         >
             {label && <div className='with'><Translate id='staking.validatorBox.with' /></div>}
             <UserIcon/>
-            <div className='left'>
-                <div>{validator}</div>
-                {fee && 
-                    <div>{fee}% <Translate id='staking.validatorBox.fee' /></div>
-                }
+            <div>
+                <div>{validatorId}</div>
+                {typeof fee === 'number' && <> 
+                    <span>{fee}% <Translate id='staking.validatorBox.fee' /> - </span>
+                    <span>
+                        {
+                        isCurrentOrNext ?
+                        <span class="active">(active)</span>
+                        :
+                        <span class="inactive">(inactive)</span>
+                    }
+                    </span>
+                </>}
             </div>
             {amount &&
                 <div className='right'>

--- a/src/components/staking/components/Validators.js
+++ b/src/components/staking/components/Validators.js
@@ -35,7 +35,7 @@ export default function Validators({ validators, stakeFromAccount }) {
                     <ValidatorBox
                         key={i}
                         validator={validator}
-                />
+                    />
                 )}
             </ListWrapper>
         </>

--- a/src/components/staking/components/Validators.js
+++ b/src/components/staking/components/Validators.js
@@ -4,11 +4,10 @@ import ListWrapper from './ListWrapper'
 import ValidatorBox from './ValidatorBox'
 
 export default function Validators({ validators, stakeFromAccount }) {
-    const currentValidators = validators.filter((v) => v.current || v.next)
 
     const [validator, setValidator] = useState('')
 
-    const validValidator = currentValidators.map(validator => validator.accountId).includes(validator)
+    const validValidator = validators.map(validator => validator.accountId).includes(validator)
 
     return (
         <>
@@ -32,11 +31,10 @@ export default function Validators({ validators, stakeFromAccount }) {
                 <div className='input-validation-label success'><Translate id='staking.validators.search.success' /></div>
             }
             <ListWrapper>
-                {currentValidators.filter(v => v.accountId.includes(validator)).map((validator, i) => 
+                {validators.filter(v => v.accountId.includes(validator)).map((validator, i) => 
                     <ValidatorBox
                         key={i}
-                        validator={validator.accountId}
-                        fee={validator.fee.percentage}
+                        validator={validator}
                 />
                 )}
             </ListWrapper>

--- a/src/utils/staking.js
+++ b/src/utils/staking.js
@@ -284,6 +284,7 @@ export class Staking {
         }
 
         const currentAccount = await this.wallet.getAccount(this.wallet.accountId)
+
         return (await Promise.all(
             accountIds.map(async (account_id) => {
                 try {


### PR DESCRIPTION
bug: the UI was filtering validators out if not current or next status

bug: the UI was filtering out validators with fee: 0

fix: includes all validators in /Validators component list, shows (active) or (inactive) status