### PR TITLE
Don't use --https by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "predeploy": "yarn build",
     "update:static": "cp src/wasm/multisig.wasm dist/multisig.wasm && cp src/wasm/main.wasm dist/main.wasm",
-    "start": "yarn update:static; parcel src/index.html --https",
+    "start": "yarn update:static; parcel src/index.html",
     "prebuild": "rm -rf dist/",
     "build": "parcel build src/index.html && node scripts/sentry-send-release.js && yarn update:static",
     "test": "jest",


### PR DESCRIPTION
It gets in a way every time server is restarted and only required for limited set of features.
It is possible to use `yarn start --https` to enable HTTPS on demand when needed.