### PR TITLE
Fix `zh` translation of `notSupportedPhone`

### DIFF
--- a/src/translations/zh-hans.global.json
+++ b/src/translations/zh-hans.global.json
@@ -700,7 +700,7 @@
         "phoneTitle": "手机短信方式",
         "phoneDesc": "请输入你的手机号以接收恢复链接。",
         "phonePlaceholder": "+1 415 797 8554",
-        "notSupportedPhone": "抱歉，目前我们还为你所在的地区开放短信恢复方式。请选择 Email 方式。",
+        "notSupportedPhone": "抱歉，目前我们暂未对你所在的地区开放短信恢复方式。请选择 Email 方式。",
         "advancedSecurity": "高级安全",
         "advancedSecurityDesc": "记录 12 个单词组成的助记词，并安全保存。",
         "ledgerTitle": "Ledger 硬件钱包",

--- a/src/translations/zh-hant.global.json
+++ b/src/translations/zh-hant.global.json
@@ -700,7 +700,7 @@
         "phoneTitle": "手機短信方式",
         "phoneDesc": "請輸入你的手機號以接收恢復鏈接。",
         "phonePlaceholder": "+1 415 797 8554",
-        "notSupportedPhone": "抱歉，目前我們還為你所在的地區開放短信恢復方式。請選擇 Email 方式。",
+        "notSupportedPhone": "抱歉，目前我們暫未對你所在的地區開放短信恢復方式。請選擇 Email 方式。",
         "advancedSecurity": "高級安全",
         "advancedSecurityDesc": "記錄 12 個單詞組成的助記詞，並安全保存。",
         "ledgerTitle": "Ledger 硬件錢包",


### PR DESCRIPTION
### Description

We found one translation issue of the `notSupportedPhone` message, when user tries to import account with SMS. 

Here we'd like to fix the issue. 