### PR TITLE
Add methodNames to URL for signin

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -160,7 +160,7 @@ export const allowLogin = () => async (dispatch, getState) => {
 
     if (success_url) {
         if (public_key) {
-            await dispatchWithAlert(addAccessKey(account.accountId, url.contract_id, url.public_key), { onlyError: true })
+            await dispatchWithAlert(addAccessKey(account.accountId, url.contract_id, url.public_key, false, url.methodNames), { onlyError: true })
         }
         const availableKeys = await wallet.getAvailableKeys();
         const allKeys = availableKeys.map(key => key.toString());
@@ -172,7 +172,7 @@ export const allowLogin = () => async (dispatch, getState) => {
         parsedUrl.searchParams.set('all_keys', allKeys.join(','))
         window.location = parsedUrl.href
     } else {
-        await dispatchWithAlert(addAccessKey(account.accountId, url.contract_id, url.public_key), { data: { title } })
+        await dispatchWithAlert(addAccessKey(account.accountId, url.contract_id, url.public_key, false, url.methodNames), { data: { title } })
         dispatch(redirectTo('/authorized-apps', { globalAlertPreventClear: true }))
     }
 }


### PR DESCRIPTION
This allows method names to be passed via the URL to restrict an access keys usage to a subset of methods on a smart contract.

Associated `near-api-js` PR: https://github.com/near/near-api-js/pull/578