### PR TITLE
Fix Firefox glitch where selected language is partially visible behind Language Switch

### DIFF
--- a/src/components/navigation/DesktopContainer.js
+++ b/src/components/navigation/DesktopContainer.js
@@ -78,6 +78,7 @@ const Lang = styled.div`
         user-select: none;
         width: 54px;
         z-index: 1;
+        text-indent: 54px;
 
         &::-ms-expand {
             display: none;

--- a/src/components/navigation/MobileContainer.js
+++ b/src/components/navigation/MobileContainer.js
@@ -145,6 +145,7 @@ const Lang = styled.div`
         position: relative;
         width: 100%;
         z-index: 1;
+        text-indent: 54px;
     }
 
     &.mobile-lang .lang-selector  {


### PR DESCRIPTION
Fixes #1929 

Basically indent the text so that its hidden behind the css `background-image`

This fixes the issue on Desktop and also for Mobile only when `showNavLinks` is `false`.

This has no effect on Mobile when `showNavLinks` is `true` since a more specific `text-indent` will override