### PR TITLE
Add Mixpanel events for funded account flow

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -221,7 +221,6 @@ export const {
     getLedgerKey,
     getLedgerPublicKey,
     setupRecoveryMessage,
-    setupRecoveryMessageNewAccount,
     deleteRecoveryMethod,
     checkNearDropBalance,
     claimLinkdropToAccount,
@@ -301,7 +300,6 @@ export const {
         wallet.setupRecoveryMessage.bind(wallet),
         () => showAlert()
     ],
-    SETUP_RECOVERY_MESSAGE_NEW_ACCOUNT: wallet.setupRecoveryMessageNewAccount.bind(wallet),
     DELETE_RECOVERY_METHOD: [
         wallet.deleteRecoveryMethod.bind(wallet),
         () => showAlert()

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -227,6 +227,7 @@ export const {
     checkIsNew,
     checkNewAccount,
     createNewAccount,
+    saveAccount,
     checkAccountAvailable,
     clearCode
 } = createActions({
@@ -321,6 +322,7 @@ export const {
         () => showAlert({ localAlert: true })
     ],
     CREATE_NEW_ACCOUNT: wallet.createNewAccount.bind(wallet),
+    SAVE_ACCOUNT: wallet.saveAccount.bind(wallet),
     CHECK_ACCOUNT_AVAILABLE: [
         wallet.checkAccountAvailable.bind(wallet),
         () => showAlert({ localAlert: true })
@@ -527,7 +529,7 @@ export const refreshAccount = (basicData = false) => async (dispatch, getState) 
     if (!wallet.accountId) {
         return
     }
-    
+
     dispatch(setLocalStorage(wallet.accountId))
     await dispatch(refreshAccountOwner(flowLimitation.accountData))
 

--- a/src/components/Recaptcha.js
+++ b/src/components/Recaptcha.js
@@ -176,7 +176,7 @@ export class Recaptcha extends Component {
                     ref={(ref) => this.setCaptchaRef(ref)}
                     onChange={this.handleOnChange}
                     asyncScriptOnLoad={this.handleOnLoad}
-                    class='recaptcha-widget'
+                    className='recaptcha-widget'
                 />}
                 {loaded &&
                     <RecaptchaString className='recaptcha-disclaimer'>

--- a/src/components/Recaptcha.js
+++ b/src/components/Recaptcha.js
@@ -1,9 +1,11 @@
 import React, { Component } from 'react'
 import styled from 'styled-components'
 import ReCAPTCHA from 'react-google-recaptcha';
+import { Translate } from 'react-localize-redux';
+
 import PuzzleIcon from './svg/PuzzleIcon';
 import FormButton from './common/FormButton';
-import { Translate } from 'react-localize-redux';
+import { Mixpanel } from '../mixpanel/index'
 
 const RECAPTCHA_CHALLENGE_API_KEY = process.env.RECAPTCHA_CHALLENGE_API_KEY;
 
@@ -106,6 +108,11 @@ export class Recaptcha extends Component {
      */
     handleOnChange = (token) => {
         debugLog('onchange()', token);
+
+        if (token) {
+            Mixpanel.track('solved reCaptcha');
+        }
+
         this.props.onChange && this.props.onChange(token);
     }
 
@@ -115,11 +122,15 @@ export class Recaptcha extends Component {
         this.clearLoadingTimeout();
 
         if (scriptDetails.errored === true) {
+            Mixpanel.track('failed to load reCaptcha script');
+
             this.setState({ loaded: false, loadFailed: true });
             this.props.onLoadFailed && this.props.onLoadFailed();
         } else {
+            Mixpanel.track('loaded reCaptcha script');
             this.setState({ loaded: true });
         }
+
     }
 
     reset() {
@@ -138,7 +149,15 @@ export class Recaptcha extends Component {
                     <PuzzleIcon/>
                     <div className='title'><Translate id='reCAPTCHA.fail.title'/></div>
                     <div className='desc'><Translate id='reCAPTCHA.fail.desc'/></div>
-                    <FormButton color='link' onClick={this.props.onFundAccountCreation}><Translate id='reCAPTCHA.fail.link'/></FormButton>
+                    <FormButton
+                        color='link'
+                        onClick={() => {
+                            Mixpanel.track('CA used reCaptcha escape hatch');
+                            this.props.onFundAccountCreation();
+                        }}
+                    >
+                        <Translate id='reCAPTCHA.fail.link'/>
+                    </FormButton>
                 </RecaptchaFailedBox>
             )
         }

--- a/src/components/accounts/SetupSeedPhrase.js
+++ b/src/components/accounts/SetupSeedPhrase.js
@@ -146,6 +146,7 @@ class SetupSeedPhrase extends Component {
                 this.setState({ submitting: false });
                 
                 if (isRetryableRecaptchaError(err)) {
+                    Mixpanel.track('Funded account creation failed due to invalid / expired reCaptcha response from user');
                     this.recaptchaRef.reset();
                     showCustomAlert({
                         success: false,

--- a/src/components/accounts/SetupSeedPhrase.js
+++ b/src/components/accounts/SetupSeedPhrase.js
@@ -153,6 +153,7 @@ class SetupSeedPhrase extends Component {
                         messageCode: 'walletErrorCodes.invalidRecaptchaCode'
                     })
                 } else if(err.code === 'NotEnoughBalance') {
+                    Mixpanel.track('SR-SP NotEnoughBalance creating funded account');
                     await fundCreateAccount(accountId, recoveryKeyPair, 'seed');
                 } else {
                     showCustomAlert({

--- a/src/components/accounts/ledger/SetupLedger.js
+++ b/src/components/accounts/ledger/SetupLedger.js
@@ -112,6 +112,7 @@ const SetupLedger = (props) => {
                         Mixpanel.track("SR-Ledger Create new account ledger")
                     } catch(err) {
                         if (isRetryableRecaptchaError(err)) {
+                            Mixpanel.track('Funded account creation failed due to invalid / expired reCaptcha response from user');
                             recaptchaRef.current.reset();
 
                             dispatch(showCustomAlert({

--- a/src/components/accounts/ledger/SetupLedger.js
+++ b/src/components/accounts/ledger/SetupLedger.js
@@ -120,6 +120,7 @@ const SetupLedger = (props) => {
                                 messageCode: 'walletErrorCodes.invalidRecaptchaCode'
                             }))
                         } else if(err.code === 'NotEnoughBalance') {
+                            Mixpanel.track('SR-Ledger NotEnoughBalance creating funded account');
                             dispatch(fundCreateAccountLedger(accountId, publicKey))
                         } else {
                             recaptchaRef.current.reset();

--- a/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
+++ b/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
@@ -17,6 +17,7 @@ import {
     get2faMethod,
     checkIsNew,
     createNewAccount,
+    saveAccount,
     fundCreateAccount,
     validateSecurityCode
 } from '../../../actions/account';
@@ -31,7 +32,7 @@ import { showCustomAlert } from '../../../actions/status';
 import { isRetryableRecaptchaError } from '../../Recaptcha';
 import { parseSeedPhrase } from 'near-seed-phrase';
 import { KeyPair } from 'near-api-js';
-import { DISABLE_CREATE_ACCOUNT, wallet } from '../../../utils/wallet';
+import { DISABLE_CREATE_ACCOUNT } from '../../../utils/wallet';
 
 // FIXME: Use `debug` npm package so we can keep some debug logging around but not spam the console everywhere
 const ENABLE_DEBUG_LOGGING = false;
@@ -159,12 +160,17 @@ class SetupRecoveryMethod extends Component {
     }
 
     async setupRecoveryMessageNewAccount(accountId, method, securityCode, fundingOptions, recoverySeedPhrase, recaptchaToken) {
-        const { fundCreateAccount, createNewAccount, validateSecurityCode } = this.props;
+        const {
+            fundCreateAccount,
+            createNewAccount,
+            validateSecurityCode,
+            saveAccount
+        } = this.props;
 
         const { secretKey } = parseSeedPhrase(recoverySeedPhrase)
         const recoveryKeyPair = KeyPair.fromString(secretKey)
         await validateSecurityCode(accountId, method, securityCode);
-        await wallet.saveAccount(accountId, recoveryKeyPair);
+        await saveAccount(accountId, recoveryKeyPair);
 
         // IMPLICIT ACCOUNT
         if (DISABLE_CREATE_ACCOUNT && !fundingOptions && !recaptchaToken) {
@@ -400,6 +406,7 @@ const mapDispatchToProps = {
     showCustomAlert,
     fundCreateAccount,
     createNewAccount,
+    saveAccount,
     validateSecurityCode
 }
 

--- a/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
+++ b/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
@@ -218,6 +218,7 @@ class SetupRecoveryMethod extends Component {
                                 messageCode: 'walletErrorCodes.setupRecoveryMessageNewAccount.invalidCode'
                             })
                         } else if (isRetryableRecaptchaError(e)) {
+                            Mixpanel.track('Funded account creation failed due to invalid / expired reCaptcha response from user');
                             showCustomAlert({
                                 success: false,
                                 messageCodeHeader: 'error',


### PR DESCRIPTION
Closes #1779

Adds new Mixpanel events throughout the funded account flow
See #1779 for the things we can now track via Mixpanel events.

Note: I moved `setupRecoveryMessageNewAccount()` out of `wallet.js` because I wanted to add Mixpanel tracking to this logic, but didn't want to leak Mixpanel awareness into the code in `wallet.js`.  It also was a bit of a mis-fit for `wallet.js` because it was one of the few places there that used our `store.dispatch()` method directly to dispatch a bunch of sub-actions.  Incidentally, this had caused me to add handling of `NotEnoughBalance` errors during account creation inside `wallet.js` _only for this one case_ where the other account creation flows had the logic in the UI components -- so by moving this code out of the actions, we avoided adding Mixpanel to wallet.js and eliminated some coupling to `dispatch()` that made it awkward to handle error cases consistently across the UI components. 🎉  :)