### PR TITLE
Transfer Fungible Tokens: prepare redux actions

### DIFF
--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -26,7 +26,7 @@ export const transfer = ({
             dispatch(send.setTxStatus(transaction.hash, 'success'));
         }
     } else if(type === TOKEN_TYPES.NEP141) {
-        if (!isStorageBalanceAvailable) {
+        if (isStorageBalanceAvailable === false) {
             await dispatch(send.payStorageDeposit(contractName, receiverId));
         }
 

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -4,7 +4,7 @@ import { showAlert } from '../utils/alerts';
 import { wallet } from '../utils/wallet';
 
 export const transfer = ({ contractName, amount, memo, receiverId, isStorageBalanceAvailable }) => async (dispatch, gesState) => {
-    if (!isStorageBalanceAvailable) {
+    if (contractName && !isStorageBalanceAvailable) {
         await dispatch(send.transfer.storageDeposit(contractName, receiverId));
     }
 

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -28,7 +28,7 @@ export const transfer = ({
             if (status?.SuccessValue) {
                 dispatch(send.setTxStatus({
                     hash: transaction.hash,
-                    newStatus: 'success'
+                    status: 'success'
                 }));
             }
             break;
@@ -59,7 +59,7 @@ export const transfer = ({
             } else {
                 dispatch(send.setTxStatus({
                     hash,
-                    newStatus: 'success'
+                    status: 'success'
                 }));
             }
             break;

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -27,5 +27,6 @@ export const { send } = createActions({
                 () => showAlert({ onlyError: true })
             ],
         },
+        SET_TX_STATUS: null,
     }
 });

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -46,7 +46,7 @@ export const transfer = ({
             dispatch(send.setTxStatus(transaction.hash, 'success'));
         }
     } else {
-        throw new WalletError(`Could not transfer unsupported token: ${type}`, 'send.unsupportedToken', { type: type });
+        throw new WalletError(`Could not transfer unsupported token: ${type}`, 'send.unsupportedToken', { type });
     }
 };
 
@@ -58,16 +58,16 @@ export const { send } = createActions({
                 () => showAlert({ onlyError: true })
             ],
             NEP141: [
-                () => {},
+                wallet.fungibleTokens.transfer.bind(wallet),
                 () => showAlert({ onlyError: true })
             ],
         },
         PAY_STORAGE_DEPOSIT: [
-            () => {},
+            wallet.fungibleTokens.transferStorageDeposit.bind(wallet),
             () => showAlert({ onlyError: true })
         ],
         IS_STORAGE_BALANCE_AVAILABLE: [
-            () => {},
+            wallet.fungibleTokens.isStorageBalanceAvailable.bind(wallet),
             () => showAlert({ onlyError: true })
         ],
         SET_TX_STATUS: null,

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -12,7 +12,7 @@ export const { send } = createActions({
     SEND: {
         TRANSFER: {
             NEAR: [
-                () => {},
+                wallet.sendMoney.bind(wallet),
                 () => showAlert({ onlyError: true })
             ],
             TOKENS: [

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -3,7 +3,7 @@ import { createActions } from 'redux-actions';
 import { showAlert } from '../utils/alerts';
 import { wallet } from '../utils/wallet';
 
-export const transfer = ({ contractName, amount, memo, receiverId, isStorageBalanceAvailable }) => async (dispatch, gesState) => {
+export const transfer = ({ contractName, amount, memo, receiverId, isStorageBalanceAvailable }) => async (dispatch) => {
     if (contractName && !isStorageBalanceAvailable) {
         await dispatch(send.transfer.storageDeposit(contractName, receiverId));
     }

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -1,2 +1,2 @@
-export const transfer = () => async (dispatch, gesState) => {
+export const transfer = ({ contractName, amount, memo, receiverId, isStorageBalanceAvailable }) => async (dispatch, gesState) => {
 };

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -66,6 +66,14 @@ export const { send } = createActions({
             ],
             NEP141: [
                 wallet.fungibleTokens.transfer?.bind(wallet.fungibleTokens),
+                ({
+                    amount,
+                    receiverId
+                }) => ({
+                    ...showAlert({ onlyError: true }),
+                    amount,
+                    receiverId
+                })
             ],
         },
         PAY_STORAGE_DEPOSIT: [

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -15,11 +15,10 @@ export const transfer = ({
     params: {
         contractName, 
         amount, 
-        memo, 
-        receiverId
+        receiverId,
+        memo
     }
-}) => async (dispatch) => {
-
+}) => async (dispatch, getState) => {
     if (type === TOKEN_TYPES.NEAR) {
         const { transaction, status } = await dispatch(send.transfer.near(receiverId, amount));
 
@@ -31,7 +30,17 @@ export const transfer = ({
             await dispatch(send.payStorageDeposit(contractName, receiverId));
         }
 
-        const { transaction, status } = await dispatch(send.transfer.nep141(contractName, amount, memo, receiverId));
+        const { transaction, status } = await dispatch(send.transfer.nep141({
+            token: { 
+                contractName,
+                metadata: { 
+                    decimals: getState().tokens.tokens[contractName]
+                }
+            },
+            amount,
+            receiverId,
+            memo
+        }));
 
         if (status?.SuccessValue) {
             dispatch(send.setTxStatus(transaction.hash, 'success'));

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -31,6 +31,10 @@ export const { send } = createActions({
                 () => showAlert({ onlyError: true })
             ],
         },
+        IS_STORAGE_BALANCE_AVAILABLE: [
+            () => {},
+            () => showAlert({ onlyError: true })
+        ],
         SET_TX_STATUS: null,
     }
 });

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -1,2 +1,16 @@
+import { createActions } from 'redux-actions';
+
+import { showAlert } from '../utils/alerts';
 export const transfer = ({ contractName, amount, memo, receiverId, isStorageBalanceAvailable }) => async (dispatch, gesState) => {
 };
+
+export const { send } = createActions({
+    SEND: {
+        TRANSFER: {
+            STORAGE_DEPOSIT: [
+                () => {},
+                () => showAlert({ onlyError: true })
+            ],
+        },
+    }
+});

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -45,6 +45,9 @@ export const transfer = ({
                 hash,
                 newStatus: 'success'
             }));
+        } else {
+            const { error_message, error_type} = status.Failure
+            throw new WalletError(error_message, error_type)
         }
     } else {
         throw new WalletError(`Could not transfer unsupported token: ${type}`, 'send.unsupportedToken', { type });

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -47,15 +47,15 @@ export const { send } = createActions({
                 wallet.sendMoney.bind(wallet),
                 () => showAlert({ onlyError: true })
             ],
-            TOKENS: [
-                () => {},
-                () => showAlert({ onlyError: true })
-            ],
-            STORAGE_DEPOSIT: [
+            NEP141: [
                 () => {},
                 () => showAlert({ onlyError: true })
             ],
         },
+        PAY_STORAGE_DEPOSIT: [
+            () => {},
+            () => showAlert({ onlyError: true })
+        ],
         IS_STORAGE_BALANCE_AVAILABLE: [
             () => {},
             () => showAlert({ onlyError: true })

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -58,7 +58,11 @@ export const { send } = createActions({
         TRANSFER: {
             NEAR: [
                 wallet.sendMoney.bind(wallet),
-                () => showAlert({ onlyError: true })
+                (receiverId, amount) => ({
+                    ...showAlert({ onlyError: true }),
+                    receiverId,
+                    amount
+                })
             ],
             NEP141: [
                 wallet.fungibleTokens.transfer.bind(wallet),

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -1,0 +1,2 @@
+export const transfer = () => async (dispatch, gesState) => {
+};

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -40,7 +40,7 @@ export const transfer = ({
             memo
         }));
 
-        if (status?.SuccessValue === '') {
+        if (!status.SuccessValue || typeof status.SuccessValue !== 'string') {
             dispatch(send.setTxStatus({
                 hash,
                 newStatus: 'success'

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -33,9 +33,7 @@ export const transfer = ({
         const { transaction: { hash }, status } = await dispatch(send.transfer.nep141({
             token: { 
                 contractName,
-                metadata: { 
-                    decimals: getState().tokens.tokens[contractName].decimals
-                }
+                metadata: getState().tokens.tokens[contractName]
             },
             amount,
             receiverId,

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -1,11 +1,14 @@
 import { createActions } from 'redux-actions';
 
 import { showAlert } from '../utils/alerts';
+import { wallet } from '../utils/wallet';
 
 export const transfer = ({ contractName, amount, memo, receiverId, isStorageBalanceAvailable }) => async (dispatch, gesState) => {
     if (!isStorageBalanceAvailable) {
         await dispatch(send.transfer.storageDeposit(contractName, receiverId));
     }
+
+    const { transaction, status } = await dispatch(send.transfer[contractName ? 'TOKENS' : 'NEAR'](contractName, amount, memo, receiverId));
 };
 
 export const { send } = createActions({

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -2,6 +2,7 @@ import { createActions } from 'redux-actions';
 
 import { showAlert } from '../utils/alerts';
 import { wallet } from '../utils/wallet';
+import { WalletError } from '../utils/walletError';
 
 export const TOKEN_TYPES = {
     NEAR: 'NEAR',
@@ -36,7 +37,7 @@ export const transfer = ({
             dispatch(send.setTxStatus(transaction.hash, 'success'));
         }
     } else {
-        throw new TypeError(`Could not transfer unsupported token: ${type}`);
+        throw new WalletError(`Could not transfer unsupported token: ${type}`, 'send.unsupportedToken', { type: type });
     }
 };
 

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -30,7 +30,7 @@ export const transfer = ({
             await dispatch(send.payStorageDeposit(contractName, receiverId));
         }
 
-        const { transaction, status } = await dispatch(send.transfer.nep141({
+        const { transaction: { hash }, status } = await dispatch(send.transfer.nep141({
             token: { 
                 contractName,
                 metadata: { 
@@ -42,8 +42,10 @@ export const transfer = ({
             memo
         }));
 
-        if (status?.SuccessValue) {
-            dispatch(send.setTxStatus(transaction.hash, 'success'));
+            dispatch(send.setTxStatus({
+                hash,
+                newStatus: 'success'
+            }));
         }
     } else {
         throw new WalletError(`Could not transfer unsupported token: ${type}`, 'send.unsupportedToken', { type });

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -65,16 +65,15 @@ export const { send } = createActions({
                 })
             ],
             NEP141: [
-                wallet.fungibleTokens.transfer.bind(wallet),
-                () => showAlert({ onlyError: true })
+                wallet.fungibleTokens.transfer?.bind(wallet.fungibleTokens),
             ],
         },
         PAY_STORAGE_DEPOSIT: [
-            wallet.fungibleTokens.transferStorageDeposit.bind(wallet),
+            wallet.fungibleTokens.transferStorageDeposit?.bind(wallet.fungibleTokens),
             () => showAlert({ onlyError: true })
         ],
         IS_STORAGE_BALANCE_AVAILABLE: [
-            wallet.fungibleTokens.isStorageBalanceAvailable.bind(wallet),
+            wallet.fungibleTokens.isStorageBalanceAvailable?.bind(wallet.fungibleTokens),
             () => showAlert({ onlyError: true })
         ],
         SET_TX_STATUS: null,

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -11,6 +11,14 @@ export const transfer = ({ contractName, amount, memo, receiverId, isStorageBala
 export const { send } = createActions({
     SEND: {
         TRANSFER: {
+            NEAR: [
+                () => {},
+                () => showAlert({ onlyError: true })
+            ],
+            TOKENS: [
+                () => {},
+                () => showAlert({ onlyError: true })
+            ],
             STORAGE_DEPOSIT: [
                 () => {},
                 () => showAlert({ onlyError: true })

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -42,6 +42,7 @@ export const transfer = ({
             memo
         }));
 
+        if (status?.SuccessValue === '') {
             dispatch(send.setTxStatus({
                 hash,
                 newStatus: 'success'

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -1,7 +1,11 @@
 import { createActions } from 'redux-actions';
 
 import { showAlert } from '../utils/alerts';
+
 export const transfer = ({ contractName, amount, memo, receiverId, isStorageBalanceAvailable }) => async (dispatch, gesState) => {
+    if (!isStorageBalanceAvailable) {
+        await dispatch(send.transfer.storageDeposit(contractName, receiverId));
+    }
 };
 
 export const { send } = createActions({

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -1,4 +1,5 @@
 import { createActions } from 'redux-actions';
+import { selectTokenDetails } from '../reducers/tokens';
 
 import { showAlert } from '../utils/alerts';
 import { wallet } from '../utils/wallet';
@@ -58,7 +59,7 @@ export const { send } = createActions({
     SEND: {
         TRANSFER: {
             NEAR: [
-                wallet.sendMoney.bind(wallet),
+                (...args) => wallet.sendMoney(...args),
                 (receiverId, amount) => ({
                     ...showAlert({ onlyError: true }),
                     receiverId,
@@ -66,7 +67,7 @@ export const { send } = createActions({
                 })
             ],
             NEP141: [
-                wallet.fungibleTokens.transfer?.bind(wallet.fungibleTokens),
+                (...args) => wallet.fungibleTokens.transfer(...args),
                 ({
                     amount,
                     receiverId
@@ -78,11 +79,11 @@ export const { send } = createActions({
             ],
         },
         PAY_STORAGE_DEPOSIT: [
-            wallet.fungibleTokens.transferStorageDeposit?.bind(wallet.fungibleTokens),
+            (...args) => wallet.fungibleTokens.transferStorageDeposit(...args),
             () => showAlert({ onlyError: true })
         ],
         IS_STORAGE_BALANCE_AVAILABLE: [
-            wallet.fungibleTokens.isStorageBalanceAvailable?.bind(wallet.fungibleTokens),
+            (...args) => wallet.fungibleTokens.isStorageBalanceAvailable(...args),
             () => showAlert({ onlyError: true })
         ],
         SET_TX_STATUS: null,

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -3,10 +3,10 @@ import { createActions } from 'redux-actions';
 import { showAlert } from '../utils/alerts';
 import { wallet } from '../utils/wallet';
 
-export const transfer = ({ contractName, amount, memo, receiverId, isStorageBalanceAvailable }) => async (dispatch) => {
-    if (contractName && !isStorageBalanceAvailable) {
-        await dispatch(send.transfer.storageDeposit(contractName, receiverId));
-    }
+export const TOKEN_TYPES = {
+    NEAR: 'NEAR',
+    NEP141: 'NEP141'
+};
 
     const { transaction, status } = await dispatch(send.transfer[contractName ? 'TOKENS' : 'NEAR'](contractName, amount, memo, receiverId));
 

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -9,6 +9,10 @@ export const transfer = ({ contractName, amount, memo, receiverId, isStorageBala
     }
 
     const { transaction, status } = await dispatch(send.transfer[contractName ? 'TOKENS' : 'NEAR'](contractName, amount, memo, receiverId));
+
+    if (status?.SuccessValue) {
+        dispatch(send.setTxStatus(transaction.hash, 'success'));
+    }
 };
 
 export const { send } = createActions({

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -33,7 +33,7 @@ export const transfer = ({
         const { transaction: { hash }, status } = await dispatch(send.transfer.nep141({
             token: { 
                 contractName,
-                metadata: getState().tokens.tokens[contractName]
+                metadata: selectTokenDetails(getState(), contractName)
             },
             amount,
             receiverId,

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -34,7 +34,7 @@ export const transfer = ({
             token: { 
                 contractName,
                 metadata: { 
-                    decimals: getState().tokens.tokens[contractName]
+                    decimals: getState().tokens.tokens[contractName].decimals
                 }
             },
             amount,

--- a/src/actions/send.js
+++ b/src/actions/send.js
@@ -24,7 +24,10 @@ export const transfer = ({
         const { transaction, status } = await dispatch(send.transfer.near(receiverId, amount));
 
         if (status?.SuccessValue) {
-            dispatch(send.setTxStatus(transaction.hash, 'success'));
+            dispatch(send.setTxStatus({
+                hash: transaction.hash,
+                newStatus: 'success'
+            }));
         }
     } else if(type === TOKEN_TYPES.NEP141) {
         if (isStorageBalanceAvailable === false) {

--- a/src/reducers/tokens/index.js
+++ b/src/reducers/tokens/index.js
@@ -51,3 +51,5 @@ export default reduceReducers(
 );
 
 export const selectTokensDetails = state => state.tokens.tokens;
+
+export const selectTokenDetails = (state, contractName) => state.tokens.tokens[contractName]

--- a/src/reducers/tokens/index.js
+++ b/src/reducers/tokens/index.js
@@ -52,4 +52,4 @@ export default reduceReducers(
 
 export const selectTokensDetails = state => state.tokens.tokens;
 
-export const selectTokenDetails = (state, contractName) => state.tokens.tokens[contractName]
+export const selectTokenDetails = (state, contractName) => state.tokens.tokens[contractName];

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -133,6 +133,9 @@
         },
         "setupRecoveryMessageNewAccount": {
             "invalidCode": "Invalid code"
+        },
+        "send": {
+            "unsupportedToken": "Could not transfer unsupported token: ${type}"
         }
     },
     "account": {

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -165,7 +165,7 @@ class Wallet {
     }
 
     async sendMoney(receiverId, amount) {
-        await (await this.getAccount(this.accountId)).sendMoney(receiverId, amount);
+        return await (await this.getAccount(this.accountId)).sendMoney(receiverId, amount);
     }
 
     isEmpty() {


### PR DESCRIPTION
Set of actions to handle Redux state management for transfer fungible tokens.

Async `transfer` action will handle:
 - checking and performing storage deposits needed if a fungible token transfer is happening
 - performing transfer
 - setting transfer status if the transaction was successful

There is also `isStorageBalanceAvailable` action that should be dispatched before the transfer is requested, and the result should be passed to `transfer` action. This is because the user needs to be aware that he will be paying (or not paying) for the receiver's storage deposit