### PR TITLE
i18n: Fix claim linkdrop Chinese translation

### DIFF
--- a/src/translations/zh-hans.global.json
+++ b/src/translations/zh-hans.global.json
@@ -650,7 +650,7 @@
     "linkdropLanding": {
         "title": "你收到了 NEAR 空投！",
         "desc": "你可以登录已有的账户领取，或创建新的账户领取。",
-        "ctaAccount": "登录已有账户并领取",
+        "ctaAccount": "用已登录的账户领取",
         "ctaLogin": "登录并领取",
         "ctaNew": "注册新账户并领取",
         "or": "或",

--- a/src/translations/zh-hant.global.json
+++ b/src/translations/zh-hant.global.json
@@ -650,7 +650,7 @@
     "linkdropLanding": {
         "title": "你收到了 NEAR 空投！",
         "desc": "你可以登錄已有的賬戶領取，或創建新的賬戶領取。",
-        "ctaAccount": "登錄已有賬戶並領取",
+        "ctaAccount": "用已登錄的賬戶領取",
         "ctaLogin": "登錄並領取",
         "ctaNew": "註冊新賬戶並領取",
         "or": "或",


### PR DESCRIPTION
### Description

The Chinese translation of claiming linkdrop with existing account is inaccurate. 

Fix this with the more accurate translation. 

![image](https://user-images.githubusercontent.com/46699230/125653658-70842d8c-4578-4f6d-a43b-04835cce2d00.png)

