### PR TITLE
Enable creating account w/ current account

### DIFF
--- a/src/components/accounts/SetupImplicit.js
+++ b/src/components/accounts/SetupImplicit.js
@@ -64,6 +64,12 @@ const StyledContainer = styled(Container)`
         &.green, &.black {
             margin-top: 25px !important;
         }
+
+        &.green {
+            height: auto !important;
+            line-break: anywhere;
+            line-height: normal;
+        }
     }
 `
 
@@ -90,9 +96,9 @@ class SetupImplicit extends Component {
     state = { ...initialState }
 
     handleContinue = async () => {
-        const { dispatch, accountId, implicitAccountId, recoveryMethod } = this.props
+        const { dispatch, newAccountId, implicitAccountId, recoveryMethod } = this.props
         this.setState({ createAccount: true })
-        await dispatch(createAccountFromImplicit(accountId, implicitAccountId, recoveryMethod))
+        await dispatch(createAccountFromImplicit(newAccountId, implicitAccountId, recoveryMethod))
         await dispatch(redirectTo('/fund-create-account/success'))
     }
 
@@ -211,11 +217,11 @@ class SetupImplicit extends Component {
     }
 
     handleFundWithAccount = async () => {
-        const { dispatch, implicitAccountId, accountId, recoveryMethod } = this.props
+        const { dispatch, implicitAccountId, newAccountId, recoveryMethod } = this.props
         this.setState({ createFromAccount: true })
         await dispatch(sendMoney(implicitAccountId, MIN_BALANCE_TO_CREATE.toString()))
-        await dispatch(createAccountFromImplicit(accountId, implicitAccountId, recoveryMethod))
-        await dispatch(redirectTo('/fund-create-account/success'))
+        await dispatch(createAccountFromImplicit(newAccountId, implicitAccountId, recoveryMethod))
+        dispatch(redirectTo('/fund-create-account/success'))
     }
 
     render() {
@@ -229,7 +235,7 @@ class SetupImplicit extends Component {
             createFromAccount
         } = this.state
 
-        const { implicitAccountId, accountId, mainLoader, balance } = this.props
+        const { implicitAccountId, newAccountId, accountId, mainLoader, balance } = this.props
 
         return (
             <Translate>
@@ -270,7 +276,7 @@ class SetupImplicit extends Component {
                                 sendingString='button.fundingNewAccount'
                                 color='green'
                             >
-                                <Translate id='button.fundWithCurrentAccount'/>
+                                <Translate id='button.fundWithCurrentAccount' data={{ accountId: accountId }}/>
                             </FormButton>
                         }
                         {moonpayAvailable &&
@@ -301,7 +307,7 @@ class SetupImplicit extends Component {
                                 checked={checked}
                                 handleCheckboxChange={e => this.setState({ checked: e.target.checked })}
                                 implicitAccountId={implicitAccountId}
-                                accountId={accountId}
+                                accountId={newAccountId}
                                 handleFinishSetup={this.handleContinue}
                                 loading={mainLoader}
                             />
@@ -315,7 +321,7 @@ class SetupImplicit extends Component {
 
 const mapStateToProps = ({ account, status }, { match: { params: { accountId, implicitAccountId, recoveryMethod } } }) => ({
     ...account,
-    accountId,
+    newAccountId: accountId,
     implicitAccountId,
     recoveryMethod,
     mainLoader: status.mainLoader

--- a/src/components/common/AlertBanner.js
+++ b/src/components/common/AlertBanner.js
@@ -76,11 +76,15 @@ export default function AlertBanner({ title, button, linkTo, data, theme }) {
             <AlertRoundedIcon/>
             <div>
                 <Translate id={title} data={{ data: data }}/>
-                {linkTo.includes('http') ? (
-                    <a target='_blank' rel='noreferrer' className='link' href={linkTo}><Translate id={button} /></a>
-                ) : (
-                    <FormButton className='link' linkTo={linkTo}><Translate id={button} /></FormButton>
-                )}
+                {linkTo &&
+                    <>
+                        {linkTo.includes('http') ? (
+                            <a target='_blank' rel='noreferrer' className='link' href={linkTo}><Translate id={button} /></a>
+                        ) : (
+                            <FormButton className='link' linkTo={linkTo}><Translate id={button} /></FormButton>
+                        )}
+                    </>
+                }
             </div>
         </Container>
     )

--- a/src/components/common/Divider.js
+++ b/src/components/common/Divider.js
@@ -7,6 +7,7 @@ const Container = styled.div`
     position: relative;
     width: 100%;
     margin: 10px 0;
+    text-align: center;
 
     &:after {
         content: '';

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -166,6 +166,9 @@
                     "button": "Where can I purchase NEAR?",
                     "title": "Purchase NEAR tokens",
                     "desc": "NEAR tokens are available to purchase through the following exchanges"
+                },
+                "alertBanner": {
+                    "title": "Keep this page open while funding your account. Open a new tab or window to perform any actions outside of this page."
                 }
             },
             "post": {
@@ -454,7 +457,10 @@
         "authorizing": "Authorizing",
         "deAuthorizing": "Deauthorizing",
         "finish": "Finish",
-        "transferring": "Transferring"
+        "transferring": "Transferring",
+        "fundWithCurrentAccount": "Fund with Current Account",
+        "fundingNewAccount": "Funding New Account",
+        "fundWithCard": "Fund with Credit/Debit Card"
     },
 
     "link": {
@@ -996,7 +1002,7 @@
     "total": "total",
     "amount": "amount",
     "or": "OR",
-    "sending": "SENDING",
+    "sending": "Sending",
     "connecting": "Connecting",
     "back": "Back",
     "of": "of",

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -458,7 +458,7 @@
         "deAuthorizing": "Deauthorizing",
         "finish": "Finish",
         "transferring": "Transferring",
-        "fundWithCurrentAccount": "Fund with Current Account",
+        "fundWithCurrentAccount": "Fund with ${accountId}",
         "fundingNewAccount": "Funding New Account",
         "fundWithCard": "Fund with Credit/Debit Card"
     },


### PR DESCRIPTION
Create an account using currently logged in account:
1. First sign in w/ existing account: https://deploy-preview-1424--near-wallet-staging.netlify.app/
2. Navigate to `/create` and start the account creation flow
3. Once you're on the funding page, click the green button that says 'Fund with XXXXXX.near'


![Screen Shot 2021-02-05 at 4 11 38 PM](https://user-images.githubusercontent.com/24921205/107101654-dcc7c100-67cc-11eb-87c8-95d6500c0c2f.png)
