### PR TITLE
Add back fallback for missing translations

### DIFF
--- a/src/components/Routing.js
+++ b/src/components/Routing.js
@@ -57,6 +57,8 @@ const theme = {}
 
 const PATH_PREFIX = process.env.PUBLIC_URL
 
+const onMissingTranslation = ({ defaultTranslation }) => defaultTranslation;
+
 const Container = styled.div`
     min-height: 100vh;
     padding-bottom: 200px;
@@ -89,6 +91,7 @@ class Routing extends Component {
             languages,
             options: {
                 defaultLanguage: 'en',
+                onMissingTranslation,
                 renderToStaticMarkup: false,
                 renderInnerHtml: true
             }


### PR DESCRIPTION
@Patrick1904 This is the fix.

`onMissingTranslation` was removed  in https://github.com/near/near-wallet/commit/8581a373f6db9e0dddac1875b7b81aa92ab4fd3d. Maybe ask @icerove before merge?