### PR TITLE
Transfer Fungible Tokens: prepare redux reducer

### DIFF
--- a/src/reducers/send/index.js
+++ b/src/reducers/send/index.js
@@ -1,0 +1,14 @@
+import reduceReducers from 'reduce-reducers';
+import { handleActions } from 'redux-actions';
+
+const initialState = {
+    items: []
+}
+
+const sendReducer = handleActions({
+}, initialState)
+
+export default reduceReducers(
+    initialState,
+    sendReducer
+);

--- a/src/reducers/send/index.js
+++ b/src/reducers/send/index.js
@@ -1,11 +1,36 @@
 import reduceReducers from 'reduce-reducers';
 import { handleActions } from 'redux-actions';
 
+import { send } from '../../actions/send'
+
 const initialState = {
     items: []
 }
 
 const sendReducer = handleActions({
+    [send.transfer.near]: (state, { payload, meta }) => 
+        (!ready || error)
+            ? state
+            : ({
+                ...state,
+                items: [
+                    ...state.items,
+                    {
+                        hash: payload.transaction.hash,
+                        type: 'NEAR',
+                        details: {
+                            amount: meta.amount,
+                            receiver: {
+                                accountId: meta.receiverId
+                            }
+                        },
+                        status: {
+                            txStatus: 'pending',
+                            networkFees: payload.transaction_outcome.outcome.gas_burnt,
+                        }
+                    }
+                ]
+            }),
 }, initialState)
 
 export default reduceReducers(

--- a/src/reducers/send/index.js
+++ b/src/reducers/send/index.js
@@ -8,7 +8,7 @@ const initialState = {
 }
 
 const sendReducer = handleActions({
-    [send.transfer.near]: (state, { payload, meta }) => 
+    [send.transfer.near]: (state, { payload, meta, ready, error }) => 
         (!ready || error)
             ? state
             : ({

--- a/src/reducers/send/index.js
+++ b/src/reducers/send/index.js
@@ -1,7 +1,7 @@
 import reduceReducers from 'reduce-reducers';
 import { handleActions } from 'redux-actions';
 
-import { send } from '../../actions/send'
+import { send } from '../../actions/send';
 
 // sample items states for near and fungible tokens transfer
 // const items = [
@@ -42,7 +42,7 @@ import { send } from '../../actions/send'
 
 const initialState = {
     items: []
-}
+};
 
 const sendReducer = handleActions({
     [send.transfer.near]: (state, { payload, meta, ready, error }) => 
@@ -107,7 +107,7 @@ const sendReducer = handleActions({
             : item
         )
     })
-}, initialState)
+}, initialState);
 
 export default reduceReducers(
     initialState,

--- a/src/reducers/send/index.js
+++ b/src/reducers/send/index.js
@@ -57,6 +57,19 @@ const sendReducer = handleActions({
                     }
                 ]
             }),
+    [send.setTxStatus]: (state, { payload }) => ({
+        ...state,
+        items: state.items.map((item) => item.hash === payload.hash
+            ? ({
+                ...item,
+                status: {
+                    ...item.status,
+                    txStatus: payload.newStatus
+                }
+            })
+            : item
+        )
+    })
 }, initialState)
 
 export default reduceReducers(

--- a/src/reducers/send/index.js
+++ b/src/reducers/send/index.js
@@ -3,6 +3,43 @@ import { handleActions } from 'redux-actions';
 
 import { send } from '../../actions/send'
 
+// sample items states for near and fungible tokens transfer
+// const items = [
+//     {
+//         hash: '',
+//         type: 'NEP141',
+//         details: {
+//             token: {
+//                 contractName: '',
+//                 name: '',
+//                 symbol: ''
+//             },
+//             amount: '',
+//             receiver: {
+//                 accountId: '',
+//             },
+//         },
+//         status: {
+//             txStatus: '',
+//             networkFees: ''
+//         }
+//     },
+//     {
+//         hash: '',
+//         type: 'NEAR',
+//         details: {
+//             amount: '',
+//             receiver: {
+//                 accountId: ''
+//             }
+//         },
+//         status: {
+//             txStatus: '',
+//             networkFees: ''
+//         }
+//     }
+// ]
+
 const initialState = {
     items: []
 }

--- a/src/reducers/send/index.js
+++ b/src/reducers/send/index.js
@@ -31,6 +31,32 @@ const sendReducer = handleActions({
                     }
                 ]
             }),
+    [send.transfer.nep141]: (state, { payload, meta, ready, error }) => 
+        (!ready || error)
+            ? state
+            : ({
+                ...state,
+                items: [
+                    ...state.items,
+                    {
+                        hash: payload.transaction.hash,
+                        type: 'NEP141',
+                        details: {
+                            token: {
+                                contractName: payload.transaction.receiver_id
+                            },
+                            amount: meta.amount,
+                            receiver: {
+                                accountId: meta.receiverId
+                            }
+                        },
+                        status: {
+                            txStatus: 'pending',
+                            networkFees: payload.transaction_outcome.outcome.gas_burnt,
+                        }
+                    }
+                ]
+            }),
 }, initialState)
 
 export default reduceReducers(


### PR DESCRIPTION
Includes Redux `send` reducer, which handles actions related to transfer fungible tokens.

Transfers are stored in an array of objects, with similar structures for each transfer type.