### PR TITLE
Point 'HELP' button to Zendesk page

### DIFF
--- a/src/components/navigation/DesktopContainer.js
+++ b/src/components/navigation/DesktopContainer.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { Translate } from 'react-localize-redux';
 import styled from 'styled-components';
-import helpIcon from '../../images/icon-help.svg';
 import userIcon from '../../images/user-icon-grey.svg';
 import languagesIcon from '../../images/icon-languages.svg';
 import Logo from './Logo';
@@ -36,34 +35,6 @@ const Container = styled.div`
         position: relative;
     }
 `
-
-const Help = styled.a`
-    color: white;
-    display: flex;
-    align-items: center;
-    margin-left: auto;
-    text-transform: uppercase;
-    cursor: pointer;
-    letter-spacing: 2px;
-    padding-top: 2px;
-    
-    &:hover {
-        color: white;
-        text-decoration: none;
-    }
-
-    &:before {
-        content: '';
-        background: url(${helpIcon});
-        background-repeat: no-repeat;
-        display: inline-block;
-        width: 23px;
-        height: 23px;
-        margin-right: 10px;
-        margin-top: -2px;
-    }
-`
-
 const User = styled.div`
     border-left: 2px solid #5d5f60;
     position: relative;
@@ -181,7 +152,7 @@ const UserIcon = styled.div`
 `
 
 const Lang = styled.div`
-    margin-left: 20px;
+    margin-left: auto;
     position: relative;
 
     &:after {
@@ -240,9 +211,6 @@ class DesktopContainer extends Component {
                 {showNavLinks &&
                     <NavLinks />
                 }
-                <Help href='http://near.chat/' target='_blank' rel='noopener noreferrer'>
-                    <Translate id='link.help'/>
-                </Help>
                 <Lang>
                     <LanguageToggle />
                 </Lang>

--- a/src/components/navigation/DesktopContainer.js
+++ b/src/components/navigation/DesktopContainer.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Translate } from 'react-localize-redux';
 import styled from 'styled-components';
+import helpIcon from '../../images/icon-help.svg';
 import userIcon from '../../images/user-icon-grey.svg';
 import languagesIcon from '../../images/icon-languages.svg';
 import Logo from './Logo';
@@ -35,6 +36,32 @@ const Container = styled.div`
         position: relative;
     }
 `
+const Help = styled.a`
+    color: white;
+    display: flex;
+    align-items: center;
+    margin-left: auto;
+    text-transform: uppercase;
+    cursor: pointer;
+    letter-spacing: 2px;
+    padding-top: 2px;
+    
+    &:hover {
+        color: white;
+        text-decoration: none;
+    }
+    &:before {
+        content: '';
+        background: url(${helpIcon});
+        background-repeat: no-repeat;
+        display: inline-block;
+        width: 23px;
+        height: 23px;
+        margin-right: 10px;
+        margin-top: -2px;
+    }
+`
+
 const User = styled.div`
     border-left: 2px solid #5d5f60;
     position: relative;
@@ -152,7 +179,7 @@ const UserIcon = styled.div`
 `
 
 const Lang = styled.div`
-    margin-left: auto;
+    margin-left: 20px;
     position: relative;
 
     &:after {
@@ -211,6 +238,9 @@ class DesktopContainer extends Component {
                 {showNavLinks &&
                     <NavLinks />
                 }
+                <Help href='https://nearhelp.zendesk.com/' target='_blank' rel='noopener noreferrer'>
+                    <Translate id='link.help'/>
+                </Help>
                 <Lang>
                     <LanguageToggle />
                 </Lang>

--- a/src/index.html
+++ b/src/index.html
@@ -25,5 +25,8 @@
             To create a production bundle, use `npm run build` or `yarn build`.
         -->
         <script src="./index.js"></script>
+        <!-- Start Zendesk Widget script -->
+        <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=770e5b96-533a-4b0c-a0f4-519d2f459535"> </script>
+        <!-- End Zendesk Widget script -->
     </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -25,8 +25,5 @@
             To create a production bundle, use `npm run build` or `yarn build`.
         -->
         <script src="./index.js"></script>
-        <!-- Start Zendesk Widget script -->
-        <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=770e5b96-533a-4b0c-a0f4-519d2f459535"> </script>
-        <!-- End Zendesk Widget script -->
     </body>
 </html>


### PR DESCRIPTION
Point 'HELP' button to `https://nearhelp.zendesk.com/` instead of Discord.