### PR TITLE
Add linkdrop redirect for existing users

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -313,7 +313,10 @@ export const {
         () => ({})
     ],
     CLAIM_LINKDROP_TO_ACCOUNT: [
-        wallet.claimLinkdropToAccount.bind(wallet),
+        async (fundingContract, fundingKey, accountId, url) => {
+            await wallet.claimLinkdropToAccount(fundingContract, fundingKey)
+            finishLinkdropClaim(accountId, url)
+        },
         () => showAlert({ onlyError: true })
     ],
     CHECK_IS_NEW: [
@@ -459,8 +462,7 @@ export const finishAccountSetup = () => async (dispatch, getState) => {
     }
 }
 
-export const finishLinkdropClaim = () => async (dispatch, getState) => {
-    const { balance, url, accountId } = getState().account
+const finishLinkdropClaim = (accountId, url) => {
     if (url?.redirectUrl) {
         window.location = `${url.redirectUrl}?accountId=${accountId}`
     }

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -459,6 +459,13 @@ export const finishAccountSetup = () => async (dispatch, getState) => {
     }
 }
 
+export const finishLinkdropClaim = () => async (dispatch, getState) => {
+    const { balance, url, accountId } = getState().account
+    if (url?.redirectUrl) {
+        window.location = `${url.redirectUrl}?accountId=${accountId}`
+    }
+}
+
 export const createAccountFromImplicit = createAction('CREATE_ACCOUNT_FROM_IMPLICIT', async (accountId, implicitAccountId, recoveryMethod) => {
     const recoveryKeyPair = await wallet.keyStore.getKey(wallet.connection.networkId, implicitAccountId)
     if (recoveryKeyPair) {

--- a/src/components/accounts/LinkdropLanding.js
+++ b/src/components/accounts/LinkdropLanding.js
@@ -88,8 +88,8 @@ class LinkdropLanding extends Component {
     }
 
     handleClaimNearDrop = async () => {
-        const { fundingContract, fundingKey, redirectTo, claimLinkdropToAccount } = this.props
-        await claimLinkdropToAccount(fundingContract, fundingKey)
+        const { fundingContract, fundingKey, redirectTo, claimLinkdropToAccount, accountId, url } = this.props
+        await claimLinkdropToAccount(fundingContract, fundingKey, accountId, url)
         localStorage.setItem('linkdropAmount', this.state.balance)
         redirectTo('/')
     }

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -18,7 +18,6 @@ import {
     redirectTo,
     fundCreateAccount,
     finishAccountSetup,
-    finishLinkdropClaim,
     selectAccount
 } from '../actions/account'
 
@@ -439,8 +438,6 @@ class Wallet {
         });
 
         await contract.claim({ account_id: accountId }, LINKDROP_GAS);
-
-        await store.dispatch(finishLinkdropClaim());
     }
 
     async saveAccount(accountId, keyPair) {

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -18,6 +18,7 @@ import {
     redirectTo,
     fundCreateAccount,
     finishAccountSetup,
+    finishLinkdropClaim,
     selectAccount
 } from '../actions/account'
 
@@ -438,6 +439,8 @@ class Wallet {
         });
 
         await contract.claim({ account_id: accountId }, LINKDROP_GAS);
+
+        await store.dispatch(finishLinkdropClaim());
     }
 
     async saveAccount(accountId, keyPair) {


### PR DESCRIPTION
### Description

Resolves: #1827

Similar to #1641 which is designed specific for new users, add url redirect support after an existing user claimed the linkdroip. 