### PR TITLE
USD value: fix conversion for >1k NEAR amount and add commas

### DIFF
--- a/src/components/common/balance/BalanceDisplayUSD.js
+++ b/src/components/common/balance/BalanceDisplayUSD.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { getRoundedBalanceInFiat } from './helpers';
+import { getRoundedBalanceInFiat, formatWithCommas } from './helpers';
 
 const BalanceDisplayUSD = ({
     amount,
@@ -23,7 +23,7 @@ const BalanceDisplayUSD = ({
                         {showSignUSD && <>$</>}
                     </>
                 }
-                {roundedBalanceInUSD}
+                {formatWithCommas(roundedBalanceInUSD)}
                 {showSymbolUSD && ` ${USDSymbol}`}
             </>
         );

--- a/src/components/common/balance/helpers.js
+++ b/src/components/common/balance/helpers.js
@@ -43,5 +43,5 @@ export const getNearAndFiatValue = (rawNearAmount, tokenFiatValue, fiat = 'usd')
     const fiatAmount = getRoundedBalanceInFiat(rawNearAmount, tokenFiatValue);
     const fiatSymbol = fiat.toUpperCase();
     const fiatPrefix = fiatAmount !== '< 0.01' ? '≈ ' : '';
-    return `${nearAmount} NEAR (${fiatPrefix}${fiatAmount || '—'} ${fiatSymbol})`;
+    return `${nearAmount} NEAR (${fiatPrefix}${formatWithCommas(fiatAmount) || '—'} ${fiatSymbol})`;
 };

--- a/src/components/common/balance/helpers.js
+++ b/src/components/common/balance/helpers.js
@@ -29,7 +29,7 @@ export const formatWithCommas = (value) => {
 };
 
 export const getRoundedBalanceInFiat = (rawNearAmount, tokenFiatValue) => {
-    const formattedNearAmount = rawNearAmount && formatNearAmount(rawNearAmount);
+    const formattedNearAmount = rawNearAmount && formatNearAmount(rawNearAmount).replace(/,/g, '');
     const balanceInFiat = Number(formattedNearAmount) * tokenFiatValue;
     const roundedBalanceInFiat = balanceInFiat && balanceInFiat.toFixed(2);
     if (roundedBalanceInFiat === '0.00' || formattedNearAmount === '< 0.00001') {


### PR DESCRIPTION
Fixes issue with converting NEAR amounts greater than 1,000 NEAR to USD

<img width="349" alt="Screen_Shot_2021-08-06_at_2 31 52_PM" src="https://user-images.githubusercontent.com/24921205/128574700-0ef7587c-f263-461d-903b-42a06d471d5c.png">
