### PR TITLE
Fix 2fa check for Profile page refresh

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -398,7 +398,7 @@ export const finishAccountSetup = () => async (dispatch, getState) => {
     await dispatch(getBalance())
     const account = getState().account
     
-    let promptTwoFactor = await TwoFactor.checkCanEnableTwoFactor(account)
+    let promptTwoFactor = await TwoFactor.checkCanEnableTwoFactor(account.balance)
 
     if (new BN(account.balance.available).lt(new BN(utils.format.parseNearAmount(MULTISIG_MIN_PROMPT_AMOUNT)))) {
         promptTwoFactor = false

--- a/src/components/profile/Profile.js
+++ b/src/components/profile/Profile.js
@@ -238,7 +238,7 @@ export function Profile({ match }) {
                             <>
                                 <hr/>
                                 <h2><LockIcon/><Translate id='profile.twoFactor'/></h2>
-                                {!recoveryLoader ? (
+                                {account.canEnableTwoFactor !== null ? (
                                     <>
                                         <div className='sub-heading'><Translate id='profile.twoFactorDesc'/></div>
                                         {/* TODO: Also check recovery methods in DB for Ledger */}
@@ -247,7 +247,7 @@ export function Profile({ match }) {
                                 ) : (
                                     <SkeletonLoading
                                         height='80px'
-                                        show={recoveryLoader}
+                                        show={true}
                                     />
                                 )}
                             </>

--- a/src/components/profile/Profile.js
+++ b/src/components/profile/Profile.js
@@ -142,8 +142,8 @@ export function Profile({ match }) {
                 await dispatch(loadRecoveryMethods())
                 dispatch(getAccessKeys(accountId))
                 dispatch(getLedgerKey())
-                await dispatch(getBalance())
-                dispatch(checkCanEnableTwoFactor(account))
+                const balance = await dispatch(getBalance())
+                dispatch(checkCanEnableTwoFactor(balance))
                 dispatch(getProfileStakingDetails())
             }
         })()

--- a/src/utils/twoFactor.js
+++ b/src/utils/twoFactor.js
@@ -36,8 +36,8 @@ export class TwoFactor extends Account2FA {
         return MULTISIG_CONTRACT_HASHES.includes(state.code_hash)
     }
 
-    static async checkCanEnableTwoFactor(account) {
-        const availableBalance = new BN(account.balance.available)
+    static async checkCanEnableTwoFactor(balance) {
+        const availableBalance = new BN(balance.available)
         const multisigMinAmount = new BN(utils.format.parseNearAmount(MULTISIG_MIN_AMOUNT))
         return multisigMinAmount.lt(availableBalance)
     }


### PR DESCRIPTION
**Current issue:**
Refresh the browser on the `/profile` page and notice that you're not able to enable 2FA - it says not enough funds

**Acceptance criteria:**
You can enable 2FA after refreshing the browser while on the `/profile` page - assuming you have enough funds in 'available balance' and do not have Ledger enabled.

