### PR TITLE
Stop dependabot from spamming PRs about minor changes to our dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,5 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: "@storybook/addon-essentials"
-  - dependency-name: "@storybook/addon-links"
-  - dependency-name: "@storybook/addon-actions"
-  - dependency-name: "@storybook/react"
-  - dependency-name: react-phone-number-input
-    versions:
-    - 3.x
+  open-pull-requests-limit: 0
+  target-branch: "dump"


### PR DESCRIPTION
Disables automatic creation of non-security related package version update PRs 
**- Security vulnerabilities will still result in PRs being created.**
- This is ensured by updating the dependabot.yml NPM configuration to target the `dump` branch.  Per this documentation, this ensures that the overridden configuration of 0 PRs max will not change the defaults that the security updates use: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/customizing-dependency-updates#impact-of-configuration-changes-on-security-updates

- Currently, since dependabot creates PRs for stuff like patch releases of our dependencies, we see a constant stream of PRs opened for our dependent packages (10 at a time by our existing configuration) which amounts to noise in our PRs list for things that are not urgent or even necessary in many cases for us to merge.
- Merging dependency updates requires careful review of the changes in a dependent package to ensure we really want that update to be merged immediately.
- Merging brand new updates increases the likelihood that we will be impacted by a supply chain attack where one of our dependencies may be compromised by an attacker; ideally, we want to let new publishes to NPM simmer for some time before we adopt them unless they are critical security fixes.
