### PR TITLE
Fix linkdrop redirect after recover account

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -330,10 +330,7 @@ export const {
         () => ({})
     ],
     CLAIM_LINKDROP_TO_ACCOUNT: [
-        async (fundingContract, fundingKey, accountId, url) => {
-            await wallet.claimLinkdropToAccount(fundingContract, fundingKey);
-            finishLinkdropClaim(accountId, url);
-        },
+        wallet.claimLinkdropToAccount.bind(wallet),
         () => showAlert({ onlyError: true })
     ],
     CHECK_IS_NEW: [
@@ -476,12 +473,6 @@ export const finishAccountSetup = () => async (dispatch, getState) => {
         } else {
             dispatch(redirectToApp('/'));
         }
-    }
-};
-
-const finishLinkdropClaim = (accountId, url) => {
-    if (url?.redirectUrl) {
-        window.location = `${url.redirectUrl}?accountId=${accountId}`;
     }
 };
 

--- a/src/components/accounts/CreateAccount.js
+++ b/src/components/accounts/CreateAccount.js
@@ -121,7 +121,7 @@ class CreateAccount extends Component {
             if (params.get('redirect') === 'false') {
                 this.handleCheckNearDropBalance();
             } else {
-                const redirectUrl = params.has('redirectUrl') ? `?redirectUrl=${params.get('redirectUrl')}` : '';
+                const redirectUrl = params.has('redirectUrl') ? `?redirectUrl=${encodeURIComponent(params.get('redirectUrl'))}` : '';
                 redirectTo(`/linkdrop/${fundingContract}/${fundingKey}${redirectUrl}`);
             }
         }

--- a/src/components/accounts/LinkdropLanding.js
+++ b/src/components/accounts/LinkdropLanding.js
@@ -3,7 +3,7 @@ import { Translate } from 'react-localize-redux';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 
-import { checkNearDropBalance, claimLinkdropToAccount, redirectTo } from '../../actions/account';
+import { checkNearDropBalance, claimLinkdropToAccount, redirectTo, handleRefreshUrl } from '../../actions/account';
 import { clearLocalAlert } from '../../actions/status';
 import { Mixpanel } from '../../mixpanel/index';
 import { actionsPending } from '../../utils/alerts';
@@ -71,9 +71,10 @@ class LinkdropLanding extends Component {
     }
 
     componentDidMount() {
-        const { fundingContract, fundingKey } = this.props;
+        const { fundingContract, fundingKey, handleRefreshUrl } = this.props;
         if (fundingContract && fundingKey) {
             this.handleCheckNearDropBalance();
+            handleRefreshUrl();
         }
     }
 
