### PR TITLE
Disable Cloudflare for testnet

### DIFF
--- a/ci/ParcelBundler.js
+++ b/ci/ParcelBundler.js
@@ -111,7 +111,8 @@ class ParcelBundler {
 
         return {
             ...this.getBaseConfig(),
-            publicUrl: this.buildCloudflarePath('/rnd/testnet/')
+            // FIXME: Re-enable once we have figured out render.com SSL problems with `wallet.testnet.near.org`?
+            // publicUrl: this.buildCloudflarePath('/rnd/testnet/')
         };
     }
 


### PR DESCRIPTION
SSL problems :(. This will leave it enabled for staging/mainnet but disable it only for testnet for now.