### PR TITLE
Ensure that current account state is used when calling fungibleTokensService.transfer()

### DIFF
--- a/src/actions/nft.js
+++ b/src/actions/nft.js
@@ -34,7 +34,6 @@ async function getLikelyContracts(accountId) {
 async function getMetadata(contractName, accountId) {
     const account = new Account(wallet.connection, accountId);
     const metadata = await account.viewFunction(contractName, 'nft_metadata');
-    console.log('metadata', metadata);
     return { metadata, contractName };
 }
 
@@ -43,7 +42,6 @@ async function getTokens(contractName, accountId, { base_uri }) {
     let tokens;
     try {
         const tokenIds = await account.viewFunction(contractName, 'nft_tokens_for_owner_set', { account_id: accountId });
-        console.log('tokenIds', tokenIds);
         tokens = await Promise.all(tokenIds.map(async token_id => {
             let metadata = await account.viewFunction(contractName, 'nft_token_metadata', { token_id: token_id.toString() });
             let { media, reference } = metadata;
@@ -64,7 +62,6 @@ async function getTokens(contractName, accountId, { base_uri }) {
         // TODO: Pagination
         tokens = await account.viewFunction(contractName, 'nft_tokens_for_owner', { account_id: accountId, from_index: "0", limit: 50 });
     }
-    console.log('tokens', tokens);
     // TODO: Separate Redux action for loading image
     tokens = await Promise.all(tokens.filter(({ metadata }) => !!metadata).map(async ({ metadata, ...token }) => {
         const { media } = metadata;
@@ -87,7 +84,6 @@ async function getTokens(contractName, accountId, { base_uri }) {
             }
         };
     }));
-    console.log('tokens map', tokens);
 
     return { contractName, tokens };
 }

--- a/src/services/FungibleTokens.js
+++ b/src/services/FungibleTokens.js
@@ -95,7 +95,7 @@ export default class FungibleTokens {
     }
 
     async isStorageBalanceAvailable({ contractName, accountId }) {
-        const storageBalance = await FungibleTokens.getStorageBalance({ contractName, accountId });
+        const storageBalance = await this.constructor.getStorageBalance({ contractName, accountId });
         return storageBalance?.total !== undefined;
     }
 

--- a/src/services/FungibleTokens.js
+++ b/src/services/FungibleTokens.js
@@ -42,6 +42,9 @@ const FT_TRANSFER_DEPOSIT = '1';
 // Fungible Token Standard
 // https://github.com/near/NEPs/tree/master/specs/Standards/FungibleToken
 export default class FungibleTokens {
+    // View functions are not signed, so do not require a real account!
+    static viewFunctionAccount = wallet.getAccountBasic('dontcare')
+
     static getParsedTokenAmount(amount, symbol, decimals) {
         const parsedTokenAmount = symbol === 'NEAR'
             ? parseNearAmount(amount)
@@ -58,12 +61,24 @@ export default class FungibleTokens {
         return formattedTokenAmount;
     }
 
-    constructor(account) {
-        this.account = account;
+    static async getLikelyTokenContracts({ accountId }) {
+        return sendJson('GET', `${ACCOUNT_HELPER_URL}/account/${accountId}/likelyTokens`);
     }
 
-    async getEstimatedTotalFees(contractName, accountId) {
-        if (contractName && accountId && !await this.isStorageBalanceAvailable(contractName, accountId)) {
+    static async getStorageBalance({ contractName, accountId }) {
+        return await this.viewFunctionAccount.viewFunction(contractName, 'storage_balance_of', { account_id: accountId });
+    }
+
+    static async getMetadata({ contractName }) {
+        return this.viewFunctionAccount.viewFunction(contractName, 'ft_metadata');
+    }
+
+    static async getBalanceOf({ contractName, accountId }) {
+        return this.viewFunctionAccount.viewFunction(contractName, 'ft_balance_of', { account_id: accountId });
+    }
+
+    async getEstimatedTotalFees({ accountId, contractName } = {}) {
+        if (contractName && accountId && !await this.isStorageBalanceAvailable({ contractName, accountId })) {
             return new BN(FT_TRANSFER_GAS)
                 .add(new BN(FT_MINIMUM_STORAGE_BALANCE))
                 .add(new BN(FT_STORAGE_DEPOSIT_GAS))
@@ -73,72 +88,69 @@ export default class FungibleTokens {
         }
     }
 
-    async getEstimatedTotalNearAmount(amount) {
+    async getEstimatedTotalNearAmount({ amount }) {
         return new BN(amount)
             .add(new BN(await this.getEstimatedTotalFees()))
             .toString();
     }
 
-    async isStorageBalanceAvailable(contractName, accountId) {
-        const storageBalance = await this.getStorageBalance(contractName, accountId);
+    async isStorageBalanceAvailable({ contractName, accountId }) {
+        const storageBalance = await FungibleTokens.getStorageBalance({ contractName, accountId });
         return storageBalance?.total !== undefined;
     }
 
-    async getStorageBalance(contractName, accountId) {
-        return await this.account.viewFunction(contractName, 'storage_balance_of', { account_id: accountId });
-    }
+    async transfer({ accountId, contractName, amount, receiverId, memo }) {
+        // Ensure our awareness of 2FA being enabled is accurate before we submit any transaction(s)
+        const account = await wallet.getAccount(accountId);
 
-    async transfer({ contractName, amount, receiverId, memo }) {
         if (contractName) {
-            const storageAvailable = await this.isStorageBalanceAvailable(contractName, receiverId);
+            const storageAvailable = await this.isStorageBalanceAvailable({ contractName, accountId: receiverId });
 
             if (!storageAvailable) {
                 try {
-                    await this.transferStorageDeposit(contractName, receiverId, FT_MINIMUM_STORAGE_BALANCE);
+                    await this.transferStorageDeposit({
+                        account,
+                        contractName,
+                        receiverId,
+                        storageDepositAmount: FT_MINIMUM_STORAGE_BALANCE
+                    });
                 } catch (e) {
                     // sic.typo in `mimimum` wording of responses, so we check substring
                     // Original string was: 'attached deposit is less than the mimimum storage balance'
                     if (e.message.includes('attached deposit is less than')) {
-                        await this.transferStorageDeposit(contractName, receiverId, FT_MINIMUM_STORAGE_BALANCE_LARGE);
+                        await this.transferStorageDeposit({
+                            account,
+                            contractName,
+                            receiverId,
+                            storageDepositAmount: FT_MINIMUM_STORAGE_BALANCE_LARGE
+                        });
                     }
                 }
             }
 
-            return await this.signAndSendTransaction(contractName, [
+            return await account.signAndSendTransaction(contractName, [
                 functionCall('ft_transfer', {
                     amount,
                     memo: memo,
                     receiver_id: receiverId,
                 }, FT_TRANSFER_GAS, FT_TRANSFER_DEPOSIT)
             ]);
-
         } else {
-            return await wallet.sendMoney(receiverId, amount);
+            return await account.sendMoney(receiverId, amount);
         }
     }
 
-    async transferStorageDeposit(contractName, accountId, storageDepositAmount) {
-        return this.signAndSendTransaction(contractName, [
-            functionCall('storage_deposit', {
-                account_id: accountId,
-                registration_only: true,
-            }, FT_STORAGE_DEPOSIT_GAS, storageDepositAmount)
-        ]);
-    }
-
-    async signAndSendTransaction(receiverId, actions) {
-        return await this.account.signAndSendTransaction(receiverId, actions);
-    }
-
-    getLikelyTokenContracts() {
-        return sendJson('GET', `${ACCOUNT_HELPER_URL}/account/${this.account.accountId}/likelyTokens`);
-    }
-
-    async getMetadata(contractName) {
-        return await this.account.viewFunction(contractName, 'ft_metadata');
-    }
-
-    async getBalanceOf(contractName) {
-        return await this.account.viewFunction(contractName, 'ft_balance_of', { account_id: this.account.accountId });
+    async transferStorageDeposit({ account, contractName, receiverId, storageDepositAmount }) {
+        return account.signAndSendTransaction(
+            contractName,
+            [
+                functionCall('storage_deposit', {
+                    account_id: receiverId,
+                    registration_only: true,
+                }, FT_STORAGE_DEPOSIT_GAS, storageDepositAmount)
+            ]
+        );
     }
 }
+
+export const fungibleTokensService = new FungibleTokens();

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -163,7 +163,7 @@ class Wallet {
         return ACCOUNT_ID_REGEX.test(accountId);
     }
 
-    async sendMoney({ account, receiverId, amount }) {
+    async sendMoney(receiverId, amount) {
         return (await this.getAccount(this.accountId)).sendMoney(receiverId, amount);
     }
 

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -15,7 +15,6 @@ import {
     finishAccountSetup,
     makeAccountActive
 } from '../actions/account';
-import FungibleTokens from '../services/FungibleTokens';
 import sendJson from '../tmp_fetch_send_json';
 import { decorateWithLockup } from './account-with-lockup';
 import { getAccountIds } from './helper-api';
@@ -129,10 +128,6 @@ class Wallet {
         this.accountId = localStorage.getItem(KEY_ACTIVE_ACCOUNT_ID) || '';
     }
 
-    createFungibleTokensInstance(account) {
-        this.fungibleTokens = new FungibleTokens(account);
-    }
-
     async getLocalAccessKey(accountId, accessKeys) {
         const localPublicKey = await this.inMemorySigner.getPublicKey(accountId, NETWORK_ID);
         return localPublicKey && accessKeys.find(({ public_key }) => public_key === localPublicKey.toString());
@@ -168,7 +163,7 @@ class Wallet {
         return ACCOUNT_ID_REGEX.test(accountId);
     }
 
-    async sendMoney(receiverId, amount) {
+    async sendMoney({ account, receiverId, amount }) {
         return (await this.getAccount(this.accountId)).sendMoney(receiverId, amount);
     }
 
@@ -226,7 +221,6 @@ class Wallet {
             const ledgerKey = accessKeys.find(key => key.meta.type === 'ledger');
             const account = await this.getAccount(this.accountId, limitedAccountData);
             const state = await account.state();
-            this.createFungibleTokensInstance(account);
 
             return {
                 ...state,


### PR DESCRIPTION
1. Refactored fungibleTokensService to no longer have a `this.account` property that we needed to keep in sync with the rest of the wallet UI/systems
- removed fungibleTokensService.signAndSendTransaction() function since it was superfluous post-refactor
2. Moved some methods to be static methods on the FungibleTokens class since they are purely viewFunction calls
- Using a statically created account object for `viewFunction` calls since they aren't actually signed
3. Removed spammy and not useful console.logs inside the `nft` actions redux thunk
4. Removed fungibleTokensService from the wallet object; it gained nothing from being present there as it is now a stateless singleton that can be imported and used wherever we want