### PR TITLE
Sign transfer: add balance breakdown

### DIFF
--- a/src/components/sign/SignTransferReady.js
+++ b/src/components/sign/SignTransferReady.js
@@ -11,7 +11,7 @@ import Balance from '../common/Balance'
 import Button from '../common/Button'
 import InlineNotification from '../common/InlineNotification'
 import FormButton from '../common/FormButton'
-import Tooltip from '../common/Tooltip'
+import BalanceBreakdown from '../staking/components/BalanceBreakdown'
 
 
 const Container = styled.div`
@@ -21,6 +21,18 @@ const Container = styled.div`
     flex-direction: column;
     align-items: center;
     color: #25282A;
+
+    .balance-breakdown {
+        width: 100%;
+        border: 1px solid #F0F0F1;
+        padding: 0px 15px;
+        border-radius: 8px;
+        margin-top: 30px;
+
+        #balance-breakdown-1 {
+            cursor: pointer;
+        }
+    }
 `
 
 const Title = styled.div`
@@ -42,21 +54,6 @@ const TransferAmount = styled.div`
     div {
         font-size: 26px !important;
         font-weight: 600;
-    }
-`
-
-const CurrentBalance = styled.div`
-    margin-top: 5px;
-    text-align: center;
-    color: #888888;
-    font-size: 14px;
-    font-weight: 400;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    .list {
-        margin: 0 !important;
     }
 `
 
@@ -89,7 +86,7 @@ const ActionsCounter = styled.div`
 
 const Footer = styled.div`
     width: 100%;
-    margin-top: 40px;
+    margin-top: 30px;
 
     @media (max-width: 767px) {
         position: fixed;
@@ -186,11 +183,12 @@ class SignTransferReady extends Component {
                         <TransferAmount>
                             <Balance amount={txTotalAmount}/>
                         </TransferAmount>
-                        <CurrentBalance>
-                            <Translate id='sign.availableBalance' />:&nbsp;
-                            <Balance amount={availableBalance}/>
-                            <Tooltip translate='availableBalanceInfo'/>
-                        </CurrentBalance>
+                        <BalanceBreakdown
+                            total={availableBalance}
+                            availableType='sign.availableToTransfer'
+                            error={insufficientFunds}
+                            transfer={true}
+                        />
                         <InlineNotification
                             show={insufficientFunds}
                             onClick={handleDeny}

--- a/src/components/staking/components/BalanceBreakdown.js
+++ b/src/components/staking/components/BalanceBreakdown.js
@@ -79,7 +79,7 @@ const Container = styled.div`
     }
 `
 
-function BalanceBreakdown({ total, onClickAvailable, availableType, error }) {
+function BalanceBreakdown({ total, onClickAvailable, availableType, error, transfer }) {
     const [open, setOpen] = useState(false)
 
     const subtractAmount = nearApiJs.utils.format.parseNearAmount(WALLET_APP_MIN_AMOUNT)
@@ -90,7 +90,7 @@ function BalanceBreakdown({ total, onClickAvailable, availableType, error }) {
     return (
         <Translate>
             {({ translate }) => (
-                <Container className={classNames([open ? 'open' : '', error ? 'error' : ''])}>
+                <Container className={classNames(['balance-breakdown' , open ? 'open' : '', error ? 'error' : ''])}>
                     <Accordion trigger='balance-breakdown-1'>
                         <div className='item'>
                             <Translate id='balanceBreakdown.available'/>
@@ -106,7 +106,11 @@ function BalanceBreakdown({ total, onClickAvailable, availableType, error }) {
                             </div>
                         </div>
                     </Accordion>
-                    <div className='title'>
+                    <div 
+                        className='title'
+                        id={transfer ? 'balance-breakdown-1' : ''}
+                        onClick={() => transfer ? setOpen(!open) : null}
+                    >
                         <div id='balance-breakdown-1' onClick={() => {setOpen(!open); Mixpanel.track("Watch available to send")}}>
                             <Translate id={availableType}/><ChevronIcon color='#0072ce'/>
                         </div>

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -1043,6 +1043,7 @@
             "deleteAccount": "You are about to delete your account! Your NEAR balance will be destroyed, and all of your account data deleted."
         },
         "insufficientFunds": "Insufficient Funds",
+        "availableToTransfer": "Available to transfer",
         "hereAreSomeDetails": "Here are some details that will help you.",
         "contract": "Contract:",
         "unknownApp": "Unknown App",


### PR DESCRIPTION
**Changes:**
1. on `/sign`: when transfer is requested, show 'Available to transfer' and clickable balance breakdown.

**To test:**
1. Create or recover a testnet account on https://near-wallet-pr-1671.onrender.com 
2. Go to https://near-examples.github.io/guest-book/ and click 'Log in'
3. Edit the login URL by replacing https://wallet.testnet.near.org with https://near-wallet-pr-1671.onrender.com
4. Approve the app login request
5. Now sign a message with a donation
6. Edit the sign URL by replacing https://wallet.testnet.near.org with https://near-wallet-pr-1671.onrender.com
7. Observe the balance dropdown

<img width="661" alt="Screen Shot 2021-04-19 at 2 27 36 PM" src="https://user-images.githubusercontent.com/24921205/115306359-91128b80-a11c-11eb-8d10-9da5bf279333.png">
