### PR TITLE
Linkdrops: remove support for automatic redirect from /create to /linkdrop

### DIFF
--- a/src/components/accounts/CreateAccount.js
+++ b/src/components/accounts/CreateAccount.js
@@ -115,16 +115,10 @@ class CreateAccount extends Component {
     }
 
     componentDidMount() {
-        const { fundingContract, fundingKey, history, redirectTo } = this.props;
-        const params = new URLSearchParams(history.location.search);
+        const { fundingContract, fundingKey } = this.props;
 
         if (fundingContract && fundingKey) {
-            if (params.get('redirect') === 'false') {
-                this.handleCheckNearDropBalance();
-            } else {
-                const redirectUrl = params.has('redirectUrl') ? `?redirectUrl=${encodeURIComponent(params.get('redirectUrl'))}` : '';
-                redirectTo(`/linkdrop/${fundingContract}/${fundingKey}${redirectUrl}`);
-            }
+            this.handleCheckNearDropBalance();
         }
     }
 

--- a/src/components/accounts/LinkdropLanding.js
+++ b/src/components/accounts/LinkdropLanding.js
@@ -138,7 +138,7 @@ class LinkdropLanding extends Component {
                         </FormButton>
                     }
                     <div className='or'><Translate id='linkdropLanding.or'/></div>
-                    <FormButton color='gray-blue' disabled={claimingDrop} linkTo={`/create/${fundingContract}/${fundingKey}?redirect=false`}>
+                    <FormButton color='gray-blue' disabled={claimingDrop} linkTo={`/create/${fundingContract}/${fundingKey}`}>
                         <Translate id='linkdropLanding.ctaNew'/>
                     </FormButton>
                 </StyledContainer>


### PR DESCRIPTION
This removes the automatic redirect to `/linkdrop` for linkdrops that use the `/create` route. More context can be found [here](https://github.com/near/near-wallet/issues/1982#issuecomment-893769813).

Example behavior:

Linkdrop for when you want users to **always create a new account**:
`https://wallet.near.org/create/someFundingContract/someFundingKey`

Linkdrop for when you want users to be able to **choose between creating a new account, or claim to existing**:
`https://wallet.near.org/linkdrop/someFundingContract/someFundingKey`