### PR TITLE
TX sign: disable 'Allow' button only if confirmed insufficient funds

### DIFF
--- a/src/components/sign/SignTransferReady.js
+++ b/src/components/sign/SignTransferReady.js
@@ -227,7 +227,7 @@ class SignTransferReady extends Component {
                         </Button>
                         <FormButton
                             onClick={handleAllow}
-                            disabled={isMonetaryTransaction && insufficientFunds || !availableBalance}
+                            disabled={insufficientFunds}
                             sending={sending}
                             sendingString='button.authorizing'
                         >


### PR DESCRIPTION
Changes:
1. On the `/sign` route: Only disable the 'Allow' button once the account balance has finished loading and `insufficientFunds` is confirmed in order to speed up the UX when the user first lands on the page.
2. Also removing the `isMonetaryTransaction` flag as it's being determined while setting `insufficientFunds` anyway.