### PR TITLE
Add `isMaxAmount` to handle edge cases around sending the entire balance of a token

### DIFF
--- a/src/components/send/SendContainerV2.js
+++ b/src/components/send/SendContainerV2.js
@@ -222,7 +222,7 @@ const SendContainerV2 = ({
                     }}
                     amount={getRawAmount()}
                     selectedToken={selectedToken}
-                    onClickContinue={() => handleSendToken(getRawAmount(), receiverId, selectedToken.contractName)}
+                    onClickContinue={() => handleSendToken(isMaxAmount ? selectedToken.balance : getRawAmount(), receiverId, selectedToken.contractName)}
                     senderId={accountId}
                     receiverId={receiverId}
                     estimatedFeesInNear={estimatedTotalFees}

--- a/src/components/send/SendContainerWrapper.js
+++ b/src/components/send/SendContainerWrapper.js
@@ -42,7 +42,7 @@ export function SendContainerWrapper({ match }) {
             availableNearBalance={availableNearBalance}
             reservedNearForFees={reservedNearForFees}
             redirectTo={path => dispatch(redirectTo(path))}
-            checkAccountAvailable={accountId => dispatch(checkAccountAvailable(accountId)).catch(() => null)}
+            checkAccountAvailable={accountId => dispatch(checkAccountAvailable(accountId))}
             parseNearAmount={parseNearAmount}
             formatNearAmount={formatNearAmount}
             fungibleTokens={fungibleTokensList}

--- a/src/components/send/components/InputAccountId.js
+++ b/src/components/send/components/InputAccountId.js
@@ -126,7 +126,7 @@ class InputAccountId extends Component {
     }
 
     handleChangeAccountId = ({ userValue, el }) => {
-        const { handleChange, localAlert, clearLocalAlert } = this.props;
+        const { handleChange, localAlert, clearLocalAlert, setAccountIdIsValid } = this.props;
         const { wrongChar } = this.state;
         const pattern = /[^a-zA-Z0-9._-]/;
 
@@ -140,6 +140,7 @@ class InputAccountId extends Component {
             } else {
                 this.setState({ wrongChar: true });
             }
+            setAccountIdIsValid(false);
             return;
         } else {
             this.setState({ wrongChar: false });
@@ -158,7 +159,7 @@ class InputAccountId extends Component {
     isImplicitAccount = (accountId) => accountId.length === 64 && !accountId.includes('.')
 
     handleCheckAvailability = async (accountId) => {
-        const { checkAvailability, clearLocalAlert } = this.props;
+        const { checkAvailability, clearLocalAlert, setAccountIdIsValid } = this.props;
 
         if (!accountId) {
             return false;
@@ -166,12 +167,16 @@ class InputAccountId extends Component {
 
         try {
             await checkAvailability(accountId);
+            setAccountIdIsValid(true);
         } catch(e) {
             if (this.isImplicitAccount(accountId) && e.toString().includes('does not exist while viewing')) {
                 console.warn(`${accountId} does not exist. Assuming this is an implicit Account ID.`);
                 clearLocalAlert();
+                setAccountIdIsValid(true);
                 return;
             }
+            setAccountIdIsValid(false);
+
         }
     }
 

--- a/src/components/send/components/InputAccountId.js
+++ b/src/components/send/components/InputAccountId.js
@@ -137,10 +137,11 @@ class InputAccountId extends Component {
                 el.style.animation = 'none';
                 void el.offsetHeight;
                 el.style.animation = null;
+                setAccountIdIsValid(true);
             } else {
+                setAccountIdIsValid(false);
                 this.setState({ wrongChar: true });
             }
-            setAccountIdIsValid(false);
             return;
         } else {
             this.setState({ wrongChar: false });
@@ -162,6 +163,7 @@ class InputAccountId extends Component {
         const { checkAvailability, clearLocalAlert, setAccountIdIsValid } = this.props;
 
         if (!accountId) {
+            setAccountIdIsValid(false);
             return false;
         }
 
@@ -176,7 +178,6 @@ class InputAccountId extends Component {
                 return;
             }
             setAccountIdIsValid(false);
-
         }
     }
 

--- a/src/components/send/components/InputAccountId.js
+++ b/src/components/send/components/InputAccountId.js
@@ -172,7 +172,6 @@ class InputAccountId extends Component {
                 clearLocalAlert();
                 return;
             }
-            throw e;
         }
     }
 

--- a/src/components/send/components/ReceiverInputWithLabel.js
+++ b/src/components/send/components/ReceiverInputWithLabel.js
@@ -50,6 +50,7 @@ const ReceiverInputWithLabel = ({
     checkAccountAvailable,
     localAlert,
     clearLocalAlert,
+    setAccountIdIsValid,
     autoFocus
 }) => {
 
@@ -74,6 +75,7 @@ const ReceiverInputWithLabel = ({
                 autoFocus={!receiverId && autoFocus}
                 success={success}
                 problem={problem}
+                setAccountIdIsValid={setAccountIdIsValid}
             />  
         </StyledContainer>
     );

--- a/src/components/send/components/views/EnterReceiver.js
+++ b/src/components/send/components/views/EnterReceiver.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Translate } from 'react-localize-redux';
 import styled from 'styled-components';
 
@@ -27,7 +27,7 @@ const StyledContainer = styled.form`
     }
 `;
 
-const EnterReceiver = ({ 
+const EnterReceiver = ({
     onClickGoBack,
     onClickCancel,
     amount,
@@ -40,12 +40,10 @@ const EnterReceiver = ({
     onClickContinue,
     isMobile
 }) => {
-
-    const inputError = !localAlert?.success && localAlert?.show;
-    const continueAllowed = localAlert?.success && localAlert?.show;
+    const [ accountIdIsValid, setAccountIdIsValid] = useState(false);
 
     return (
-        <StyledContainer 
+        <StyledContainer
             className='buttons-bottom'
             onSubmit={(e) => {onClickContinue(e); e.preventDefault();}}
         >
@@ -65,8 +63,8 @@ const EnterReceiver = ({
                 checkAccountAvailable={checkAccountAvailable}
                 localAlert={localAlert}
                 clearLocalAlert={clearLocalAlert}
-                inputError={inputError}
                 autoFocus={!isMobile}
+                setAccountIdIsValid={setAccountIdIsValid}
             />
             <div className='input-sub-label'>
                 <Translate id='input.accountId.subLabel'/>
@@ -75,7 +73,7 @@ const EnterReceiver = ({
                 {/* TODO: Add error state */}
                 <FormButton
                     type='submit'
-                    disabled={!continueAllowed}
+                    disabled={!accountIdIsValid}
                 >
                     <Translate id='button.continue'/>
                 </FormButton>


### PR DESCRIPTION
Per the title, since we round up for displaying the amount to the user, we need to handle this case specially in two ways:
1. To avoid validation failing because the amount we show the user is technically more than the amount of available balance
2. To ensure that we do send the _entire_ balance when someone actually submits the transaction and we don't leave token dust behind :)