### PR TITLE
Add balance to every account in Switch account section on the top nav (#1496)

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -554,16 +554,16 @@ export const getAvailableAccountsBalance = () => async (dispatch, getState) => {
     for (let i = 0; i < availableAccounts.length; i++) {
         const accountId = availableAccounts[i]
         if (!accountsBalance || !accountsBalance[accountId]) {
-            i < 5 && await dispatch(setAccountBalance(accountId))
+            i < 0 && await dispatch(setAccountBalance(accountId))
         }
     }
 
-    accountsBalance = getState().account.accountsBalance
+    accountsBalance = getState().account.accountsBalance || {}
 
     for (let i = 0; i < Object.keys(accountsBalance).length; i++) {
         const accountId = Object.keys(accountsBalance)[i]
         if (accountsBalance[accountId].loading) {
-            await dispatch(getAccountBalance(accountId, true))
+            await dispatch(getAccountBalance(accountId))
         }
     }
 }

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -546,14 +546,11 @@ export const switchAccount = (accountId) => async (dispatch, getState) => {
 export const getAvailableAccountsBalance = () => async (dispatch, getState) => {
     const { accounts, accountsBalance } = getState().account
 
-
-    Object.keys(accounts)
-        .filter((accountId) => accountId !== wallet.accountId)
-        .forEach(async accountId => {
-            if (!accountsBalance || !accountsBalance[accountId]) {
-                await dispatch(getAccountBalance(accountId))
-            }
-        });
+    for (let i = 0; i < Object.keys(accounts).length; i++) {
+        if (!accountsBalance || !accountsBalance[accountId]) {
+            await dispatch(getAccountBalance(Object.keys(accounts)[i]))
+        }
+    }
 }
 
 export const { selectAccount, refreshAccountOwner, refreshAccountExternal, refreshUrl, updateStakingAccount, updateStakingLockup, getBalance, setLocalStorage, getAccountBalance } = createActions({

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -543,6 +543,19 @@ export const switchAccount = (accountId) => async (dispatch, getState) => {
     dispatch(refreshAccount())
 }
 
+export const getAvailableAccountsBalance = () => async (dispatch, getState) => {
+    const { accounts } = getState().account
+
+
+    Object.keys(accounts)
+        .filter((accountId) => accountId !== wallet.accountId)
+        .forEach(async accountId => {
+            console.log('a1');
+            await dispatch(getAccountBalance(accountId))
+            console.log('a2');
+        });
+}
+
 export const { selectAccount, refreshAccountOwner, refreshAccountExternal, refreshUrl, updateStakingAccount, updateStakingLockup, getBalance, setLocalStorage, getAccountBalance } = createActions({
     SELECT_ACCOUNT: wallet.selectAccount.bind(wallet),
     REFRESH_ACCOUNT_OWNER: [

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -554,7 +554,7 @@ export const getAvailableAccountsBalance = () => async (dispatch, getState) => {
     }
 }
 
-export const { selectAccount, refreshAccountOwner, refreshAccountExternal, refreshUrl, updateStakingAccount, updateStakingLockup, getBalance, setLocalStorage, getAccountBalance } = createActions({
+export const { selectAccount, refreshAccountOwner, refreshAccountExternal, refreshUrl, updateStakingAccount, updateStakingLockup, getBalance, setLocalStorage, getAccountBalance, setAccountBalance } = createActions({
     SELECT_ACCOUNT: wallet.selectAccount.bind(wallet),
     REFRESH_ACCOUNT_OWNER: [
         wallet.refreshAccount.bind(wallet),
@@ -597,5 +597,6 @@ export const { selectAccount, refreshAccountOwner, refreshAccountExternal, refre
                 ignoreMainLoader: true
             }
         })
-    ]
+    ],
+    SET_ACCOUNT_BALANCE: null
 })

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -547,8 +547,9 @@ export const getAvailableAccountsBalance = () => async (dispatch, getState) => {
     const { accounts, accountsBalance } = getState().account
 
     for (let i = 0; i < Object.keys(accounts).length; i++) {
+        const accountId = Object.keys(accounts)[i]
         if (!accountsBalance || !accountsBalance[accountId]) {
-            await dispatch(getAccountBalance(Object.keys(accounts)[i]))
+            await dispatch(getAccountBalance(accountId))
         }
     }
 }

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -590,6 +590,11 @@ export const { selectAccount, refreshAccountOwner, refreshAccountExternal, refre
     SET_LOCAL_STORAGE: null,
     GET_ACCOUNT_BALANCE: [
         wallet.getBalance.bind(wallet),
-        (accountId) => ({ accountId })
+        (accountId) => ({ 
+            accountId,
+            alert: {
+                ignoreMainLoader: true
+            }
+        })
     ]
 })

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -557,7 +557,9 @@ export const getAvailableAccountsBalance = () => async (dispatch, getState) => {
 
     for (let i = 0; i < Object.keys(accountsBalance).length; i++) {
         const accountId = Object.keys(accountsBalance)[i]
-        await dispatch(getAccountBalance(accountId))
+        if (accountsBalance[accountId].loading) {
+            await dispatch(getAccountBalance(accountId))
+        }
     }
 }
 

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -544,10 +544,15 @@ export const switchAccount = (accountId) => async (dispatch, getState) => {
 }
 
 export const getAvailableAccountsBalance = () => async (dispatch, getState) => {
-    let { accounts, accountsBalance } = getState().account
+    let { accountsBalance } = getState().account
+    let { availableAccounts, flowLimitation } = getState()
 
-    for (let i = 0; i < Object.keys(accounts).length; i++) {
-        const accountId = Object.keys(accounts)[i]
+    if (flowLimitation.accountData) {
+        return
+    }
+
+    for (let i = 0; i < availableAccounts.length; i++) {
+        const accountId = availableAccounts[i]
         if (!accountsBalance || !accountsBalance[accountId]) {
             i < 5 && await dispatch(setAccountBalance(accountId))
         }

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -563,7 +563,7 @@ export const getAvailableAccountsBalance = () => async (dispatch, getState) => {
     for (let i = 0; i < Object.keys(accountsBalance).length; i++) {
         const accountId = Object.keys(accountsBalance)[i]
         if (accountsBalance[accountId].loading) {
-            await dispatch(getAccountBalance(accountId))
+            await dispatch(getAccountBalance(accountId, true))
         }
     }
 }

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -544,13 +544,20 @@ export const switchAccount = (accountId) => async (dispatch, getState) => {
 }
 
 export const getAvailableAccountsBalance = () => async (dispatch, getState) => {
-    const { accounts, accountsBalance } = getState().account
+    let { accounts, accountsBalance } = getState().account
 
     for (let i = 0; i < Object.keys(accounts).length; i++) {
         const accountId = Object.keys(accounts)[i]
         if (!accountsBalance || !accountsBalance[accountId]) {
-            await dispatch(getAccountBalance(accountId))
+            i < 5 && await dispatch(setAccountBalance(accountId))
         }
+    }
+
+    accountsBalance = getState().account.accountsBalance
+
+    for (let i = 0; i < Object.keys(accountsBalance).length; i++) {
+        const accountId = Object.keys(accountsBalance)[i]
+        await dispatch(getAccountBalance(accountId))
     }
 }
 

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -544,15 +544,15 @@ export const switchAccount = (accountId) => async (dispatch, getState) => {
 }
 
 export const getAvailableAccountsBalance = () => async (dispatch, getState) => {
-    const { accounts } = getState().account
+    const { accounts, accountsBalance } = getState().account
 
 
     Object.keys(accounts)
         .filter((accountId) => accountId !== wallet.accountId)
         .forEach(async accountId => {
-            console.log('a1');
-            await dispatch(getAccountBalance(accountId))
-            console.log('a2');
+            if (!accountsBalance || !accountsBalance[accountId]) {
+                await dispatch(getAccountBalance(accountId))
+            }
         });
 }
 

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -543,7 +543,7 @@ export const switchAccount = (accountId) => async (dispatch, getState) => {
     dispatch(refreshAccount())
 }
 
-export const { selectAccount, refreshAccountOwner, refreshAccountExternal, refreshUrl, getBalance, setLocalStorage } = createActions({
+export const { selectAccount, refreshAccountOwner, refreshAccountExternal, refreshUrl, updateStakingAccount, updateStakingLockup, getBalance, setLocalStorage, getAccountBalance } = createActions({
     SELECT_ACCOUNT: wallet.selectAccount.bind(wallet),
     REFRESH_ACCOUNT_OWNER: [
         wallet.refreshAccount.bind(wallet),
@@ -562,6 +562,24 @@ export const { selectAccount, refreshAccountOwner, refreshAccountExternal, refre
          })
     ],
     REFRESH_URL: null,
+    UPDATE_STAKING_ACCOUNT: [
+        async (accountId) => await wallet.staking.updateStakingAccount([], [] , accountId),
+        (accountId) => ({
+            accountId,
+            ...showAlert({ onlyError: true })
+        })
+    ],
+    UPDATE_STAKING_LOCKUP: [
+        async (accountId) => await wallet.staking.updateStakingLockup(accountId),
+        (accountId) => ({
+            accountId,
+            ...showAlert({ onlyError: true })
+        })
+    ],
     GET_BALANCE: wallet.getBalance.bind(wallet),
-    SET_LOCAL_STORAGE: null
+    SET_LOCAL_STORAGE: null,
+    GET_ACCOUNT_BALANCE: [
+        wallet.getBalance.bind(wallet),
+        (accountId) => ({ accountId })
+    ]
 })

--- a/src/components/GlobalStyle.js
+++ b/src/components/GlobalStyle.js
@@ -4,7 +4,7 @@ import EmailIconGray from '../images/email-icon-gray.svg'
 import CloseBtn from '../images/close-btn.svg'
 
 export default createGlobalStyle`
-  
+
   * {
         box-sizing: inherit;
     }
@@ -142,7 +142,7 @@ export default createGlobalStyle`
 
     .username-input-icon {
         position: relative;
-      
+
         &:after {
             content: '';
             background: url(${EmailIconGray}) center no-repeat;
@@ -371,7 +371,7 @@ export default createGlobalStyle`
             > h5.item {
                 top: -4px;
             }
-        } 
+        }
     }
 
 
@@ -391,7 +391,7 @@ export default createGlobalStyle`
             font-weight: 100 !important;
         }
     }
-   
+
 
     .transactions-block .item {
         margin-left: 10px !important;
@@ -481,7 +481,7 @@ export default createGlobalStyle`
     .send-theme {
 
         > button {
-            width: 100% !important;
+            width: 100%;
         }
 
         .header-button {

--- a/src/components/common/Balance.js
+++ b/src/components/common/Balance.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { List } from 'semantic-ui-react'
 import { utils } from 'near-api-js'
 import { BN } from 'bn.js'
+import { Translate } from 'react-localize-redux'
 
 const CustomDiv = styled(List)`
     position: relative;
@@ -64,7 +65,7 @@ const Balance = ({ amount, symbol, className }) => {
             {amount && symbol !== false && symbol !== 'near' && <span className='symbol'>Ⓝ</span>}
             {amount
                 ? amountShow
-                : <div className="dots">Retrieving balance</div>
+                : <div className="dots"><Translate id='loadingNoDots'/></div>
             }
             {amount && symbol === 'near' && <span className='currency'>&nbsp;NEAR</span>}
         </CustomDiv>

--- a/src/components/common/Balance.js
+++ b/src/components/common/Balance.js
@@ -24,7 +24,7 @@ const CustomDiv = styled(List)`
         :after {
             content: '.';
             animation: link 1s steps(5, end) infinite;
-        
+
             @keyframes link {
                 0%, 20% {
                     color: rgba(0,0,0,0);
@@ -64,7 +64,7 @@ const Balance = ({ amount, symbol, className }) => {
             {amount && symbol !== false && symbol !== 'near' && <span className='symbol'>Ⓝ</span>}
             {amount
                 ? amountShow
-                : <div className="dots">Loading</div>
+                : <div className="dots">Retrieving balance</div>
             }
             {amount && symbol === 'near' && <span className='currency'>&nbsp;NEAR</span>}
         </CustomDiv>

--- a/src/components/navigation/DesktopContainer.js
+++ b/src/components/navigation/DesktopContainer.js
@@ -93,8 +93,9 @@ class DesktopContainer extends Component {
             availableAccounts,
             selectAccount,
             showNavLinks,
-            flowLimitation
-        } = this.props;
+            flowLimitation,
+            refreshBalance
+        } = this.props
 
         return (
             <Container>
@@ -122,6 +123,7 @@ class DesktopContainer extends Component {
                             selectAccount={selectAccount}
                             accountsBalance={account.accountsBalance}
                             balance={account.balance}
+                            refreshBalance={refreshBalance}
                         />
                     </>
                 }

--- a/src/components/navigation/DesktopContainer.js
+++ b/src/components/navigation/DesktopContainer.js
@@ -120,6 +120,8 @@ class DesktopContainer extends Component {
                             accountIdLocalStorage={account.localStorage?.accountId}
                             accounts={availableAccounts}
                             selectAccount={selectAccount}
+                            accountsBalance={account.accountsBalance}
+                            balance={account.balance}
                         />
                     </>
                 }

--- a/src/components/navigation/DesktopContainer.js
+++ b/src/components/navigation/DesktopContainer.js
@@ -94,7 +94,8 @@ class DesktopContainer extends Component {
             selectAccount,
             showNavLinks,
             flowLimitation,
-            refreshBalance
+            refreshBalance,
+            getBalance
         } = this.props
 
         return (
@@ -124,6 +125,7 @@ class DesktopContainer extends Component {
                             accountsBalance={account.accountsBalance}
                             balance={account.balance}
                             refreshBalance={refreshBalance}
+                            getBalance={getBalance}
                         />
                     </>
                 }

--- a/src/components/navigation/DesktopContainer.js
+++ b/src/components/navigation/DesktopContainer.js
@@ -132,4 +132,4 @@ class DesktopContainer extends Component {
     }
 }
 
-export default DesktopContainer;
+export default DesktopContainer

--- a/src/components/navigation/DesktopMenu.js
+++ b/src/components/navigation/DesktopMenu.js
@@ -53,6 +53,7 @@ const DesktopMenu = ({ show, accountId, accounts, selectAccount, accountIdLocalS
                     selectAccount={selectAccount}
                     accountsBalance={accountsBalance}
                     balance={balance}
+                    refreshBalance={refreshBalance}
                 />
                 <AccessAccountBtn/>
                 <CreateAccountBtn/>

--- a/src/components/navigation/DesktopMenu.js
+++ b/src/components/navigation/DesktopMenu.js
@@ -41,7 +41,6 @@ const Menu = styled.div`
 `
 
 const DesktopMenu = ({ show, accountId, accounts, selectAccount, accountIdLocalStorage, accountsBalance, balance, refreshBalance }) => {
-
     if (show) {
         return (
             <Menu id='desktop-menu'>
@@ -63,4 +62,4 @@ const DesktopMenu = ({ show, accountId, accounts, selectAccount, accountIdLocalS
     return null;
 }
 
-export default DesktopMenu;
+export default DesktopMenu

--- a/src/components/navigation/DesktopMenu.js
+++ b/src/components/navigation/DesktopMenu.js
@@ -25,7 +25,7 @@ const Menu = styled.div`
     }
 `
 
-const DesktopMenu = ({ show, accountId, accounts, selectAccount, accountIdLocalStorage, accountsBalance, balance, refreshBalance }) => {
+const DesktopMenu = ({ show, accountId, accounts, selectAccount, accountIdLocalStorage, accountsBalance, balance, refreshBalance, getBalance }) => {
     if (show) {
         return (
             <Menu id='desktop-menu'>
@@ -38,6 +38,7 @@ const DesktopMenu = ({ show, accountId, accounts, selectAccount, accountIdLocalS
                     accountsBalance={accountsBalance}
                     balance={balance}
                     refreshBalance={refreshBalance}
+                    getBalance={getBalance}
                 />
                 <AccessAccountBtn/>
                 <CreateAccountBtn/>

--- a/src/components/navigation/DesktopMenu.js
+++ b/src/components/navigation/DesktopMenu.js
@@ -7,29 +7,14 @@ import AccessAccountBtn from './AccessAccountBtn';
 
 const Menu = styled.div`
     position: absolute;
-    top: 85px;
-    right: 40px;
-    border-radius: 4px;
+    top: 70px;
+    right: 16px;
+    border-radius: 8px;
     background-color: white;
     color: #4a4f54;
     width: 320px;
-    box-shadow: 0px 3px 9px -1px rgba(0,0,0,0.17);
-    padding: 20px;
-
-    :after {
-        content: '';
-        position: absolute;
-        top: -6px;
-        right: 25px;
-        width: 12px;
-        height: 12px;
-        background-color: white;
-        transform: rotate(-135deg);
-        border: 1px solid #eaeaea73;
-        border-left: 0;
-        border-top: 0;
-
-    }
+    box-shadow: 0px 45px 56px rgba(0, 0, 0, 0.07), 0px 10.0513px 12.5083px rgba(0, 0, 0, 0.0417275), 0px 2.99255px 3.72406px rgba(0, 0, 0, 0.0282725);
+    padding: 16px;
 
     .user-links {
         padding: 20px;

--- a/src/components/navigation/DesktopMenu.js
+++ b/src/components/navigation/DesktopMenu.js
@@ -40,7 +40,7 @@ const Menu = styled.div`
     }
 `
 
-const DesktopMenu = ({ show, accountId, accounts, selectAccount, accountIdLocalStorage }) => {
+const DesktopMenu = ({ show, accountId, accounts, selectAccount, accountIdLocalStorage, accountsBalance, balance, refreshBalance }) => {
 
     if (show) {
         return (
@@ -51,6 +51,8 @@ const DesktopMenu = ({ show, accountId, accounts, selectAccount, accountIdLocalS
                     accountId={accountId}
                     accountIdLocalStorage={accountIdLocalStorage}
                     selectAccount={selectAccount}
+                    accountsBalance={accountsBalance}
+                    balance={balance}
                 />
                 <AccessAccountBtn/>
                 <CreateAccountBtn/>

--- a/src/components/navigation/MobileContainer.js
+++ b/src/components/navigation/MobileContainer.js
@@ -223,4 +223,4 @@ class MobileContainer extends Component {
     }
 }
 
-export default MobileContainer;
+export default MobileContainer

--- a/src/components/navigation/MobileContainer.js
+++ b/src/components/navigation/MobileContainer.js
@@ -171,8 +171,9 @@ class MobileContainer extends Component {
             menuOpen,
             toggleMenu,
             showNavLinks,
-            flowLimitation
-        } = this.props;
+            flowLimitation,
+            refreshBalance
+        } = this.props
 
         return (
             <Container className={menuOpen ? 'show' : ''} id='mobile-menu'>
@@ -208,6 +209,9 @@ class MobileContainer extends Component {
                                 accountId={account.accountId}
                                 accountIdLocalStorage={account.localStorage?.accountId}
                                 selectAccount={selectAccount}
+                                accountsBalance={account.accountsBalance}
+                                balance={account.balance}
+                                refreshBalance={refreshBalance}
                             />
                             <AccessAccountBtn/>
                             <CreateAccountBtn/>

--- a/src/components/navigation/MobileContainer.js
+++ b/src/components/navigation/MobileContainer.js
@@ -172,7 +172,8 @@ class MobileContainer extends Component {
             toggleMenu,
             showNavLinks,
             flowLimitation,
-            refreshBalance
+            refreshBalance,
+            getBalance
         } = this.props
 
         return (
@@ -212,6 +213,7 @@ class MobileContainer extends Component {
                                 accountsBalance={account.accountsBalance}
                                 balance={account.balance}
                                 refreshBalance={refreshBalance}
+                                getBalance={getBalance}
                             />
                             <AccessAccountBtn/>
                             <CreateAccountBtn/>

--- a/src/components/navigation/Navigation.js
+++ b/src/components/navigation/Navigation.js
@@ -54,6 +54,10 @@ class Navigation extends Component {
         const desktopMenu = document.getElementById('desktop-menu');
         const mobileMenu = document.getElementById('mobile-menu');
 
+        if (e.target.tagName === 'SPAN') {
+            return false
+        }
+
         if (e.target.tagName === 'BUTTON' || e.target.tagName === 'A' || (!desktopMenu.contains(e.target) && !mobileMenu.contains(e.target))) {
             this.setState({ menuOpen: false });
         }

--- a/src/components/navigation/Navigation.js
+++ b/src/components/navigation/Navigation.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
-import { switchAccount, getAvailableAccountsBalance, getAccountBalance } from '../../actions/account';
+import { switchAccount, getAvailableAccountsBalance, getAccountBalance, getBalance } from '../../actions/account';
 import { connect } from 'react-redux';
 import DesktopContainer from './DesktopContainer';
 import MobileContainer from './MobileContainer';
@@ -95,6 +95,7 @@ class Navigation extends Component {
                     showNavLinks={this.showNavLinks}
                     flowLimitation={flowLimitation}
                     refreshBalance={this.props.getAccountBalance}
+                    getBalance={this.props.getBalance}
                     {...this.props}
                 />
                 <MobileContainer
@@ -121,7 +122,8 @@ const mapStateToProps = ({ account, availableAccounts, router, flowLimitation })
 const mapDispatchToProps = {
     switchAccount,
     getAvailableAccountsBalance,
-    getAccountBalance
+    getAccountBalance,
+    getBalance
 }
 
 export default connect(

--- a/src/components/navigation/Navigation.js
+++ b/src/components/navigation/Navigation.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
-import { switchAccount } from '../../actions/account';
+import { switchAccount, getAvailableAccountsBalance, getAccountBalance } from '../../actions/account';
 import { connect } from 'react-redux';
 import DesktopContainer from './DesktopContainer';
 import MobileContainer from './MobileContainer';
@@ -114,7 +114,8 @@ const mapStateToProps = ({ account, availableAccounts, router, flowLimitation })
 })
 
 const mapDispatchToProps = {
-    switchAccount
+    switchAccount,
+    getAvailableAccountsBalance,
 }
 
 export default connect(

--- a/src/components/navigation/Navigation.js
+++ b/src/components/navigation/Navigation.js
@@ -65,6 +65,10 @@ class Navigation extends Component {
     }
 
     toggleMenu = () => {
+        if (!this.state.menuOpen) {
+            this.props.getAvailableAccountsBalance()
+        }
+
         this.setState(prevState => ({
             menuOpen: !prevState.menuOpen
         }));

--- a/src/components/navigation/Navigation.js
+++ b/src/components/navigation/Navigation.js
@@ -61,7 +61,6 @@ class Navigation extends Component {
         if (e.target.tagName === 'BUTTON' || e.target.tagName === 'A' || (!desktopMenu.contains(e.target) && !mobileMenu.contains(e.target))) {
             this.setState({ menuOpen: false });
         }
-
     }
 
     get showNavLinks() {

--- a/src/components/navigation/Navigation.js
+++ b/src/components/navigation/Navigation.js
@@ -105,6 +105,7 @@ class Navigation extends Component {
                     showNavLinks={this.showNavLinks}
                     flowLimitation={flowLimitation}
                     refreshBalance={this.props.getAccountBalance}
+                    getBalance={this.props.getBalance}
                     {...this.props}
                 />
             </Container>

--- a/src/components/navigation/Navigation.js
+++ b/src/components/navigation/Navigation.js
@@ -91,6 +91,7 @@ class Navigation extends Component {
                     selectAccount={this.handleSelectAccount}
                     showNavLinks={this.showNavLinks}
                     flowLimitation={flowLimitation}
+                    refreshBalance={this.props.getAccountBalance}
                     {...this.props}
                 />
                 <MobileContainer
@@ -99,6 +100,7 @@ class Navigation extends Component {
                     selectAccount={this.handleSelectAccount}
                     showNavLinks={this.showNavLinks}
                     flowLimitation={flowLimitation}
+                    refreshBalance={this.props.getAccountBalance}
                     {...this.props}
                 />
             </Container>
@@ -116,6 +118,7 @@ const mapStateToProps = ({ account, availableAccounts, router, flowLimitation })
 const mapDispatchToProps = {
     switchAccount,
     getAvailableAccountsBalance,
+    getAccountBalance
 }
 
 export default connect(

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -70,9 +70,10 @@ const Account = styled.div`
         flex: 1;
         flex-direction: column;
         padding: 16px 0 16px 16px;
+        overflow: hidden;
+        margin-right: 5px;
 
         .accountId {
-            max-width: 150px;
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 import Balance from '../common/Balance'
 import SkeletonLoading from '../common/SkeletonLoading';
+import classNames from '../../utils/classNames'
 
 const Wrapper = styled.div`
     .animation-wrapper > .animation {
@@ -66,19 +67,55 @@ const Account = styled.div`
     }
 `
 
-const SyncButton = styled.button`
-  background-color: #f8f8f8;
-  border-radius: 50px;
-  border: 2px solid #f8f8f8;
-  color: #0072ce;
-  font-size: 12px;
-  font-weight: 500;
-  padding: 4px 8px;
+const SyncButton = styled.span`
+    background-color: #f8f8f8;
+    border-radius: 50px;
+    border: 2px solid #f8f8f8;
+    color: #0072ce;
+    font-size: 12px;
+    font-weight: 500;
+    padding: 4px 8px;
 
-  :hover, :active {
+    :hover, :active {
     background-color: #F0F0F1;
     border-color: #F0F0F1;
-  }
+    }
+
+    &.dots {
+        color: #0072ce;
+        margin: 0 12px 0 0;
+        padding: 0 12px 0 6px;
+
+        :after {
+            content: '.';
+            animation: link 1s steps(5, end) infinite;
+
+            @keyframes link {
+                0%, 20% {
+                    color: rgba(0,0,0,0);
+                    text-shadow:
+                        .3em 0 0 rgba(0,0,0,0),
+                        .6em 0 0 rgba(0,0,0,0);
+                }
+                40% {
+                    color: #0072ce;
+                    text-shadow:
+                        .3em 0 0 rgba(0,0,0,0),
+                        .6em 0 0 rgba(0,0,0,0);
+                }
+                60% {
+                    text-shadow:
+                        .3em 0 0 #0072ce,
+                        .6em 0 0 rgba(0,0,0,0);
+                }
+                80%, 100% {
+                    text-shadow:
+                        .3em 0 0 #0072ce,
+                        .6em 0 0 #0072ce;
+                }
+            }
+        }
+    }
 `
 
 const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorage, accountsBalance, balance, refreshBalance }) => (
@@ -103,9 +140,13 @@ const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorag
                         </div>
                     </div>
                     <div>
-                        {accountsBalance && accountsBalance[account]?.available && (
-                            <SyncButton onClick={() => refreshBalance(account)} title='Sync balance'>Sync</SyncButton>
-                        )}
+                        <SyncButton className={classNames([{'dots': !(accountsBalance && accountsBalance[account]?.available)}])} onClick={() => refreshBalance(account)} title='Sync balance'>
+                            {accountsBalance && accountsBalance[account]?.available
+                                ? 'Sync'
+                                : ''
+                            }
+
+                        </SyncButton>
                     </div>
                 </Account>
             )) : <SkeletonLoading

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -28,10 +28,17 @@ const Account = styled.div`
     cursor: pointer;
     font-weight: 500;
     transition: 100ms;
+    position: relative;
 
     @media (min-width: 992px) {
         :hover {
             color: #0072CE;
+
+            &.additional-account {
+                .balance {
+                    color: #0072CE;
+                }
+            }
         }
     }
 
@@ -44,9 +51,31 @@ const Account = styled.div`
         color: black;
     }
 
+    .balance {
+        color: #00C08B;
+        font-weight: 400;
+    }
+
     &.additional-account {
         :last-of-type {
             border-bottom: 0;
+        }
+        z-index: 2000;
+
+        .refresh {
+            position: absolute;
+            width: 20px;
+            height: 100%;
+            top: 0px;
+            right: 0px;
+
+            z-index: 3000;
+            background: red;
+
+            > span {
+                position: relative;
+                top: 36px;
+            }
         }
     }
 `

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -1,7 +1,8 @@
-import React from 'react';
-import styled from 'styled-components';
-import SkeletonLoading from '../common/SkeletonLoading';
+import React from 'react'
+import styled from 'styled-components'
+
 import Balance from '../common/Balance'
+import SkeletonLoading from '../common/SkeletonLoading';
 
 const Wrapper = styled.div`
     .animation-wrapper > .animation {
@@ -115,4 +116,4 @@ const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorag
     </Wrapper>
 )
 
-export default UserAccounts;
+export default UserAccounts

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -10,7 +10,7 @@ const Wrapper = styled.div`
     }
 
     @media (min-width: 992px) {
-        max-height: 200px;
+        max-height: 228px;
         overflow-y: auto;
 
         ::-webkit-scrollbar {

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -63,7 +63,6 @@ const Account = styled.div`
         :last-of-type {
             border-bottom: 0;
         }
-        z-index: 2000;
 
         .refresh {
             position: absolute;
@@ -71,14 +70,8 @@ const Account = styled.div`
             height: 100%;
             top: 0px;
             right: 0px;
-
-            z-index: 3000;
-            background: red;
-
-            > span {
-                position: relative;
-                top: 36px;
-            }
+            background: url(${IconRefresh}) no-repeat center 34px;
+            background-size: 20px auto;
         }
     }
 `

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -32,7 +32,6 @@ const Account = styled.div`
     text-overflow: ellipsis;
     color: #72727A;
     margin-bottom: 4px;
-    padding: 16px;
     cursor: pointer;
     font-weight: 500;
     position: relative;
@@ -70,6 +69,10 @@ const Account = styled.div`
         display: flex;
         flex: 1;
         flex-direction: column;
+        padding: 16px 0 16px 16px;
+    }
+    .sync {
+        padding: 0 16px 0 0;
     }
 
     .balance {
@@ -85,10 +88,11 @@ const SyncButton = styled.span`
     font-size: 12px;
     font-weight: 500;
     padding: 4px 8px;
+    cursor: pointer;
 
     :hover, :active {
-    background-color: #F0F0F1;
-    border-color: #F0F0F1;
+        background-color: #F0F0F1;
+        border-color: #F0F0F1;
     }
 
     &.dots {
@@ -169,7 +173,7 @@ const UserAccount = ({ accountId, balance, balanceLoading, refreshBalance, activ
                 }
             </div>
         </div>
-        <div>
+        <div className='sync'>
             <SyncButton 
                 className={classNames([{'dots': balanceLoading}])}
                 onClick={refreshBalance}

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -70,6 +70,13 @@ const Account = styled.div`
         flex: 1;
         flex-direction: column;
         padding: 16px 0 16px 16px;
+
+        .accountId {
+            max-width: 150px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
     }
     .sync {
         padding: 0 16px 0 0;

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import Balance from '../common/Balance'
 import SkeletonLoading from '../common/SkeletonLoading';
 import classNames from '../../utils/classNames'
+import { Translate } from 'react-localize-redux'
 
 const Wrapper = styled.div`
     .animation-wrapper > .animation {
@@ -142,7 +143,7 @@ const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorag
                     <div>
                         <SyncButton className={classNames([{'dots': !(accountsBalance && accountsBalance[account]?.available)}])} onClick={() => refreshBalance(account)} title='Sync balance'>
                             {accountsBalance && accountsBalance[account]?.available
-                                ? 'Sync'
+                                ? <Translate id='sync'/>
                                 : ''
                             }
 

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -136,7 +136,7 @@ const UserAccounts = ({ accounts, accountId, accountIdLocalStorage, selectAccoun
     <Wrapper>
         <UserAccount
             accountId={accountId || accountIdLocalStorage}
-            balance={actionsPending('GET_BALANCE') ? '' : balance?.available}
+            balance={actionsPending('GET_BALANCE') ? '' : balance?.total}
             balanceLoading={actionsPending('GET_BALANCE')}
             refreshBalance={() => (getBalance(), refreshBalance(accountId))}
             active={true}
@@ -146,7 +146,7 @@ const UserAccounts = ({ accounts, accountId, accountIdLocalStorage, selectAccoun
                 <UserAccount
                     key={i}
                     accountId={account}
-                    balance={accountsBalance && accountsBalance[account]?.available}
+                    balance={accountsBalance && accountsBalance[account]?.total}
                     balanceLoading={accountsBalance && accountsBalance[account]?.loading}
                     refreshBalance={() => refreshBalance(account)}
                     active={false}

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -157,9 +157,9 @@ const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorag
                             onClick={() => refreshBalance(account)} 
                             title='Sync balance'
                         >
-                            {accountsBalance && accountsBalance[account]?.loading
-                                ? ''
-                                : <Translate id='sync'/>
+                            {accountsBalance 
+                                && !accountsBalance[account]?.loading 
+                                && <Translate id='sync'/>
                             }
                         </SyncButton>
                     </div>

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -138,38 +138,36 @@ const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorag
         </Account>
         {accountId
             ? accounts.filter(a => a !== accountId).map((account, i) => (
-                <Account key={`link-${i}`} className='additional-account'>
-                    <div className='account-data' onClick={() => selectAccount(account)}>
-                        <div className='accountId'>
-                            {account}
-                        </div>
-                        <div className='balance'>
-                            {accountsBalance 
-                                && (accountsBalance[account]?.loading || accountsBalance[account]?.available)
-                                    ? <Balance amount={accountsBalance[account]?.available} />
-                                    : <div className='symbol'>Ⓝ</div>
-                            }
-                        </div>
-                    </div>
-                    <div>
-                        <SyncButton 
-                            className={classNames([{'dots': !(accountsBalance && !accountsBalance[account]?.loading)}])} 
-                            onClick={() => refreshBalance(account)} 
-                            title='Sync balance'
-                        >
-                            {accountsBalance 
-                                && !accountsBalance[account]?.loading 
-                                && <Translate id='sync'/>
-                            }
-                        </SyncButton>
-                    </div>
-                </Account>
-            )) : <SkeletonLoading
-                height='55px'
-                show={true}
-            />
-        }
-    </Wrapper>
+
+
+const UserAccount = ({ accountId, balance, balanceLoading, refreshBalance, active, onClick }) => (
+    <Account className={active ? 'active-account' : 'additional-account'}>
+        <div className='account-data' onClick={onClick}>
+            <div className='accountId'>
+                {accountId}
+            </div>
+            <div className='balance'>
+                {!balance && !balanceLoading
+                    ? <div className='symbol'>Ⓝ</div>
+                    : <Balance amount={balance} />
+                }
+            </div>
+        </div>
+        <div>
+            <SyncButton 
+                className={classNames([{'dots': balanceLoading}])}
+                onClick={refreshBalance}
+                title='Sync balance'
+            >
+                {balance
+                    ? <Translate id='sync'/>
+                    : !balanceLoading
+                        ? <Translate id='getBalance'/>
+                        : ''
+                }
+            </SyncButton>
+        </div>
+    </Account>
 )
 
 export default UserAccounts

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -4,6 +4,8 @@ import styled from 'styled-components'
 import Balance from '../common/Balance'
 import SkeletonLoading from '../common/SkeletonLoading';
 
+import IconRefresh from '../../images/icon-nodes.svg'
+
 const Wrapper = styled.div`
     .animation-wrapper > .animation {
         border-radius: 8px;
@@ -102,9 +104,7 @@ const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorag
                     </div>
                     <div>
                         {accountsBalance && accountsBalance[account]?.available && (
-                            <div className='refresh' onClick={() => refreshBalance(account)}>
-                                <span>refresh</span>
-                            </div>
+                            <span className='refresh' onClick={() => refreshBalance(account)} title='Refresh balance' />
                         )}
                     </div>
                 </Account>

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -61,8 +61,15 @@ const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorag
         </Account>
         {accountId
             ? accounts.filter(a => a !== accountId).map((account, i) => (
-                <Account key={`link-${i}`} onClick={() => selectAccount(account)} className='additional-account'>
-                    {account}
+                <Account key={`link-${i}`} className='additional-account'>
+                    <div onClick={() => selectAccount(account)}>
+                        <div>
+                            {account}
+                        </div>
+                        <div className='balance'>
+                            <Balance amount={accountsBalance && accountsBalance[account]?.available} />
+                        </div>
+                    </div>
                 </Account>
             )) : <SkeletonLoading
                 height='55px'

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -4,14 +4,14 @@ import styled from 'styled-components'
 import Balance from '../common/Balance'
 import SkeletonLoading from '../common/SkeletonLoading';
 
-import IconRefresh from '../../images/icon-nodes.svg'
-
 const Wrapper = styled.div`
     .animation-wrapper > .animation {
         border-radius: 8px;
     }
 
     @media (min-width: 992px) {
+        display: flex;
+        flex-direction: column;
         max-height: 228px;
         overflow-y: auto;
 
@@ -22,73 +22,80 @@ const Wrapper = styled.div`
 `
 
 const Account = styled.div`
-    display: block;
-    overflow: hidden;
+    align-items: center;
+    border-radius: 8px;
+    display: flex;
+    justify-content: space-between;
     text-overflow: ellipsis;
     color: #72727A;
-    padding: 18px 14px;
-    border-bottom: 1px solid #efefef;
+    margin-bottom: 4px;
+    padding: 16px;
     cursor: pointer;
     font-weight: 500;
-    transition: 100ms;
     position: relative;
 
     @media (min-width: 992px) {
         :hover {
-            color: #0072CE;
+            background-color: #f8f8f8;
 
-            &.additional-account {
-                .balance {
-                    color: #0072CE;
-                }
-            }
+          .accountId {
+            color: black;
+          }
         }
     }
 
-    :first-of-type {
-        color: white;
-        background-color: #EAF3FE;
-        border-radius: 8px;
-        cursor: default;
-        border: 2px solid #BED0EA;
-        color: black;
+    &.active-account {
+      color: white;
+      background-color: #ECFDF5;
+      border-radius: 8px;
+      cursor: default;
+      color: black;
+
+      .balance {
+        color: #008D6A;
+      }
+    }
+
+    .account-data {
+      display: flex;
+      flex-direction: column;
     }
 
     .balance {
-        color: #00C08B;
-        font-weight: 400;
+      font-weight: 400;
     }
+`
 
-    &.additional-account {
-        :last-of-type {
-            border-bottom: 0;
-        }
+const SyncButton = styled.button`
+  background-color: #f8f8f8;
+  border-radius: 50px;
+  border: 2px solid #f8f8f8;
+  color: #0072ce;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 8px;
 
-        .refresh {
-            position: absolute;
-            width: 20px;
-            height: 100%;
-            top: 0px;
-            right: 0px;
-            background: url(${IconRefresh}) no-repeat center 34px;
-            background-size: 20px auto;
-        }
-    }
+  :hover, :active {
+    background-color: #F0F0F1;
+    border-color: #F0F0F1;
+  }
 `
 
 const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorage, accountsBalance, balance, refreshBalance }) => (
     <Wrapper>
-        <Account>
+        <Account className='active-account'>
+          <div className="account-data">
             {accountId || accountIdLocalStorage}
             <div className='balance'>
                 <Balance amount={balance?.available} />
             </div>
+          </div>
         </Account>
         {accountId
             ? accounts.filter(a => a !== accountId).map((account, i) => (
                 <Account key={`link-${i}`} className='additional-account'>
-                    <div onClick={() => selectAccount(account)}>
-                        <div>
+                    <div className='account-data' onClick={() => selectAccount(account)}>
+                        <div className='accountId'>
                             {account}
                         </div>
                         <div className='balance'>
@@ -97,7 +104,7 @@ const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorag
                     </div>
                     <div>
                         {accountsBalance && accountsBalance[account]?.available && (
-                            <span className='refresh' onClick={() => refreshBalance(account)} title='Refresh balance' />
+                            <SyncButton onClick={() => refreshBalance(account)} title='Sync balance'>Sync</SyncButton>
                         )}
                     </div>
                 </Account>

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -5,6 +5,7 @@ import Balance from '../common/Balance'
 import SkeletonLoading from '../common/SkeletonLoading';
 import classNames from '../../utils/classNames'
 import { Translate } from 'react-localize-redux'
+import { actionsPending } from '../../utils/alerts'
 
 const Wrapper = styled.div`
     .animation-wrapper > .animation {
@@ -126,19 +127,33 @@ const SyncButton = styled.span`
     }
 `
 
-const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorage, accountsBalance, balance, refreshBalance }) => (
+const UserAccounts = ({ accounts, accountId, selectAccount, accountsBalance, balance, refreshBalance, getBalance }) => (
     <Wrapper>
-        <Account className='active-account'>
-          <div className="account-data">
-            {accountId || accountIdLocalStorage}
-            <div className='balance'>
-                <Balance amount={balance?.available} />
-            </div>
-          </div>
-        </Account>
+        <UserAccount
+            accountId={accountId || accountIdLocalStorage}
+            balance={actionsPending('GET_BALANCE') ? '' : balance?.available}
+            balanceLoading={actionsPending('GET_BALANCE')}
+            refreshBalance={() => (getBalance(), refreshBalance(accountId))}
+            active={true}
+        />
         {accountId
             ? accounts.filter(a => a !== accountId).map((account, i) => (
-
+                <UserAccount
+                    key={i}
+                    accountId={account}
+                    balance={accountsBalance && accountsBalance[account]?.available}
+                    balanceLoading={accountsBalance && accountsBalance[account]?.loading}
+                    refreshBalance={() => refreshBalance(account)}
+                    active={false}
+                    onClick={() => selectAccount(account)}
+                />
+            )) : <SkeletonLoading
+                height='55px'
+                show={true}
+            />
+        }
+    </Wrapper>
+)
 
 const UserAccount = ({ accountId, balance, balanceLoading, refreshBalance, active, onClick }) => (
     <Account className={active ? 'active-account' : 'additional-account'}>

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -39,27 +39,27 @@ const Account = styled.div`
         :hover {
             background-color: #f8f8f8;
 
-          .accountId {
+            .accountId {
             color: black;
-          }
+            }
         }
     }
 
     &.active-account {
-      color: white;
-      background-color: #ECFDF5;
-      border-radius: 8px;
-      cursor: default;
-      color: black;
+        color: white;
+        background-color: #ECFDF5;
+        border-radius: 8px;
+        cursor: default;
+        color: black;
 
-      .balance {
+        .balance {
         color: #008D6A;
-      }
+        }
     }
 
     .account-data {
-      display: flex;
-      flex-direction: column;
+        display: flex;
+        flex-direction: column;
     }
 
     .balance {

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -137,7 +137,11 @@ const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorag
                             {account}
                         </div>
                         <div className='balance'>
-                            <Balance amount={accountsBalance && accountsBalance[account]?.available} />
+                            {accountsBalance 
+                                && (accountsBalance[account]?.loading || accountsBalance[account]?.available)
+                                    ? <Balance amount={accountsBalance[account]?.available} />
+                                    : <div className='symbol'>Ⓝ</div>
+                            }
                         </div>
                     </div>
                     <div>

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -51,7 +51,7 @@ const Account = styled.div`
     }
 `
 
-const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorage }) => (
+const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorage, accountsBalance, balance, refreshBalance }) => (
     <Wrapper>
         <Account>
             {accountId || accountIdLocalStorage}
@@ -69,6 +69,13 @@ const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorag
                         <div className='balance'>
                             <Balance amount={accountsBalance && accountsBalance[account]?.available} />
                         </div>
+                    </div>
+                    <div>
+                        {accountsBalance && accountsBalance[account]?.available && (
+                            <div className='refresh' onClick={() => refreshBalance(account)}>
+                                <span>refresh</span>
+                            </div>
+                        )}
                     </div>
                 </Account>
             )) : <SkeletonLoading

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import SkeletonLoading from '../common/SkeletonLoading';
+import Balance from '../common/Balance'
 
 const Wrapper = styled.div`
     .animation-wrapper > .animation {
@@ -54,6 +55,9 @@ const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorag
     <Wrapper>
         <Account>
             {accountId || accountIdLocalStorage}
+            <div className='balance'>
+                <Balance amount={balance?.available} />
+            </div>
         </Account>
         {accountId
             ? accounts.filter(a => a !== accountId).map((account, i) => (

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -132,7 +132,7 @@ const SyncButton = styled.span`
     }
 `
 
-const UserAccounts = ({ accounts, accountId, selectAccount, accountsBalance, balance, refreshBalance, getBalance }) => (
+const UserAccounts = ({ accounts, accountId, accountIdLocalStorage, selectAccount, accountsBalance, balance, refreshBalance, getBalance }) => (
     <Wrapper>
         <UserAccount
             accountId={accountId || accountIdLocalStorage}

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -141,12 +141,15 @@ const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorag
                         </div>
                     </div>
                     <div>
-                        <SyncButton className={classNames([{'dots': !(accountsBalance && accountsBalance[account]?.available)}])} onClick={() => refreshBalance(account)} title='Sync balance'>
-                            {accountsBalance && accountsBalance[account]?.available
-                                ? <Translate id='sync'/>
-                                : ''
+                        <SyncButton 
+                            className={classNames([{'dots': !(accountsBalance && accountsBalance[account]?.available)}])} 
+                            onClick={() => refreshBalance(account)} 
+                            title='Sync balance'
+                        >
+                            {accountsBalance 
+                                && accountsBalance[account]?.available
+                                && <Translate id='sync'/>
                             }
-
                         </SyncButton>
                     </div>
                 </Account>

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -35,6 +35,13 @@ const Account = styled.div`
     cursor: pointer;
     font-weight: 500;
     position: relative;
+    
+    .symbol {
+        transform: scale(0.65);
+        font-weight: 700;
+        margin-left: -2%;
+        float: left;
+    }
 
     @media (min-width: 992px) {
         :hover {

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -49,7 +49,7 @@ const Account = styled.div`
             background-color: #f8f8f8;
 
             .accountId {
-            color: black;
+                color: black;
             }
         }
     }
@@ -62,12 +62,13 @@ const Account = styled.div`
         color: black;
 
         .balance {
-        color: #008D6A;
+            color: #008D6A;
         }
     }
 
     .account-data {
         display: flex;
+        flex: 1;
         flex-direction: column;
     }
 

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -146,13 +146,13 @@ const UserAccounts = ({ accounts, accountId, selectAccount, accountIdLocalStorag
                     </div>
                     <div>
                         <SyncButton 
-                            className={classNames([{'dots': !(accountsBalance && accountsBalance[account]?.available)}])} 
+                            className={classNames([{'dots': !(accountsBalance && !accountsBalance[account]?.loading)}])} 
                             onClick={() => refreshBalance(account)} 
                             title='Sync balance'
                         >
-                            {accountsBalance 
-                                && accountsBalance[account]?.available
-                                && <Translate id='sync'/>
+                            {accountsBalance && accountsBalance[account]?.loading
+                                ? ''
+                                : <Translate id='sync'/>
                             }
                         </SyncButton>
                     </div>

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -169,14 +169,19 @@ const account = handleActions({
                 ...state,
                 accountsBalance: {
                     ...state.accountsBalance,
-                    [meta.accountId]: undefined
+                    [meta.accountId]: {
+                        loading: true
+                    }
                 }
             }
             : {
                 ...state,
                 accountsBalance: {
                     ...state.accountsBalance,
-                    [meta.accountId]: payload
+                    [meta.accountId]: {
+                        ...payload,
+                        loading: false
+                    }
                 }
             },
     [setAccountBalance]: (state, { payload }) => ({

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -14,7 +14,8 @@ import {
     getLedgerKey,
     getBalance,
     selectAccount,
-    setLocalStorage
+    setLocalStorage,
+    getAccountBalance
 } from '../../actions/account'
 
 import { 
@@ -28,7 +29,8 @@ const initialState = {
     actionsPending: [],
     canEnableTwoFactor: null,
     twoFactor: null,
-    ledgerKey: null
+    ledgerKey: null,
+    accountsBalance: undefined
 }
 
 const recoverCodeReducer = handleActions({
@@ -159,7 +161,24 @@ const account = handleActions({
             accountFound: !!payload,
             accountId: payload
         }
-    })
+    }),
+    [getAccountBalance]: (state, { error, payload, ready, meta }) => 
+        (!ready || error)
+            ? {
+                ...state,
+                // accountsBalance: state.accountsBalance || {}
+                accountsBalance: {
+                    ...state.accountsBalance,
+                    [meta.accountId]: undefined
+                }
+            }
+            : ({
+                ...state,
+                accountsBalance: {
+                    ...state.accountsBalance,
+                    [meta.accountId]: payload
+                }
+            }),
 }, initialState)
 
 export default reduceReducers(

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -166,19 +166,18 @@ const account = handleActions({
         (!ready || error)
             ? {
                 ...state,
-                // accountsBalance: state.accountsBalance || {}
                 accountsBalance: {
                     ...state.accountsBalance,
                     [meta.accountId]: undefined
                 }
             }
-            : ({
+            : {
                 ...state,
                 accountsBalance: {
                     ...state.accountsBalance,
                     [meta.accountId]: payload
                 }
-            }),
+            },
 }, initialState)
 
 export default reduceReducers(

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -15,7 +15,8 @@ import {
     getBalance,
     selectAccount,
     setLocalStorage,
-    getAccountBalance
+    getAccountBalance,
+    setAccountBalance
 } from '../../actions/account'
 
 import { 
@@ -178,6 +179,15 @@ const account = handleActions({
                     [meta.accountId]: payload
                 }
             },
+    [setAccountBalance]: (state, { payload }) => ({
+        ...state,
+        accountsBalance: {
+            ...state.accountsBalance,
+            [payload]: {
+                loading: true
+            }
+        }
+    })
 }, initialState)
 
 export default reduceReducers(

--- a/src/reducers/status/index.js
+++ b/src/reducers/status/index.js
@@ -78,7 +78,7 @@ const alertReducer = (state, { error, ready, payload, meta, type }) => {
                             : 'pending'
                     }`
                 }
-                : undefined
+                : state.localAlert
     }
 }
 

--- a/src/reducers/status/index.js
+++ b/src/reducers/status/index.js
@@ -29,13 +29,13 @@ const alertReducer = (state, { error, ready, payload, meta, type }) => {
                     : (ready ? !error : undefined),
                 pending: typeof ready === 'undefined' 
                     ? undefined 
-                    : !ready,
+                    : !meta?.alert?.ignoreMainLoader && !ready,
                 errorType: payload?.type,
                 errorMessage: (error && payload?.toString()) || undefined,
                 data: {
                     ...meta?.data,
                     ...payload
-                } 
+                }
             }
     }
 

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -690,6 +690,7 @@
 
     "loading": "Loading...",
     "loadingNoDots": "Loading",
+    "sync": "Sync",
 
     "balance": {
         "balance": "Total Balance",

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -691,6 +691,7 @@
     "loading": "Loading...",
     "loadingNoDots": "Loading",
     "sync": "Sync",
+    "getBalance": "Get balance",
 
     "balance": {
         "balance": "Total Balance",

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -689,6 +689,7 @@
     },
 
     "loading": "Loading...",
+    "loadingNoDots": "Loading",
 
     "balance": {
         "balance": "Total Balance",


### PR DESCRIPTION
1. Request is starting when the submenu is opened.
2. Balance for accounts is fetched sequentially, to make it a bit lighter.
3. It needed some additional work including `localAlert` mechanism and `mainLoader` - because we rely on `mainLoader` for some local actions, I think that in future works we should avoid using `mainLoader` and instead use `actionsPending` for specific actions. `mainLoader` should be used if we decide to add main loader to Wallet.
4. Also added `Refresh` button for every account balance, it might be handy for users if, for example, you want to check if balance changed without switching account.

Please try to open the submenu, and send money quickly. It works well for 7 accounts or less, but if you have more, you would need to wait longer for the transfer to finish. It might be longer with a slow network.

Not many users have a lot of accounts, but I would suggest adding some improvements in the future, some propositions listed in this comment:
https://github.com/near/near-wallet/pull/1470#issuecomment-785319046