### PR TITLE
1659 - Only redirect to `/recover-seed-phrase` if NEAR account was successfully created

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -414,11 +414,15 @@ export const handleCreateAccountWithSeedPhrase = (accountId, recoveryKeyPair, fu
     try {
         await dispatch(createAccountWithSeedPhrase(accountId, recoveryKeyPair, fundingOptions))
     } catch (error) {
-        dispatch(redirectTo('/recover-seed-phrase', { 
-            globalAlertPreventClear: true,
-            defaultAccountId: accountId
-        }))
-        return
+        if(await wallet.accountExists(accountId)) {
+            // Requests sometimes fail after creating the NEAR account for another reason (transport error?)
+            // If that happened, we allow the user can add the NEAR account to the wallet by entering the seed phrase
+            dispatch(redirectTo('/recover-seed-phrase', {
+                globalAlertPreventClear: true,
+                defaultAccountId: accountId
+            }))
+            return
+        }
     }
 }
 


### PR DESCRIPTION
Important since `createAccountFunded` contract helper route will throw errors for reCaptcha related errors before the NEAR account has been created.

Prior to this change, no matter what caused an error to be thrown from the `createAccount()` call, we assumed that it was after the NEAR account was created and that it would be sane to redirect the user to the `recovery-seed-phrase` route to let them import the account to the wallet.

Without it, errored responses from the createFundedAccount contract-helper involving reCaptcha would be a fatal onboarding error requiring the user restart the create account process from the beginning.