### PR TITLE
Remove unnecessary queries of account access keys via RPC

### DIFF
--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -144,6 +144,11 @@ class Wallet {
         accountId = accountId || this.accountId;
         // TODO: Refactor so that every account just stores a flag if it's on Ledger?
 
+        // special handing for fixing issue #1919
+        if (accountId === ACCOUNT_ID_SUFFIX) {
+            return null;
+        }
+
         const accessKeys = await this.getAccessKeys(accountId);
         if (accessKeys) {
             const localKey = await this.getLocalAccessKey(accountId, accessKeys);


### PR DESCRIPTION
### Problem

Fixes: #1919 

Now claim linkdrop is extremely slow (>60s) in Mainnet Wallet.

The root cause is that for signing transaction in wallet, now we'll first `getLedgerKey()` which will call `getAccessKeys()` and then filter out the ledger key.  This is OK for most accounts, but for acounts with thousands of keys such as `near` or `testtnet`, it impacts the performance significantly. 

https://github.com/near/near-wallet/blob/b58683fd7032b26e38a28a6385dc6f0ebf47068f/src/utils/wallet.js#L99-L120 

### Solution 

1. We don't need `getLedgerKey()` for some accounts such as the root account: `testnet`, `near`, etc.
2. We should make `getLedgerKey()` more efficient if possible, by removing unnecessary query of all access keys, or add more caches to avoid duplicate requests. 

Here, due to the urgency of the fixing the issue, which impacts the UX of claiming linkdrops and NFTs of one NFT project, in this PR, one quick workaround is proposed:

> just return `null` for `near` or `testnet` account in `getLedgerKey()` 

Please feel free to propose better solutions, but let's ensure we could fix the issue in mainnet no later than July 16th, the sooner the better to leave some time for testing. 


