### PR TITLE
Add i18n support of Zendesk FAQ URLs

### DIFF
--- a/src/components/common/GlobalAlert.js
+++ b/src/components/common/GlobalAlert.js
@@ -179,7 +179,7 @@ const GlobalAlertNew = ({ globalAlert, actionStatus, clearGlobalAlert, closeIcon
 
     const [closing, setClosing] = useState(false);
     const [alerts, setAlerts] = useState([]);
-    const zendeskBaseURL = 'https://nearhelp.zendesk.com/hc/en-us/';
+    const zendeskBaseURL = 'https://nearhelp.zendesk.com/hc/';
 
     const handleClose = (type) => {
         setClosing(type);


### PR DESCRIPTION
Resolves: #1974

An easy fix to just remove the `en-us` i18n route. 
Zendesk pages will automatically redirect user to the English or Chinese pages based on their browser languages. 