### PR TITLE
no undefined meta in callbackUrl

### DIFF
--- a/src/components/sign/Sign.js
+++ b/src/components/sign/Sign.js
@@ -97,7 +97,8 @@ class Sign extends Component {
 function addQueryParams(baseUrl, queryParams) {
     const url = new URL(baseUrl);
     for (let key in queryParams) {
-        url.searchParams.set(key, queryParams[key]);
+        const param = queryParams[key];
+        if(param) url.searchParams.set(key, param);
     }
     return url.toString();
 }


### PR DESCRIPTION
Fixes #1588 

When no `meta` is provided when signing with the wallet, don't add `meta=undefined` as a query param when returning to the application.