@@ -96,12 +97,15 @@ class LinkdropLanding extends Component {
     }
 
     render() {
-        const { fundingContract, fundingKey, accountId, mainLoader } = this.props;
+        const { fundingContract, fundingKey, accountId, mainLoader, history } = this.props;
         const { balance, invalidNearDrop } = this.state;
         const claimingDrop = actionsPending('CLAIM_LINKDROP_TO_ACCOUNT');
         const fundingAmount = balance;
 
         if (!invalidNearDrop) {
+            const params = new URLSearchParams(history.location.search);
+            const redirectUrl = params.has('redirectUrl') ? `&redirectUrl=${params.get('redirectUrl')}` : '';
+
             return (
                 <StyledContainer className='xs-centered'>
                     <NearGiftIcons/>
@@ -124,7 +128,7 @@ class LinkdropLanding extends Component {
                         </FormButton>
                         :
                         <FormButton
-                            linkTo={`/recover-account?fundingOptions=${encodeURIComponent(JSON.stringify({ fundingContract, fundingKey, fundingAmount }))}`}
+                            linkTo={`/recover-account?fundingOptions=${encodeURIComponent(JSON.stringify({ fundingContract, fundingKey, fundingAmount }))}${redirectUrl}`}
                         >
                             <Translate id='linkdropLanding.ctaLogin'/>
                         </FormButton>
@@ -152,7 +156,8 @@ const mapDispatchToProps = {
     clearLocalAlert,
     checkNearDropBalance,
     claimLinkdropToAccount,
-    redirectTo
+    redirectTo,
+    handleRefreshUrl
 };
 
 const mapStateToProps = ({ account, status }, { match }) => ({

--- a/src/components/accounts/LinkdropLanding.js
+++ b/src/components/accounts/LinkdropLanding.js
@@ -91,9 +91,13 @@ class LinkdropLanding extends Component {
 
     handleClaimNearDrop = async () => {
         const { fundingContract, fundingKey, redirectTo, claimLinkdropToAccount, accountId, url } = this.props;
-        await claimLinkdropToAccount(fundingContract, fundingKey, accountId, url);
+        await claimLinkdropToAccount(fundingContract, fundingKey);
         localStorage.setItem('linkdropAmount', this.state.balance);
-        redirectTo('/');
+        if (url?.redirectUrl) {
+            window.location = `${url.redirectUrl}?accountId=${accountId}`;
+        } else {
+            redirectTo('/');
+        }
     }
 
     render() {

--- a/src/components/accounts/LinkdropLanding.js
+++ b/src/components/accounts/LinkdropLanding.js
@@ -108,7 +108,7 @@ class LinkdropLanding extends Component {
 
         if (!invalidNearDrop) {
             const params = new URLSearchParams(history.location.search);
-            const redirectUrl = params.has('redirectUrl') ? `&redirectUrl=${params.get('redirectUrl')}` : '';
+            const redirectUrl = params.has('redirectUrl') ? `&redirectUrl=${encodeURIComponent(params.get('redirectUrl'))}` : '';
 
             return (
                 <StyledContainer className='xs-centered'>

--- a/src/components/accounts/RecoverAccountSeedPhrase.js
+++ b/src/components/accounts/RecoverAccountSeedPhrase.js
@@ -1,3 +1,4 @@
+import { parse as parseQuery } from 'query-string';
 import React, { Component } from 'react';
 import { Translate } from 'react-localize-redux';
 import { connect } from 'react-redux';
@@ -70,9 +71,12 @@ class RecoverAccountSeedPhrase extends Component {
                 await this.props.refreshAccount();
             }
         );
+
+        const query = parseQuery(this.props.location.search);
         const options = parseFundingOptions(this.props.location.search);
         if (options) {
-            this.props.redirectTo(`/linkdrop/${options.fundingContract}/${options.fundingKey}`);
+            const redirectUrl = query.redirectUrl ? `?redirectUrl=${query.redirectUrl}` : '';
+            this.props.redirectTo(`/linkdrop/${options.fundingContract}/${options.fundingKey}${redirectUrl}`);
         } else {
             this.props.redirectToApp('/');
         }

--- a/src/components/accounts/RecoverAccountSeedPhrase.js
+++ b/src/components/accounts/RecoverAccountSeedPhrase.js
@@ -75,7 +75,7 @@ class RecoverAccountSeedPhrase extends Component {
         const query = parseQuery(this.props.location.search);
         const options = parseFundingOptions(this.props.location.search);
         if (options) {
-            const redirectUrl = query.redirectUrl ? `?redirectUrl=${query.redirectUrl}` : '';
+            const redirectUrl = query.redirectUrl ? `?redirectUrl=${encodeURIComponent(query.redirectUrl)}` : '';
             this.props.redirectTo(`/linkdrop/${options.fundingContract}/${options.fundingKey}${redirectUrl}`);
         } else {
             this.props.redirectToApp('/');

--- a/src/components/common/FormButton.js
+++ b/src/components/common/FormButton.js
@@ -441,7 +441,7 @@ const FormButton = ({
         disabled={disabled}
         onClick={(e) => {
             onClick && onClick(e);
-            linkTo && (linkTo.includes('http') ? window.open(linkTo, '_blank') : history.push(linkTo));
+            linkTo && (linkTo.toLowerCase().startsWith('http') ? window.open(linkTo, '_blank') : history.push(linkTo));
             trackingId && Mixpanel.track(trackingId);
         }}
         tabIndex='3'


### PR DESCRIPTION
### Description

This PR fixes https://github.com/near/near-wallet/issues/1875  The redirect doesn't work if a user import a new account and then claim the linkdrop. 

To fix the issue, we need to: 
1. ensure the `redirectUrl` parameter (or the state that saves this parameter) is not lost when jumping back from the `recover-account` and `recover-seed-phrase` pages;
2. the `redirectUrl` parameter was saved into state correctly, so the redirection could happen successfully


