### PR TITLE
Add `strict-origin-when-cross-origin` meta to fix the `referer` issue for Huawei browsers, etc.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,7 @@
             content="width=device-width, initial-scale=1, shrink-to-fit=no"
         />
         <meta name="theme-color" content="#000000" />
+        <meta name="referrer" content="strict-origin-when-cross-origin" />
         <title>NEAR Wallet</title>
     </head>
     <body>


### PR DESCRIPTION
Fixes: #1933

Loading JS and CSS from Cloudflare workers failed when using Huawei / QQ Browsers, etc. 

Force `strict-origin-when-cross-origin` in html to change the referrer url to origin only to resolve the issue. 


