### PR TITLE
Recover account: clear previous account state after recovery

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -566,8 +566,12 @@ export const refreshAccount = (basicData = false) => async (dispatch, getState) 
 export const switchAccount = (accountId) => async (dispatch, getState) => {
     dispatch(makeAccountActive(accountId));
     dispatch(handleRefreshUrl());
-    dispatch(staking.clearState());
     dispatch(refreshAccount());
+    dispatch(clearAccountState());
+};
+
+export const clearAccountState = () => async (dispatch, getState) => {
+    dispatch(staking.clearState());
     dispatch(tokens.clearState());
     dispatch(nftSlice.actions.clearState());
 };

--- a/src/components/accounts/RecoverAccountSeedPhrase.js
+++ b/src/components/accounts/RecoverAccountSeedPhrase.js
@@ -5,8 +5,13 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { recoverAccountSeedPhrase, redirectToApp, redirectTo, refreshAccount } from '../../actions/account';
-import { staking } from '../../actions/staking';
+import {
+    recoverAccountSeedPhrase,
+    redirectToApp,
+    redirectTo,
+    refreshAccount,
+    clearAccountState
+} from '../../actions/account';
 import { clearLocalAlert } from '../../actions/status';
 import { Mixpanel } from '../../mixpanel/index';
 import parseFundingOptions from '../../utils/parseFundingOptions';
@@ -80,7 +85,7 @@ class RecoverAccountSeedPhrase extends Component {
         } else {
             this.props.redirectToApp('/');
         }
-        this.props.clearState();
+        this.props.clearAccountState();
     }
 
     render() {
@@ -111,7 +116,7 @@ const mapDispatchToProps = {
     redirectToApp,
     refreshAccount,
     clearLocalAlert,
-    clearState: staking.clearState
+    clearAccountState
 };
 
 const mapStateToProps = ({ account, status, router }, { match }) => ({

--- a/src/components/accounts/RecoverWithLink.js
+++ b/src/components/accounts/RecoverWithLink.js
@@ -8,6 +8,7 @@ import {
     recoverAccountSeedPhrase,
     refreshAccount,
     redirectTo,
+    clearAccountState
 } from '../../actions/account';
 import { Mixpanel } from '../../mixpanel/index';
 import { actionsPending } from '../../utils/alerts';
@@ -166,6 +167,7 @@ class RecoverWithLink extends Component {
                 await this.props.recoverAccountSeedPhrase(this.state.seedPhrase, this.props.match.params.accountId, false);
                 this.props.refreshAccount();
                 this.props.redirectTo('/');
+                this.props.clearAccountState();
             },
             () => {
                 this.setState({ successView: false });
@@ -236,7 +238,8 @@ class RecoverWithLink extends Component {
 const mapDispatchToProps = {
     recoverAccountSeedPhrase, 
     refreshAccount,
-    redirectTo
+    redirectTo,
+    clearAccountState
 };
 
 const mapStateToProps = ({ account, status }, { match }) => ({

--- a/src/components/accounts/ledger/SignInLedger.js
+++ b/src/components/accounts/ledger/SignInLedger.js
@@ -9,11 +9,10 @@ import {
     refreshAccount, 
     signInWithLedgerAddAndSaveAccounts, 
     checkAccountAvailable, 
-    clearSignInWithLedgerModalState
+    clearSignInWithLedgerModalState,
+    clearAccountState
 } from '../../../actions/account';
-import { staking } from '../../../actions/staking';
 import { clearLocalAlert } from '../../../actions/status';
-import { tokens } from '../../../actions/tokens';
 import { Mixpanel } from '../../../mixpanel/index';
 import { controller as controllerHelperApi } from '../../../utils/helper-api';
 import parseFundingOptions from '../../../utils/parseFundingOptions';
@@ -84,8 +83,7 @@ export function SignInLedger(props) {
         } else {
             dispatch(redirectToApp());
         }
-        dispatch(staking.clearState());
-        dispatch(tokens.clearState());
+        dispatch(clearAccountState());
     };
 
     const onClose = () => {


### PR DESCRIPTION
This fixes issue with NFTs, FTs, or/and staking data lingering after the user recovers a new account.