### PR TITLE
Recover with link: Fix error case

### DIFF
--- a/src/components/accounts/RecoverWithLink.js
+++ b/src/components/accounts/RecoverWithLink.js
@@ -160,7 +160,9 @@ class RecoverWithLink extends Component {
                 this.props.refreshAccount()
                 this.props.redirectTo('/profile')
             },
-            this.setState({ successView: false })
+            () => {
+                this.setState({ successView: false })
+            }
         )
     }
 


### PR DESCRIPTION
The 'link expired' screen was showing while the account was being recovered.