### PR TITLE
Add support for redirectUrl on /create route

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -424,8 +424,8 @@ export const finishAccountSetup = () => async (dispatch, getState) => {
     if (promptTwoFactor) {
         dispatch(redirectTo('/enable-two-factor', { globalAlertPreventClear: true }))
     } else {
-        if (url?.redirect_url.includes('/create') && url?.success_url) {
-            window.location = `${url.success_url}?account_id=${accountId}`
+        if (url?.redirectUrl) {
+            window.location = `${url.redirectUrl}?accountId=${accountId}`
         } else {
             dispatch(redirectToApp('/profile'))
         }

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -413,7 +413,7 @@ export const handleCreateAccountWithSeedPhrase = (accountId, recoveryKeyPair, fu
 export const finishAccountSetup = () => async (dispatch, getState) => {
     await dispatch(refreshAccount())
     await dispatch(getBalance())
-    const { balance, url } = getState().account
+    const { balance, url, accountId } = getState().account
     
     let promptTwoFactor = await TwoFactor.checkCanEnableTwoFactor(balance)
 
@@ -425,7 +425,7 @@ export const finishAccountSetup = () => async (dispatch, getState) => {
         dispatch(redirectTo('/enable-two-factor', { globalAlertPreventClear: true }))
     } else {
         if (url.redirect_url.includes('/create')) {
-            window.location = url.success_url
+            window.location = `${url.success_url}?account_id=${accountId}`
         } else {
             dispatch(redirectToApp('/profile'))
         }

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -424,7 +424,7 @@ export const finishAccountSetup = () => async (dispatch, getState) => {
     if (promptTwoFactor) {
         dispatch(redirectTo('/enable-two-factor', { globalAlertPreventClear: true }))
     } else {
-        if (url.redirect_url.includes('/create') && url.success_url) {
+        if (url?.redirect_url.includes('/create') && url?.success_url) {
             window.location = `${url.success_url}?account_id=${accountId}`
         } else {
             dispatch(redirectToApp('/profile'))

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -424,7 +424,7 @@ export const finishAccountSetup = () => async (dispatch, getState) => {
     if (promptTwoFactor) {
         dispatch(redirectTo('/enable-two-factor', { globalAlertPreventClear: true }))
     } else {
-        if (url.redirect_url.includes('/create')) {
+        if (url.redirect_url.includes('/create') && url.success_url) {
             window.location = `${url.success_url}?account_id=${accountId}`
         } else {
             dispatch(redirectToApp('/profile'))

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -79,7 +79,7 @@ export const handleRefreshUrl = (prevRouter) => (dispatch, getState) => {
             ...parse(search),
             redirect_url: prevRouter ? prevRouter.location.pathname : undefined
         }
-        if (['create'].includes(currentPage) && search !== '') {
+        if ([WALLET_CREATE_NEW_ACCOUNT_URL].includes(currentPage) && search !== '') {
             saveState(parsedUrl)
             dispatch(refreshUrl(parsedUrl))
         } else if ([WALLET_LOGIN_URL, WALLET_SIGN_URL].includes(currentPage) && search !== '') {


### PR DESCRIPTION
**Changes:**
1. Add support for optional `redirectUrl`
2. Add `accountId` as url param to `redirectUrl`

**Example:**
`https://wallet.near.org/create?redirectUrl=https://berryclub.io/`

After account creation --> `https://berryclub.io/?accountId=johndoe.near`

**W/ linkdrop example:**
`https://wallet.near.org/create/near/VGmU9e2cEgE8PHysrBdjeJkbzvvFtBYT1UgEmDHTFTp81gnHSdKZCVyVpV5PwjYT6FX7Znd731HCvSpVnJJmgnx?redirectUrl=https://berryclub.io/`

After account creation --> `https://berryclub.io/?accountId=johndoe.near`
