### PR TITLE
Fungible token: link to explorer

### DIFF
--- a/src/components/wallet/TokenBox.js
+++ b/src/components/wallet/TokenBox.js
@@ -76,7 +76,7 @@ const TokenBox = ({ token }) => {
             <div className='desc'>
                 <span>{token.symbol}</span>
                 <span title={token.contract}>
-                    <a href={`${EXPLORER_URL}/${token.contract}`} target='_blank' rel='noopener noreferrer'>
+                    <a href={`${EXPLORER_URL}/accounts/${token.contract}`} target='_blank' rel='noopener noreferrer'>
                         {token.contract}
                     </a>
                 </span>

--- a/src/components/wallet/TokenBox.js
+++ b/src/components/wallet/TokenBox.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import DefaultTokenIcon from '../svg/DefaultTokenIcon'
+import { EXPLORER_URL } from '../../utils/wallet'
 
 const StyledContainer = styled.div`
     display: flex;
@@ -75,7 +76,7 @@ const TokenBox = ({ token }) => {
             <div className='desc'>
                 <span>{token.symbol}</span>
                 <span title={token.contract}>
-                    <a href={`https://explorer.near.org/accounts/${token.contract}`} target='_blank' rel='noopener noreferrer'>
+                    <a href={`${EXPLORER_URL}/${token.contract}`} target='_blank' rel='noopener noreferrer'>
                         {token.contract}
                     </a>
                 </span>

--- a/src/components/wallet/TokenBox.js
+++ b/src/components/wallet/TokenBox.js
@@ -35,12 +35,24 @@ const StyledContainer = styled.div`
             :last-of-type {
                 font-size: 12px;
                 color: #72727A;
-                max-width: 200px;
+                max-width: 350px;
                 overflow: hidden;
                 text-overflow: ellipsis;
 
+                @media (max-width: 991px) {
+                    max-width: 250px;
+                }
+
                 @media (max-width: 500px) {
+                    max-width: 180px;
+                }
+
+                @media (max-width: 330px) {
                     max-width: 150px;
+                }
+
+                a {
+                    color: inherit;
                 }
             }
         }
@@ -62,7 +74,11 @@ const TokenBox = ({ token }) => {
             </div>
             <div className='desc'>
                 <span>{token.symbol}</span>
-                <span title={token.contract}>{token.contract}</span>
+                <span title={token.contract}>
+                    <a href={`https://explorer.near.org/accounts/${token.contract}`} target='_blank' rel='noopener noreferrer'>
+                        {token.contract}
+                    </a>
+                </span>
             </div>
             <div className='balance'>{token.balance}</div>
         </StyledContainer>


### PR DESCRIPTION
Changes:
1. Show as much as possible of the contract/account string before applying ellipsis
2. Make the contract/account clickable -> explorer