### PR TITLE
App login: fix app login when only asking for users Account ID

### DIFF
--- a/src/components/login/Login.js
+++ b/src/components/login/Login.js
@@ -61,7 +61,8 @@ class Login extends Component {
     render() {
         const { account: { url, accountId }, match, appTitle } = this.props
         const accountConfirmationForm = (url.public_key && (!url.contract_id || url.contract_id?.endsWith(`.${LOCKUP_ACCOUNT_ID_SUFFIX}`))) || url.contract_id === accountId
-
+        const requestAccountIdOnly = !url.public_key && !url.contract_id;
+        
         return (
             <LoginContainer>
                 <Route
@@ -79,6 +80,7 @@ class Login extends Component {
                             redirectCreateAccount={this.redirectCreateAccount}
                             handleDetails={this.handleDetails}
                             accountConfirmationForm={accountConfirmationForm}
+                            requestAccountIdOnly={requestAccountIdOnly}
                         />
                     )}
                 />

--- a/src/components/login/LoginForm.js
+++ b/src/components/login/LoginForm.js
@@ -25,7 +25,8 @@ const LoginForm = ({
     redirectCreateAccount,
     buttonLoader,
     match,
-    accountConfirmationForm
+    accountConfirmationForm,
+    requestAccountIdOnly
 }) => (
     <MobileContainer>
         <Grid padded>
@@ -53,8 +54,14 @@ const LoginForm = ({
                     {!accountConfirmationForm && (
                         <Fragment>
                             <div><b>{appTitle || <Translate id='sign.unknownApp' />}</b></div>
-                            <div className='h2'><Translate id='login.form.isRequestingTo' /> </div>
-                            <div className='h2'><Translate id='login.form.accessYourAccount' /></div>
+                            {requestAccountIdOnly ?
+                                <div className='h2'><Translate id='login.form.accountIdOnly' /></div>
+                            :
+                                <>
+                                    <div className='h2'><Translate id='login.form.isRequestingTo' /> </div>
+                                    <div className='h2'><Translate id='login.form.accessYourAccount' /></div>
+                                </>
+                            }
                         </Fragment>
                     )}
                     {accountConfirmationForm && (
@@ -82,23 +89,25 @@ const LoginForm = ({
                     )}
                 </Grid.Column>
             </Grid.Row>
-            <Grid.Row centered>
-                <Grid.Column
-                    largeScreen={12}
-                    computer={14}
-                    tablet={16}
-                    className='cont'
-                    textAlign='center'
-                >
-                    <FormButton
-                        linkTo={`${match.url}${match.url.substr(-1) === '/' ? '' : '/'}details`}
-                        className='more-information'
-                        trackingId="LOGIN Click more information button"
+            {!requestAccountIdOnly &&
+                <Grid.Row centered>
+                    <Grid.Column
+                        largeScreen={12}
+                        computer={14}
+                        tablet={16}
+                        className='cont'
+                        textAlign='center'
                     >
-                        <Translate id='button.moreInformation' />
-                    </FormButton>
-                </Grid.Column>
-            </Grid.Row>
+                        <FormButton
+                            linkTo={`${match.url}${match.url.substr(-1) === '/' ? '' : '/'}details`}
+                            className='more-information'
+                            trackingId="LOGIN Click more information button"
+                        >
+                            <Translate id='button.moreInformation' />
+                        </FormButton>
+                    </Grid.Column>
+                </Grid.Row>
+            }
         </Grid>
         <Grid padded>
             <Grid.Row centered>

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -726,7 +726,8 @@
             "isRequestingFullAccess": "is requesting <b>full access</b>",
             "toYourAccount": "to your account.",
             "thisDoesNotAllow": "This does not allow the app to transfer any tokens.",
-            "thisProvidesAccess": "This provides access to <b>all of your tokens</b>.<br />Proceed with caution!"
+            "thisProvidesAccess": "This provides access to <b>all of your tokens</b>.<br />Proceed with caution!",
+            "accountIdOnly": "is asking for your Account ID."
         },
         "confirm": {
             "pageTitle": "Are you sure?",


### PR DESCRIPTION
When app doesn't provide contract and key:
1. Show '{App} is asking for your Account ID.'
2. Hide 'More information' button

For testing, [app.ref.finance](https://app.ref.finance/) is a good example.