### PR TITLE
Fix account switcher flex-box bugs

### DIFF
--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -13,8 +13,6 @@ const Wrapper = styled.div`
     }
 
     @media (min-width: 992px) {
-        display: flex;
-        flex-direction: column;
         max-height: 260px;
         overflow-y: auto;
 

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -85,10 +85,9 @@ const Account = styled.div`
     }
 `;
 
-const SyncButton = styled.button`
+const SyncButton = styled.span`
     background-color: #f8f8f8;
     border-radius: 50px;
-    border: 2px solid #f8f8f8;
     color: #0072ce;
     font-size: 12px;
     font-weight: 500;

--- a/src/components/navigation/UserAccounts.js
+++ b/src/components/navigation/UserAccounts.js
@@ -29,13 +29,13 @@ const Account = styled.div`
     border-radius: 8px;
     display: flex;
     justify-content: space-between;
-    text-overflow: ellipsis;
     color: #72727A;
     margin-bottom: 4px;
+    padding: 16px;
     cursor: pointer;
     font-weight: 500;
     position: relative;
-    
+
     .symbol {
         transform: scale(0.65);
         font-weight: 700;
@@ -66,21 +66,16 @@ const Account = styled.div`
     }
 
     .account-data {
-        display: flex;
-        flex: 1;
-        flex-direction: column;
-        padding: 16px 0 16px 16px;
-        overflow: hidden;
-        margin-right: 5px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin-right: 8px;
 
-        .accountId {
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-        }
-    }
-    .sync {
-        padding: 0 16px 0 0;
+      .accountId {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
     }
 
     .balance-wrapper {
@@ -90,7 +85,7 @@ const Account = styled.div`
     }
 `;
 
-const SyncButton = styled.span`
+const SyncButton = styled.button`
     background-color: #f8f8f8;
     border-radius: 50px;
     border: 2px solid #f8f8f8;
@@ -99,6 +94,8 @@ const SyncButton = styled.span`
     font-weight: 500;
     padding: 4px 8px;
     cursor: pointer;
+    flex-basis: content;
+    flex-shrink: 0;
 
     :hover, :active {
         background-color: #F0F0F1;
@@ -186,20 +183,18 @@ const UserAccount = ({ accountId, balance, balanceLoading, refreshBalance, activ
                 }
             </div>
         </div>
-        <div className='sync'>
-            <SyncButton 
-                className={classNames([{'dots': balanceLoading}])}
-                onClick={refreshBalance}
-                title='Sync balance'
-            >
-                {balance
-                    ? <Translate id='sync'/>
-                    : !balanceLoading
-                        ? <Translate id='getBalance'/>
-                        : ''
-                }
-            </SyncButton>
-        </div>
+        <SyncButton
+            className={classNames([{'dots': balanceLoading}])}
+            onClick={refreshBalance}
+            title='Sync balance'
+        >
+            {balance
+                ? <Translate id='sync'/>
+                : !balanceLoading
+                    ? <Translate id='getBalance'/>
+                    : ''
+            }
+        </SyncButton>
     </Account>
 );
 


### PR DESCRIPTION
@Patrick1904 @marcinbodnar I made some small changes to the CSS of the desktop dropdown as per Patrick's request to prevent some bugs that were being caused by the previous flex-box implementation. A couple things to note:

1. `Button` elements should be used for buttons. There's really no reason we should be using `span` or `div` for buttons. This contributes to unexpected behavior in conjunction with `flex` properties, and is also semantically incorrect. The `UserAccounts` component here uses a `span` for the "Sync" button. Unfortunately, simply changing this to a `button` element isn't feasible without further refactoring considering all the things that have been done to make the `span` respond to user input like a `button`. We will need to do this though, so if you find yourself working with this component in the near future and have some time, it would be great to clean it up in this way.

2. We should not be using `!important` in our CSS for the most part. When testing to see how the component would function with a regular `button` element, I noticed that using a standard `button` resulted in several other things breaking, due to the fact that all `button` elements across the App are inheriting a `width: 100%;` property with an `!important` flag. The use of `!important`, especially at the global level, has negative downstream effects and should be avoided. I see that it is being used quite liberally throughout our CSS, so this is something that we'll need to spend some time refactoring if we want to proceed without worrying about having to add unnecessary levels of specificity to counteract it.