### PR TITLE
Automatically detect browser language

### DIFF
--- a/src/components/Routing.js
+++ b/src/components/Routing.js
@@ -18,6 +18,7 @@ import translations_zh_hans from '../translations/zh-hans.global.json';
 import translations_zh_hant from '../translations/zh-hant.global.json';
 import { handleClearAlert } from '../utils/alerts';
 import classNames from '../utils/classNames';
+import getBrowserLocale from '../utils/getBrowserLocale';
 import isMobile from '../utils/isMobile';
 import { getAccountIsInactive } from '../utils/localStorage';
 import { reportUiActiveMixpanelThrottled } from '../utils/reportUiActiveMixpanelThrottled';
@@ -111,7 +112,8 @@ class Routing extends Component {
             { name: "繁體中文", code: "zh-hant" }
         ];
 
-        const activeLang = localStorage.getItem("languageCode") || languages[0].code;
+        const browserLanguage = getBrowserLocale(languages.map(l => l.code));
+        const activeLang = localStorage.getItem("languageCode") || browserLanguage || languages[0].code;
 
         this.props.initialize({
             languages,

--- a/src/utils/getBrowserLocale.js
+++ b/src/utils/getBrowserLocale.js
@@ -1,8 +1,9 @@
 import { getUserLocales } from './getUserLocale'
 
 export default function getBrowserLocale(appLanguages) {
-  const browserLanguages = getUserLocales();
-  if (browserLanguages) {
+  const browserLanguages = getUserLocales()
+  if (appLanguages && appLanguages.length > 0
+      && browserLanguages && browserLanguages.length > 0) {
     return matchBrowserLocale(appLanguages, browserLanguages)
   } else {
     return undefined

--- a/src/utils/getBrowserLocale.js
+++ b/src/utils/getBrowserLocale.js
@@ -1,4 +1,4 @@
-import { getUserLocales } from './getUserLocale'
+import { getUserLocales } from './getUserLocale';
 
 const DEBUG_LOG = false;
 
@@ -28,7 +28,7 @@ function findBestSupportedLocale(appLocales, browserLocales) {
 
     for (const [index, browserLocale] of walletLocales.entries()) {
         // match exact locale.
-        const matchedExactLocale = appLocales.find(appLocale => appLocale.toLowerCase() === browserLocale.toLowerCase())
+        const matchedExactLocale = appLocales.find(appLocale => appLocale.toLowerCase() === browserLocale.toLowerCase());
         if (matchedExactLocale) {
             debugLog('Found direct match:', { browserLocale, matchedExactLocale });
             matchedLocales[matchedExactLocale] = { code: matchedExactLocale, score: 1 - index / walletLocales.length };
@@ -41,9 +41,9 @@ function findBestSupportedLocale(appLocales, browserLocales) {
 
                 // Deduct a thousandth for being non-exact match.
                 const newMatch = { code: matchedPartialLocale, score: 0.999 - index / walletLocales.length };
-                if (!existingMatch || existingMatch && existingMatch.score <= matchedPartialLocale.score) {
+                if (!existingMatch || (existingMatch && existingMatch.score <= matchedPartialLocale.score)) {
                     debugLog('Found language-only match:', { browserLocale, matchedPartialLocale });
-                    matchedLocales[matchedPartialLocale] = newMatch
+                    matchedLocales[matchedPartialLocale] = newMatch;
                 }
             }
         }

--- a/src/utils/getBrowserLocale.js
+++ b/src/utils/getBrowserLocale.js
@@ -9,6 +9,13 @@ export default function getBrowserLocale(appLanguages) {
 function matchBrowserLocale(appLocales, browserLocales) {
   const matchedLocales = []
 
+  // special handling for traditional Chinese
+  for (const browserCode of browserLocales) {
+    if (['zh-TW', 'zh-HK'].includes(browserCode)) {
+      return 'zh-hant'
+    }
+  }
+
   // first pass: match exact locale.
   for (const [index, browserCode] of browserLocales.entries()) {
     const matchedLocale = appLocales.find(appLocale => appLocale.toLowerCase() === browserCode.toLowerCase())

--- a/src/utils/getBrowserLocale.js
+++ b/src/utils/getBrowserLocale.js
@@ -1,0 +1,45 @@
+export default function getBrowserLocale(appLanguages) {
+  if (typeof navigator !== 'undefined' && navigator.languages) {
+    return matchBrowserLocale(appLanguages, navigator.languages)
+  } else {
+    return undefined
+  }
+}
+
+function matchBrowserLocale(appLocales, browserLocales) {
+  const matchedLocales = []
+
+  // first pass: match exact locale.
+  for (const [index, browserCode] of browserLocales.entries()) {
+    const matchedLocale = appLocales.find(appLocale => appLocale.toLowerCase() === browserCode.toLowerCase())
+    if (matchedLocale) {
+      matchedLocales.push({ code: matchedLocale, score: 1 - index / browserLocales.length })
+      break
+    }
+  }
+
+  // second pass: match only locale code part of the browser locale (not including country).
+  for (const [index, browserCode] of browserLocales.entries()) {
+    const languageCode = browserCode.split('-')[0].toLowerCase()
+    const matchedLocale = appLocales.find(appLocale => appLocale.split('-')[0].toLowerCase() === languageCode)
+    if (matchedLocale) {
+      // Deduct a thousandth for being non-exact match.
+      matchedLocales.push({ code: matchedLocale, score: 0.999 - index / browserLocales.length })
+      break
+    }
+  }
+
+  // Sort the list by score (0 - lowest, 1 - highest).
+  if (matchedLocales.length > 1) {
+    matchedLocales.sort((localeA, localeB) => {
+      if (localeA.score === localeB.score) {
+        // If scores are equal then pick more specific (longer) code.
+        return localeB.code.length - localeA.code.length
+      }
+
+      return localeB.score - localeA.score
+    })
+  }
+
+  return matchedLocales.length ? matchedLocales[0].code : undefined
+}

--- a/src/utils/getBrowserLocale.js
+++ b/src/utils/getBrowserLocale.js
@@ -1,56 +1,59 @@
 import { getUserLocales } from './getUserLocale'
 
+const DEBUG_LOG = false;
+
+const debugLog = (...args) => DEBUG_LOG && console.log(...args);
+
 export default function getBrowserLocale(appLanguages) {
-  const browserLanguages = getUserLocales()
-  if (appLanguages && appLanguages.length > 0
-      && browserLanguages && browserLanguages.length > 0) {
-    return matchBrowserLocale(appLanguages, browserLanguages)
-  } else {
-    return undefined
-  }
+    const browserLanguages = getUserLocales();
+
+    debugLog('Languages from browser:', browserLanguages);
+
+    if (appLanguages && appLanguages.length > 0
+        && browserLanguages && browserLanguages.length > 0) {
+        return findBestSupportedLocale(appLanguages, browserLanguages);
+    }
 }
 
-function matchBrowserLocale(appLocales, browserLocales) {
-  const matchedLocales = []
+function findBestSupportedLocale(appLocales, browserLocales) {
+    const matchedLocales = {};
 
-  // special handling for traditional Chinese
-  for (const browserCode of browserLocales) {
-    if (['zh-TW', 'zh-HK'].includes(browserCode)) {
-      return 'zh-hant'
+    // Process special mappings
+    const walletLocales = browserLocales.map((locale) => {
+        // Handle special cases for traditional Chinesee fallback
+        if (['zh-TW', 'zh-HK'].includes(locale)) { return 'zh-hant'; }
+
+        return locale;
+    });
+
+    for (const [index, browserLocale] of walletLocales.entries()) {
+        // match exact locale.
+        const matchedExactLocale = appLocales.find(appLocale => appLocale.toLowerCase() === browserLocale.toLowerCase())
+        if (matchedExactLocale) {
+            debugLog('Found direct match:', { browserLocale, matchedExactLocale });
+            matchedLocales[matchedExactLocale] = { code: matchedExactLocale, score: 1 - index / walletLocales.length };
+        } else {
+            // match only locale code part of the browser locale (not including country).
+            const languageCode = browserLocale.split('-')[0].toLowerCase();
+            const matchedPartialLocale = appLocales.find(appLocale => appLocale.split('-')[0].toLowerCase() === languageCode);
+            if (matchedPartialLocale) {
+                const existingMatch = matchedLocales[matchedPartialLocale];
+
+                // Deduct a thousandth for being non-exact match.
+                const newMatch = { code: matchedPartialLocale, score: 0.999 - index / walletLocales.length };
+                if (!existingMatch || existingMatch && existingMatch.score <= matchedPartialLocale.score) {
+                    debugLog('Found language-only match:', { browserLocale, matchedPartialLocale });
+                    matchedLocales[matchedPartialLocale] = newMatch
+                }
+            }
+        }
     }
-  }
 
-  // first pass: match exact locale.
-  for (const [index, browserCode] of browserLocales.entries()) {
-    const matchedLocale = appLocales.find(appLocale => appLocale.toLowerCase() === browserCode.toLowerCase())
-    if (matchedLocale) {
-      matchedLocales.push({ code: matchedLocale, score: 1 - index / browserLocales.length })
-      break
+
+    // Sort the list by score (0 - lowest, 1 - highest).
+    if (Object.keys(matchedLocales).length > 0) {
+        const bestMatch = Object.values(matchedLocales).sort((localeA, localeB) => localeB.score - localeA.score)[0].code;
+        debugLog('bestMatch', bestMatch);
+        return bestMatch;
     }
-  }
-
-  // second pass: match only locale code part of the browser locale (not including country).
-  for (const [index, browserCode] of browserLocales.entries()) {
-    const languageCode = browserCode.split('-')[0].toLowerCase()
-    const matchedLocale = appLocales.find(appLocale => appLocale.split('-')[0].toLowerCase() === languageCode)
-    if (matchedLocale) {
-      // Deduct a thousandth for being non-exact match.
-      matchedLocales.push({ code: matchedLocale, score: 0.999 - index / browserLocales.length })
-      break
-    }
-  }
-
-  // Sort the list by score (0 - lowest, 1 - highest).
-  if (matchedLocales.length > 1) {
-    matchedLocales.sort((localeA, localeB) => {
-      if (localeA.score === localeB.score) {
-        // If scores are equal then pick more specific (longer) code.
-        return localeB.code.length - localeA.code.length
-      }
-
-      return localeB.score - localeA.score
-    })
-  }
-
-  return matchedLocales.length ? matchedLocales[0].code : undefined
 }

--- a/src/utils/getBrowserLocale.js
+++ b/src/utils/getBrowserLocale.js
@@ -1,6 +1,9 @@
+import { getUserLocales } from './getUserLocale'
+
 export default function getBrowserLocale(appLanguages) {
-  if (typeof navigator !== 'undefined' && navigator.languages) {
-    return matchBrowserLocale(appLanguages, navigator.languages)
+  const browserLanguages = getUserLocales();
+  if (browserLanguages) {
+    return matchBrowserLocale(appLanguages, browserLanguages)
   } else {
     return undefined
   }


### PR DESCRIPTION
### Description

Closes https://github.com/near/near-wallet/issues/704

To improve the UX of wallet for non-English users, the wallet should automatically detect the browser language, and switch to the user defined browser language. 

### Discussion

The browser language detection works for all the languages except Tranditional Chinese `zh-hant`, because the browser locale retrieved from `window.navigator.languages` are `zh-TW` or `zh-HK` for the Traditional Chinese users, which don't match with the locale code `zh-hant` we used in the wallet app. All the `zh-XX` (including `zh-CN`, `zh-TW`, `zh-HK`) codes now will be matched to `zh-hans` by default in the current design. 

To fix this issue, we added some special handing for `zh-TW` or `zh-HK` to return `zh-hant` in https://github.com/near/near-wallet/pull/1884/commits/79b3f49893bbccb84b9cda837c173d81fdd967d0. 

