### PR TITLE
Show NEAR tokens in the token list on the main dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "redux-actions": "^2.6.5",
     "redux-thunk": "^2.3.0",
     "regenerator-runtime": "^0.13.5",
+    "reselect": "^4.0.0",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^0.88.1",
     "styled-components": "^5.3.0",

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -555,7 +555,7 @@ export const refreshAccount = (basicData = false) => async (dispatch, getState) 
 };
 
 export const switchAccount = (accountId) => async (dispatch, getState) => {
-    dispatch(selectAccount(accountId));
+    dispatch(makeAccountActive(accountId));
     dispatch(handleRefreshUrl());
     dispatch(staking.clearState());
     dispatch(refreshAccount());
@@ -588,8 +588,8 @@ export const getAvailableAccountsBalance = () => async (dispatch, getState) => {
     }
 };
 
-export const { selectAccount, refreshAccountOwner, refreshAccountExternal, refreshUrl, updateStakingAccount, updateStakingLockup, getBalance, setLocalStorage, getAccountBalance, setAccountBalance } = createActions({
-    SELECT_ACCOUNT: wallet.selectAccount.bind(wallet),
+export const { makeAccountActive, refreshAccountOwner, refreshAccountExternal, refreshUrl, updateStakingAccount, updateStakingLockup, getBalance, setLocalStorage, getAccountBalance, setAccountBalance } = createActions({
+    MAKE_ACCOUNT_ACTIVE: wallet.makeAccountActive.bind(wallet),
     REFRESH_ACCOUNT_OWNER: [
         wallet.refreshAccount.bind(wallet),
         () => ({ accountId: wallet.accountId })

--- a/src/components/navigation/DesktopContainer.js
+++ b/src/components/navigation/DesktopContainer.js
@@ -93,7 +93,7 @@ class DesktopContainer extends Component {
             menuOpen,
             toggleMenu,
             availableAccounts,
-            selectAccount,
+            handleSelectAccount,
             showNavLinks,
             flowLimitation,
             refreshBalance,
@@ -125,7 +125,7 @@ class DesktopContainer extends Component {
                             accountId={account.accountId}
                             accountIdLocalStorage={account.localStorage?.accountId}
                             accounts={availableAccounts}
-                            selectAccount={selectAccount}
+                            handleSelectAccount={handleSelectAccount}
                             accountsBalance={account.accountsBalance}
                             balance={account.balance}
                             refreshBalance={refreshBalance}

--- a/src/components/navigation/DesktopMenu.js
+++ b/src/components/navigation/DesktopMenu.js
@@ -30,7 +30,7 @@ const DesktopMenu = ({
     show,
     accountId,
     accounts,
-    selectAccount,
+    handleSelectAccount,
     accountIdLocalStorage,
     accountsBalance,
     balance,
@@ -46,7 +46,7 @@ const DesktopMenu = ({
                     accounts={accounts}
                     accountId={accountId}
                     accountIdLocalStorage={accountIdLocalStorage}
-                    selectAccount={selectAccount}
+                    handleSelectAccount={handleSelectAccount}
                     accountsBalance={accountsBalance}
                     balance={balance}
                     refreshBalance={refreshBalance}

--- a/src/components/navigation/MobileContainer.js
+++ b/src/components/navigation/MobileContainer.js
@@ -167,7 +167,7 @@ class MobileContainer extends Component {
 
         const {
             account,
-            selectAccount,
+            handleSelectAccount,
             availableAccounts,
             menuOpen,
             toggleMenu,
@@ -213,7 +213,7 @@ class MobileContainer extends Component {
                                 accounts={availableAccounts}
                                 accountId={account.accountId}
                                 accountIdLocalStorage={account.localStorage?.accountId}
-                                selectAccount={selectAccount}
+                                handleSelectAccount={handleSelectAccount}
                                 accountsBalance={account.accountsBalance}
                                 balance={account.balance}
                                 refreshBalance={refreshBalance}

--- a/src/components/navigation/Navigation.js
+++ b/src/components/navigation/Navigation.js
@@ -93,7 +93,7 @@ class Navigation extends Component {
                 <DesktopContainer
                     menuOpen={menuOpen}
                     toggleMenu={this.toggleMenu}
-                    selectAccount={this.handleSelectAccount}
+                    handleSelectAccount={this.handleSelectAccount}
                     showNavLinks={this.showNavLinks}
                     flowLimitation={flowLimitation}
                     refreshBalance={this.props.getAccountBalance}
@@ -104,7 +104,7 @@ class Navigation extends Component {
                 <MobileContainer
                     menuOpen={menuOpen}
                     toggleMenu={this.toggleMenu}
-                    selectAccount={this.handleSelectAccount}
+                    handleSelectAccount={this.handleSelectAccount}
                     showNavLinks={this.showNavLinks}
                     flowLimitation={flowLimitation}
                     refreshBalance={this.props.getAccountBalance}

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -140,7 +140,7 @@ const SyncButton = styled.span`
     }
 `;
 
-const UserAccounts = ({ accounts, accountId, accountIdLocalStorage, selectAccount, accountsBalance, balance, refreshBalance, getBalance }) => (
+const UserAccounts = ({ accounts, accountId, accountIdLocalStorage, handleSelectAccount, accountsBalance, balance, refreshBalance, getBalance }) => (
     <Wrapper>
         <UserAccount
             accountId={accountId || accountIdLocalStorage}
@@ -161,7 +161,7 @@ const UserAccounts = ({ accounts, accountId, accountIdLocalStorage, selectAccoun
                     balanceLoading={accountsBalance && accountsBalance[account]?.loading}
                     refreshBalance={() => refreshBalance(account)}
                     active={false}
-                    onClick={() => selectAccount(account)}
+                    onClick={() => handleSelectAccount(account)}
                 />
             )) : <SkeletonLoading
                 height='55px'

--- a/src/components/send/SendContainerWrapper.js
+++ b/src/components/send/SendContainerWrapper.js
@@ -1,4 +1,3 @@
-import BN from 'bn.js';
 import { utils } from 'near-api-js';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -6,49 +5,28 @@ import { useDispatch, useSelector } from 'react-redux';
 import { checkAccountAvailable, redirectTo } from '../../actions/account';
 import { clearLocalAlert, showCustomAlert } from '../../actions/status';
 import { handleGetTokens } from '../../actions/tokens';
+import { useFungibleTokensIncludingNEAR } from '../../hooks/fungibleTokensIncludingNEAR';
 import { Mixpanel } from '../../mixpanel/index';
-import { selectTokensDetails } from '../../reducers/tokens';
 import { EXPLORER_URL, SHOW_NETWORK_BANNER, wallet, WALLET_APP_MIN_AMOUNT } from '../../utils/wallet';
 import SendContainerV2, { VIEWS } from './SendContainerV2';
 
 const { parseNearAmount, formatNearAmount } = utils.format;
-
-const getAvailableNearToSend = (availableBalance, reservedForFees) => {
-    const availableToSendBN = new BN(availableBalance).sub(new BN(reservedForFees));
-    return availableToSendBN.isNeg() ? '0' : availableToSendBN.toString();
-};
-
-const fungibleTokensIncludingNEAR = (tokens, availableNearToSend) => {
-    return [
-        {
-            balance: availableNearToSend,
-            symbol: 'NEAR'
-        },
-        ...Object.values(tokens)
-    ];
-};
 
 export function SendContainerWrapper({ match }) {
     const accountIdFromUrl = match.params.accountId || '';
     const dispatch = useDispatch();
     const { accountId, balance } = useSelector(({ account }) => account);
     const { localAlert, isMobile } = useSelector(({ status }) => status);
-    const tokens = useSelector(state => selectTokensDetails(state));
 
     const availableNearBalance = balance?.available;
     const reservedNearForFees = parseNearAmount(WALLET_APP_MIN_AMOUNT);
-    const availableNearToSend = getAvailableNearToSend(availableNearBalance, parseNearAmount(WALLET_APP_MIN_AMOUNT));
 
     const [activeView, setActiveView] = useState(VIEWS.ENTER_AMOUNT);
     const [estimatedTotalFees, setEstimatedTotalFees] = useState('0');
     const [estimatedTotalInNear, setEstimatedTotalInNear] = useState('0');
     const [sendingToken, setSendingToken] = useState(false);
     const [transactionHash, setTransactionHash] = useState(null);
-    const [fungibleTokens, setFungibleTokens] = useState(() => fungibleTokensIncludingNEAR(tokens, availableNearToSend));
-
-    useEffect(() => {
-        setFungibleTokens(fungibleTokensIncludingNEAR(tokens, availableNearToSend));
-    }, [tokens, availableNearToSend]);
+    const fungibleTokensList = useFungibleTokensIncludingNEAR({ fullBalance: false });
 
     useEffect(() => {
         if (!accountId) {
@@ -67,7 +45,7 @@ export function SendContainerWrapper({ match }) {
             checkAccountAvailable={accountId => dispatch(checkAccountAvailable(accountId))}
             parseNearAmount={parseNearAmount}
             formatNearAmount={formatNearAmount}
-            fungibleTokens={fungibleTokens}
+            fungibleTokens={fungibleTokensList}
             localAlert={localAlert}
             clearLocalAlert={() => dispatch(clearLocalAlert())}
             isMobile={isMobile}
@@ -88,7 +66,7 @@ export function SendContainerWrapper({ match }) {
                             receiverId,
                             contractName
                         });
-                        
+
                         setTransactionHash(result.transaction.hash);
                         setActiveView(VIEWS.SUCCESS);
 

--- a/src/components/send/SendContainerWrapper.js
+++ b/src/components/send/SendContainerWrapper.js
@@ -42,7 +42,7 @@ export function SendContainerWrapper({ match }) {
             availableNearBalance={availableNearBalance}
             reservedNearForFees={reservedNearForFees}
             redirectTo={path => dispatch(redirectTo(path))}
-            checkAccountAvailable={accountId => dispatch(checkAccountAvailable(accountId))}
+            checkAccountAvailable={accountId => dispatch(checkAccountAvailable(accountId)).catch(() => null)}
             parseNearAmount={parseNearAmount}
             formatNearAmount={formatNearAmount}
             fungibleTokens={fungibleTokensList}

--- a/src/components/send/components/ReceiverInputWithLabel.js
+++ b/src/components/send/components/ReceiverInputWithLabel.js
@@ -50,7 +50,6 @@ const ReceiverInputWithLabel = ({
     checkAccountAvailable,
     localAlert,
     clearLocalAlert,
-    inputError,
     autoFocus
 }) => {
 

--- a/src/components/wallet/Wallet.js
+++ b/src/components/wallet/Wallet.js
@@ -353,7 +353,7 @@ const FungibleTokens = ({ balance, tokensLoader, fungibleTokens }) => {
         <>
             <NearWithBackgroundIcon/>
             <h1 className='total-balance'><Balance amount={balance?.total} symbol={false}/></h1>
-            <div className='sub-title'><Translate id='wallet.balanceTitle' /></div>
+            <div className='sub-title'><Translate id='wallet.totalBalanceTitle' /></div>
             <div className='buttons'>
                 <FormButton
                     color='dark-gray'
@@ -388,7 +388,7 @@ const FungibleTokens = ({ balance, tokensLoader, fungibleTokens }) => {
             </div>
             <div className='sub-title tokens'>
                 <span className={classNames({ dots: tokensLoader })}><Translate id='wallet.tokens' /></span>
-                <span><Translate id='wallet.balance' /></span>
+                <span><Translate id='wallet.totalBalance' /></span>
             </div>
             <Tokens tokens={fungibleTokens} />
         </>

--- a/src/components/wallet/Wallet.js
+++ b/src/components/wallet/Wallet.js
@@ -6,10 +6,10 @@ import styled from 'styled-components';
 import { handleGetNFTs } from '../../actions/nft';
 import { handleGetTokens } from '../../actions/tokens';
 import { getTransactions, getTransactionStatus } from '../../actions/transactions';
+import { useFungibleTokensIncludingNEAR } from '../../hooks/fungibleTokensIncludingNEAR';
 import { Mixpanel } from "../../mixpanel/index";
 import { selectAccountId, selectBalance } from '../../reducers/account';
 import { selectNFT } from '../../reducers/nft';
-import { selectTokensDetails } from '../../reducers/tokens';
 import { selectTransactions } from '../../reducers/transactions';
 import { actionsPendingByPrefix } from '../../utils/alerts';
 import classNames from '../../utils/classNames';
@@ -178,7 +178,6 @@ const StyledContainer = styled(Container)`
 
             > div {
                 flex: 1;
-                flex: 1;
                 display: flex;
                 align-items: center;
                 justify-content: center;
@@ -262,7 +261,7 @@ export function Wallet({ tab, setTab } ) {
     const hideExploreApps = localStorage.getItem('hideExploreApps');
     const linkdropAmount = localStorage.getItem('linkdropAmount');
     const linkdropModal = linkdropAmount && showLinkdropModal !== false;
-    const fungibleTokens = useSelector(state => selectTokensDetails(state));
+    const fungibleTokensList = useFungibleTokensIncludingNEAR({ fullBalance: true });
     const nft = useSelector(selectNFT);
     const tokensLoader = actionsPendingByPrefix('TOKENS/') || !balance?.total;
 
@@ -321,7 +320,7 @@ export function Wallet({ tab, setTab } ) {
                         : <FungibleTokens
                             balance={balance}
                             tokensLoader={tokensLoader}
-                            fungibleTokens={fungibleTokens}
+                            fungibleTokens={fungibleTokensList}
                         />
 
                     }

--- a/src/hooks/fungibleTokensIncludingNEAR.js
+++ b/src/hooks/fungibleTokensIncludingNEAR.js
@@ -1,0 +1,43 @@
+import BN from 'bn.js';
+import { parseNearAmount } from 'near-api-js/lib/utils/format';
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { selectBalance } from '../reducers/account';
+import { selectTokensDetails } from '../reducers/tokens';
+import { WALLET_APP_MIN_AMOUNT } from '../utils/wallet';
+
+const getAvailableNearToSend = (availableBalance, reservedForFees) => {
+    const availableToSendBN = new BN(availableBalance).sub(new BN(reservedForFees));
+    return availableToSendBN.isNeg() ? '0' : availableToSendBN.toString();
+};
+
+const fungibleTokensIncludingNEAR = (tokens, balance) => {
+    return [
+        {
+            balance,
+            symbol: 'NEAR'
+        },
+        ...Object.values(tokens)
+    ];
+};
+
+export const useFungibleTokensIncludingNEAR = function ({ fullBalance = true }) {
+    const balance = useSelector(selectBalance);
+    const tokens = useSelector(selectTokensDetails);
+
+    const availableNearBalance = balance?.available;
+    const totalNearBalance = balance?.total;
+    const availableNearToSend = getAvailableNearToSend(availableNearBalance, parseNearAmount(WALLET_APP_MIN_AMOUNT));
+
+    const balanceToDisplay = fullBalance ? totalNearBalance : availableNearToSend;
+    const [fungibleTokensList, setFungibleTokensList] = useState(
+        () => fungibleTokensIncludingNEAR(tokens, balanceToDisplay)
+    );
+
+    useEffect(() => {
+        setFungibleTokensList(fungibleTokensIncludingNEAR(tokens, balanceToDisplay));
+    }, [tokens, balanceToDisplay]);
+
+    return fungibleTokensList;
+};

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -1,5 +1,6 @@
 import reduceReducers from 'reduce-reducers';
 import { handleActions } from 'redux-actions';
+import { createSelector } from 'reselect';
 
 import {
     requestCode,
@@ -19,7 +20,7 @@ import {
     setAccountBalance,
     getAccountHelperWalletState
 } from '../../actions/account';
-import { 
+import {
     staking
 } from '../../actions/staking';
 
@@ -136,7 +137,7 @@ const account = handleActions({
         ...state,
         loginResetAccounts: true
     }),
-    [staking.updateAccount]: (state, { ready, error, payload }) => 
+    [staking.updateAccount]: (state, { ready, error, payload }) =>
         (!ready || error)
             ? state
             : ({
@@ -146,7 +147,7 @@ const account = handleActions({
                     account: payload
                 }
             }),
-    [staking.updateLockup]: (state, { ready, error, payload }) => 
+    [staking.updateLockup]: (state, { ready, error, payload }) =>
         (!ready || error)
             ? state
             : ({
@@ -156,7 +157,7 @@ const account = handleActions({
                     lockupAccount: payload
                 }
             }),
-    [getBalance]: (state, { error, payload, ready}) => 
+    [getBalance]: (state, { error, payload, ready }) =>
         (!ready || error)
             ? state
             : ({
@@ -176,7 +177,7 @@ const account = handleActions({
             accountId: payload
         }
     }),
-    [getAccountBalance]: (state, { error, payload, ready, meta }) => 
+    [getAccountBalance]: (state, { error, payload, ready, meta }) =>
         (!ready || error)
             ? {
                 ...state,
@@ -221,6 +222,6 @@ export default reduceReducers(
     ledgerKey
 );
 
-export const selectAccountId = state => state.account.accountId;
-
-export const selectBalance = state => state.account.balance;
+export const selectAccount = (state) => state.account;
+export const selectAccountId = createSelector(selectAccount, (account) => account.accountId);
+export const selectBalance = createSelector(selectAccount, (account) => account.balance);

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -13,7 +13,7 @@ import {
     get2faMethod,
     getLedgerKey,
     getBalance,
-    selectAccount,
+    makeAccountActive,
     setLocalStorage,
     getAccountBalance,
     setAccountBalance,
@@ -166,7 +166,7 @@ const account = handleActions({
                     ...payload
                 }
             }),
-    [selectAccount]: () => {
+    [makeAccountActive]: () => {
         return initialState;
     },
     [setLocalStorage]: (state, { payload }) => ({

--- a/src/reducers/sign.js
+++ b/src/reducers/sign.js
@@ -2,7 +2,7 @@ import BN from 'bn.js';
 import { utils, transactions as transaction } from 'near-api-js';
 import { handleActions } from 'redux-actions';
 
-import { parseTransactionsToSign, signAndSendTransactions, setSignTransactionStatus, selectAccount } from '../actions/account';
+import { parseTransactionsToSign, signAndSendTransactions, setSignTransactionStatus, makeAccountActive } from '../actions/account';
 
 const initialState = {
     status: 'needs-confirmation'
@@ -64,7 +64,7 @@ const sign = handleActions({
             status: payload.status
         };
     },
-    [selectAccount]: () => {
+    [makeAccountActive]: () => {
         return initialState;
     }
 }, initialState);

--- a/src/reducers/status/index.js
+++ b/src/reducers/status/index.js
@@ -1,7 +1,7 @@
 import reduceReducers from 'reduce-reducers';
 import { handleActions } from 'redux-actions';
 
-import { selectAccount } from '../../actions/account';
+import { makeAccountActive } from '../../actions/account';
 import {
     clearLocalAlert,
     clearGlobalAlert,
@@ -104,7 +104,7 @@ const clearReducer = handleActions({
                     : undefined)
             }), {})
     }),
-    [selectAccount]: () => {
+    [makeAccountActive]: () => {
         return initialState;
     }
 }, initialState);

--- a/src/reducers/transactions/index.js
+++ b/src/reducers/transactions/index.js
@@ -1,6 +1,6 @@
 import { handleActions } from 'redux-actions';
 
-import { selectAccount } from '../../actions/account';
+import { makeAccountActive } from '../../actions/account';
 import {
     getTransactions,
     getTransactionStatus
@@ -51,7 +51,7 @@ const transactions = handleActions({
                 : t
         ))
     }),
-    [selectAccount]: () => {
+    [makeAccountActive]: () => {
         return initialState;
     }
 }, initialState);

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -766,8 +766,10 @@
 
     "wallet": {
         "balanceTitle": "NEAR Balance",
+        "totalBalanceTitle": "Total NEAR Balance",
         "tokens": "Tokens",
         "balance": "Balance",
+        "totalBalance": "Total Balance",
         "dateAndTime": "Date & Time",
         "status": "Status",
         "balances": "Balances",

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -13,7 +13,7 @@ import {
     showLedgerModal,
     redirectTo,
     finishAccountSetup,
-    selectAccount
+    makeAccountActive
 } from '../actions/account';
 import FungibleTokens from '../services/FungibleTokens';
 import sendJson from '../tmp_fetch_send_json';
@@ -197,7 +197,7 @@ class Wallet {
                         break;
                     }
                 }
-                store.dispatch(selectAccount(nextAccountId));
+                store.dispatch(makeAccountActive(nextAccountId));
 
                 // TODO: Make sure "problem creating" only shows for actual creation
                 return {
@@ -370,7 +370,7 @@ class Wallet {
             });
         }
 
-        await this.saveAndSelectAccount(accountId);
+        await this.saveAndMakeAccountActive(accountId);
         await this.addLocalKeyAndFinishSetup(accountId, recoveryMethod, publicKey, previousAccountId);
     }
 
@@ -456,7 +456,7 @@ class Wallet {
         this.accounts[accountId] = true;
     }
 
-    selectAccount(accountId) {
+    makeAccountActive(accountId) {
         if (!(accountId in this.accounts)) {
             return false;
         }
@@ -465,9 +465,9 @@ class Wallet {
         this.save();
     }
 
-    async saveAndSelectAccount(accountId, keyPair) {
+    async saveAndMakeAccountActive(accountId, keyPair) {
         await this.saveAccount(accountId, keyPair);
-        this.selectAccount(accountId);
+        this.makeAccountActive(accountId);
         // TODO: What does setAccountConfirmed do?
         setAccountConfirmed(this.accountId, false);
     }
@@ -624,7 +624,7 @@ class Wallet {
             await this.saveAccount(accountId);
         }));
 
-        store.dispatch(selectAccount(accountIds[accountIds.length - 1]));
+        store.dispatch(makeAccountActive(accountIds[accountIds.length - 1]));
 
         return {
             numberOfAccounts: accountIds.length
@@ -772,7 +772,7 @@ class Wallet {
                     await this.saveAccount(accountId, newKeyPair);
                 } catch (error) {
                     if (previousAccountId) {
-                        await wallet.saveAndSelectAccount(previousAccountId);
+                        await wallet.saveAndMakeAccountActive(previousAccountId);
                     }
                     throw new WalletError(error, 'addAccessKey.error');
                 }
@@ -920,7 +920,7 @@ class Wallet {
                 await this.saveAccount(accountId, newKeyPair);
             }));
 
-            store.dispatch(selectAccount(accountIdsSuccess[accountIdsSuccess.length - 1].accountId));
+            store.dispatch(makeAccountActive(accountIdsSuccess[accountIdsSuccess.length - 1].accountId));
 
             return {
                 numberOfAccounts: accountIdsSuccess.length,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12233,6 +12233,11 @@ reselect@^3.0.1:
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
   integrity sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc=
 
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"


### PR DESCRIPTION
1. Adds a row for NEAR tokens to the main `tokens` list on the dashboard page
- The `balance` value here will be the _total_ balance (same as we show in large text at the top of the dashboard)
- `Sendable balance` in the token selection list inside of the `send` flow remains un-changed
- This is facilitated via the `useFungibleTokensIncludingNear` hook. In the future we should probably get NEAR _into the tokens reducer_, but that was not in-scope for shipping today! :)

2. Fixed our account input field constantly throwing errors to the console during normal operation
- If I type slower than 500ms between each key, I was generating un-caught errors for _every single keystroke_ up until I finished typing `.near` on the end of the account name
 Now we won't be sending thousands and thousands of Sentry alerts just because someone is typing an account ID slowly! :)

3. Added `reselect` to official package dependencies (it was previously only in our bundle due to `react-localize-redux` using it
- Added a selector for `selectAccount` which simply returns our `account` state slice.
- Used `createSelector` for `selectAccountId`, `selectAccountBalance` which compose on top of the base `selectAccount` selector

4. Renamed `selectAccount` action to `makeAccountActive` because that's what it was really doing; it was named based on the fact that you _selected_ the new account to make active from a drop-down box, but it didn't really represent selecting an account from the redux state perspective and since selectors are named `selectXXXXX`, it conflicted with the `selectAccount` action.