### PR TITLE
Store linkdrop amount in Redux vs localStorage

### DIFF
--- a/packages/frontend/src/components/accounts/LinkdropLanding.js
+++ b/packages/frontend/src/components/accounts/LinkdropLanding.js
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { checkNearDropBalance, claimLinkdropToAccount, redirectTo, handleRefreshUrl } from '../../actions/account';
 import { clearLocalAlert } from '../../actions/status';
 import { Mixpanel } from '../../mixpanel/index';
+import { actions as linkdropActions } from '../../slices/linkdrop';
 import { actionsPending } from '../../utils/alerts';
 import AccountDropdown from '../common/AccountDropdown';
 import Balance from '../common/balance/Balance';
@@ -13,6 +14,8 @@ import FormButton from '../common/FormButton';
 import Container from '../common/styled/Container.css';
 import BrokenLinkIcon from '../svg/BrokenLinkIcon';
 import NearGiftIcons from '../svg/NearGiftIcons';
+
+const { setLinkdropAmount } = linkdropActions;
 
 const StyledContainer = styled(Container)`
     display: flex;
@@ -90,12 +93,12 @@ class LinkdropLanding extends Component {
     }
 
     handleClaimNearDrop = async () => {
-        const { fundingContract, fundingKey, redirectTo, claimLinkdropToAccount, accountId, url } = this.props;
+        const { fundingContract, fundingKey, redirectTo, claimLinkdropToAccount, accountId, url, setLinkdropAmount } = this.props;
         await claimLinkdropToAccount(fundingContract, fundingKey);
-        localStorage.setItem('linkdropAmount', this.state.balance);
         if (url?.redirectUrl) {
             window.location = `${url.redirectUrl}?accountId=${accountId}`;
         } else {
+            setLinkdropAmount(this.state.balance);
             redirectTo('/');
         }
     }
@@ -161,7 +164,8 @@ const mapDispatchToProps = {
     checkNearDropBalance,
     claimLinkdropToAccount,
     redirectTo,
-    handleRefreshUrl
+    handleRefreshUrl,
+    setLinkdropAmount
 };
 
 const mapStateToProps = ({ account, status }, { match }) => ({

--- a/packages/frontend/src/components/accounts/SetupSeedPhrase.js
+++ b/packages/frontend/src/components/accounts/SetupSeedPhrase.js
@@ -144,7 +144,7 @@ class SetupSeedPhrase extends Component {
         await Mixpanel.withTracking("SR-SP Setup for new account",
             async () => {
                 await handleCreateAccountWithSeedPhrase(accountId, recoveryKeyPair, fundingOptions, recaptchaToken);
-                if (fundingOptions) {
+                if (fundingOptions.fundingAmount) {
                     setLinkdropAmount(fundingOptions.fundingAmount);
                 }
             },

--- a/packages/frontend/src/components/accounts/ledger/SetupLedger.js
+++ b/packages/frontend/src/components/accounts/ledger/SetupLedger.js
@@ -14,6 +14,7 @@ import {
 } from '../../../actions/account';
 import { showCustomAlert } from '../../../actions/status';
 import { Mixpanel } from '../../../mixpanel/index';
+import { actions as linkdropActions } from '../../../slices/linkdrop';
 import parseFundingOptions from '../../../utils/parseFundingOptions';
 import { DISABLE_CREATE_ACCOUNT, setKeyMeta } from '../../../utils/wallet';
 import FormButton from '../../common/FormButton';
@@ -22,6 +23,8 @@ import Container from '../../common/styled/Container.css';
 import { isRetryableRecaptchaError, Recaptcha } from '../../Recaptcha';
 import LedgerIcon from '../../svg/LedgerIcon';
 import InstructionsModal from './InstructionsModal';
+
+const { setLinkdropAmount } = linkdropActions;
 
 // FIXME: Use `debug` npm package so we can keep some debug logging around but not spam the console everywhere
 const ENABLE_DEBUG_LOGGING = false;
@@ -80,6 +83,9 @@ const SetupLedger = (props) => {
                         }
 
                         await dispatch(createNewAccount(accountId, fundingOptions, 'ledger', publicKey, undefined, recaptchaToken));
+                        if (fundingOptions) {
+                            setLinkdropAmount(fundingOptions.fundingAmount);
+                        }
                         Mixpanel.track("SR-Ledger Create new account ledger");
                     } catch(err) {
                         if (isRetryableRecaptchaError(err)) {

--- a/packages/frontend/src/components/accounts/ledger/SetupLedger.js
+++ b/packages/frontend/src/components/accounts/ledger/SetupLedger.js
@@ -83,7 +83,7 @@ const SetupLedger = (props) => {
                         }
 
                         await dispatch(createNewAccount(accountId, fundingOptions, 'ledger', publicKey, undefined, recaptchaToken));
-                        if (fundingOptions) {
+                        if (fundingOptions.fundingAmount) {
                             setLinkdropAmount(fundingOptions.fundingAmount);
                         }
                         Mixpanel.track("SR-Ledger Create new account ledger");

--- a/packages/frontend/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
+++ b/packages/frontend/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 import * as accountActions from '../../../actions/account';
 import { showCustomAlert } from '../../../actions/status';
 import { Mixpanel } from '../../../mixpanel/index';
+import { actions as linkdropActions } from '../../../slices/linkdrop';
 import { validateEmail } from '../../../utils/account';
 import { actionsPending } from '../../../utils/alerts';
 import isApprovedCountryCode from '../../../utils/isApprovedCountryCode';
@@ -22,6 +23,8 @@ import EnterVerificationCode from '../EnterVerificationCode';
 import RecoveryOption from './RecoveryOption';
 
 import 'react-phone-number-input/style.css';
+
+const { setLinkdropAmount } = linkdropActions;
 
 const {
     initializeRecoveryMethod,
@@ -179,7 +182,8 @@ class SetupRecoveryMethod extends Component {
             createNewAccount,
             validateSecurityCode,
             saveAccount,
-            location
+            location,
+            setLinkdropAmount
         } = this.props;
       
         const fundingOptions = parseFundingOptions(location.search);
@@ -200,6 +204,9 @@ class SetupRecoveryMethod extends Component {
             try {
                 // NOT IMPLICIT ACCOUNT (testnet, linkdrop, funded to delegated account via contract helper)
                 await createNewAccount(accountId, fundingOptions, method, recoveryKeyPair.publicKey, undefined, recaptchaToken);
+                if (fundingOptions) {
+                    setLinkdropAmount(fundingOptions.fundingAmount);
+                }
             } catch (e) {
                 if (e.code === 'NotEnoughBalance') {
                     Mixpanel.track('SR NotEnoughBalance creating funded account');
@@ -451,7 +458,8 @@ const mapDispatchToProps = {
     fundCreateAccount,
     createNewAccount,
     saveAccount,
-    validateSecurityCode
+    validateSecurityCode,
+    setLinkdropAmount
 };
 
 const mapStateToProps = ({ account, router, recoveryMethods, status }, { match }) => ({

--- a/packages/frontend/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
+++ b/packages/frontend/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
@@ -204,7 +204,7 @@ class SetupRecoveryMethod extends Component {
             try {
                 // NOT IMPLICIT ACCOUNT (testnet, linkdrop, funded to delegated account via contract helper)
                 await createNewAccount(accountId, fundingOptions, method, recoveryKeyPair.publicKey, undefined, recaptchaToken);
-                if (fundingOptions) {
+                if (fundingOptions.fundingAmount) {
                     setLinkdropAmount(fundingOptions.fundingAmount);
                 }
             } catch (e) {

--- a/packages/frontend/src/components/wallet/LinkDropSuccessModal.js
+++ b/packages/frontend/src/components/wallet/LinkDropSuccessModal.js
@@ -34,10 +34,11 @@ const Container = styled.div`
 `;
 
 const LinkDropSuccessModal = ({ onClose, linkdropAmount }) => {
+    const isOpen = linkdropAmount !== '0';
     return (
         <Modal
             id='near-drop-success-modal'
-            isOpen={linkdropAmount}
+            isOpen={isOpen}
             onClose={onClose}
             modalSize='sm'
             closeButton={true}

--- a/packages/frontend/src/components/wallet/LinkDropSuccessModal.js
+++ b/packages/frontend/src/components/wallet/LinkDropSuccessModal.js
@@ -33,11 +33,11 @@ const Container = styled.div`
 
 `;
 
-const LinkDropSuccessModal = ({ open, onClose, linkdropAmount }) => {
+const LinkDropSuccessModal = ({ onClose, linkdropAmount }) => {
     return (
         <Modal
             id='near-drop-success-modal'
-            isOpen={open}
+            isOpen={linkdropAmount}
             onClose={onClose}
             modalSize='sm'
             closeButton={true}

--- a/packages/frontend/src/components/wallet/Wallet.js
+++ b/packages/frontend/src/components/wallet/Wallet.js
@@ -11,6 +11,7 @@ import { Mixpanel } from "../../mixpanel/index";
 import { selectAccountId, selectBalance } from '../../reducers/account';
 import { selectTokensWithMetadataForAccountId, actions as nftActions } from '../../reducers/nft';
 import { selectTransactions } from '../../reducers/transactions';
+import { selectLinkdropAmount, actions as linkdropActions } from '../../slices/linkdrop';
 import { actionsPendingByPrefix } from '../../utils/alerts';
 import classNames from '../../utils/classNames';
 import { SHOW_NETWORK_BANNER } from '../../utils/wallet';
@@ -28,6 +29,7 @@ import NFTs from './NFTs';
 import Tokens from './Tokens';
 
 const { fetchNFTs } = nftActions;
+const { setLinkdropAmount } = linkdropActions;
 
 const StyledContainer = styled(Container)`
     @media (max-width: 991px) {
@@ -269,14 +271,12 @@ const StyledContainer = styled(Container)`
 
 export function Wallet({ tab, setTab }) {
     const [exploreApps, setExploreApps] = useState(null);
-    const [showLinkdropModal, setShowLinkdropModal] = useState(null);
     const accountId = useSelector(state => selectAccountId(state));
     const balance = useSelector(state => selectBalance(state));
     const transactions = useSelector(state => selectTransactions(state));
     const dispatch = useDispatch();
     const hideExploreApps = localStorage.getItem('hideExploreApps');
-    const linkdropAmount = localStorage.getItem('linkdropAmount');
-    const linkdropModal = linkdropAmount && showLinkdropModal !== false;
+    const linkdropAmount = useSelector(selectLinkdropAmount);
     const fungibleTokensList = useFungibleTokensIncludingNEAR({ fullBalance: true });
     const tokensLoader = actionsPendingByPrefix('TOKENS/') || !balance?.total;
 
@@ -288,7 +288,6 @@ export function Wallet({ tab, setTab }) {
             dispatch(getTransactions(accountId));
         }
     }, [accountId]);
-
 
     const sortedNFTs = useSelector((state) => selectTokensWithMetadataForAccountId(state, { accountId }));
 
@@ -308,8 +307,7 @@ export function Wallet({ tab, setTab }) {
     };
 
     const handleCloseLinkdropModal = () => {
-        localStorage.removeItem('linkdropAmount');
-        setShowLinkdropModal(false);
+        dispatch(setLinkdropAmount('0'));
         Mixpanel.track("Click dismiss NEAR drop success modal");
     };
 
@@ -322,17 +320,17 @@ export function Wallet({ tab, setTab }) {
                             className={classNames(['tab-balances', tab === 'collectibles' ? 'inactive' : ''])}
                             onClick={() => setTab('')}
                         >
-                            <Translate id='wallet.balances'/>
+                            <Translate id='wallet.balances' />
                         </div>
                         <div
                             className={classNames(['tab-collectibles', tab !== 'collectibles' ? 'inactive' : ''])}
                             onClick={() => setTab('collectibles')}
                         >
-                            <Translate id='wallet.collectibles'/>
+                            <Translate id='wallet.collectibles' />
                         </div>
                     </div>
                     {tab === 'collectibles'
-                        ? <NFTs tokens={sortedNFTs}/>
+                        ? <NFTs tokens={sortedNFTs} />
                         : <FungibleTokens
                             balance={balance}
                             tokensLoader={tokensLoader}
@@ -343,7 +341,7 @@ export function Wallet({ tab, setTab }) {
                 </div>
                 <div className='right'>
                     {!hideExploreApps && exploreApps !== false &&
-                    <ExploreApps onClick={handleHideExploreApps}/>
+                        <ExploreApps onClick={handleHideExploreApps} />
                     }
                     <Activities
                         transactions={transactions[accountId] || []}
@@ -353,12 +351,11 @@ export function Wallet({ tab, setTab }) {
                     />
                 </div>
             </div>
-            {linkdropModal &&
-            <LinkDropSuccessModal
-                onClose={handleCloseLinkdropModal}
-                open={linkdropModal}
-                linkdropAmount={linkdropAmount}
-            />
+            {linkdropAmount !== '0' &&
+                <LinkDropSuccessModal
+                    onClose={handleCloseLinkdropModal}
+                    linkdropAmount={linkdropAmount}
+                />
             }
         </StyledContainer>
     );
@@ -388,7 +385,7 @@ const FungibleTokens = ({ balance, tokensLoader, fungibleTokens }) => {
                     showSymbolUSD={false}
                     showSignUSD={true}
                 />
-                <Tooltip translate='availableBalanceInfo'/>
+                <Tooltip translate='availableBalanceInfo' />
             </div>
             <div className='buttons'>
                 <FormButton
@@ -397,9 +394,9 @@ const FungibleTokens = ({ balance, tokensLoader, fungibleTokens }) => {
                     trackingId='Click Send on Wallet page'
                 >
                     <div>
-                        <SendIcon/>
+                        <SendIcon />
                     </div>
-                    <Translate id='button.send'/>
+                    <Translate id='button.send' />
                 </FormButton>
                 <FormButton
                     color='dark-gray'
@@ -407,9 +404,9 @@ const FungibleTokens = ({ balance, tokensLoader, fungibleTokens }) => {
                     trackingId='Click Receive on Wallet page'
                 >
                     <div>
-                        <DownArrowIcon/>
+                        <DownArrowIcon />
                     </div>
-                    <Translate id='button.receive'/>
+                    <Translate id='button.receive' />
                 </FormButton>
                 <FormButton
                     color='dark-gray'
@@ -417,16 +414,16 @@ const FungibleTokens = ({ balance, tokensLoader, fungibleTokens }) => {
                     trackingId='Click Receive on Wallet page'
                 >
                     <div>
-                        <BuyIcon/>
+                        <BuyIcon />
                     </div>
-                    <Translate id='button.buy'/>
+                    <Translate id='button.buy' />
                 </FormButton>
             </div>
             <div className='sub-title tokens'>
-                <span className={classNames({ dots: tokensLoader })}><Translate id='wallet.yourPortfolio'/></span>
-                <span><Translate id='wallet.tokenBalance'/></span>
+                <span className={classNames({ dots: tokensLoader })}><Translate id='wallet.yourPortfolio' /></span>
+                <span><Translate id='wallet.tokenBalance' /></span>
             </div>
-            <Tokens tokens={fungibleTokens}/>
+            <Tokens tokens={fungibleTokens} />
         </>
     );
 };

--- a/packages/frontend/src/reducers/index.js
+++ b/packages/frontend/src/reducers/index.js
@@ -4,6 +4,7 @@ import { combineReducers } from 'redux';
 
 import allAccounts from '../reducers/allAccounts';
 import recoveryMethods from '../reducers/recoveryMethods';
+import linkdropSlice from '../slices/linkdrop';
 import tokenFiatValuesSlice from '../slices/tokenFiatValues';
 import account from './account';
 import availableAccounts from './available-accounts';
@@ -31,5 +32,6 @@ export default (history) => combineReducers({
     tokens,
     [nftSlice.name]: nftSlice.reducer,
     [tokenFiatValuesSlice.name]: tokenFiatValuesSlice.reducer,
+    [linkdropSlice.name]: linkdropSlice.reducer,
     router: connectRouter(history)
 });

--- a/packages/frontend/src/slices/linkdrop.js
+++ b/packages/frontend/src/slices/linkdrop.js
@@ -1,0 +1,28 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { createSelector } from 'reselect';
+
+const SLICE_NAME = 'linkdrop';
+
+const initialState = {
+    amount: '0'
+};
+
+const linkdropSlice = createSlice({
+    name: SLICE_NAME,
+    initialState,
+    reducers: {
+        setLinkdropAmount: (state, action) => {
+            state.amount = action.payload;
+        }
+    }
+});
+
+export default linkdropSlice;
+
+export const actions = {
+    ...linkdropSlice.actions
+};
+export const reducer = linkdropSlice.reducer;
+
+const selectLinkdropSlice = (state) => state[linkdropSlice.name];
+export const selectLinkdropAmount = createSelector(selectLinkdropSlice, ({ amount }) => amount);

--- a/packages/frontend/src/utils/wallet.js
+++ b/packages/frontend/src/utils/wallet.js
@@ -346,13 +346,10 @@ class Wallet {
     async createNewAccount(accountId, fundingOptions, recoveryMethod, publicKey, previousAccountId, recaptchaToken) {
         await this.checkNewAccount(accountId);
 
-        const { fundingContract, fundingKey, fundingAccountId, fundingAmount } = fundingOptions || {};
+        const { fundingContract, fundingKey, fundingAccountId } = fundingOptions || {};
         if (fundingContract && fundingKey) {
             await this.createNewAccountLinkdrop(accountId, fundingContract, fundingKey, publicKey);
             await this.keyStore.removeKey(NETWORK_ID, fundingContract);
-            if (fundingAmount) {
-                await localStorage.setItem('linkdropAmount', fundingAmount);
-            }
         } else if (fundingAccountId) {
             await this.createNewAccountFromAnother(accountId, fundingAccountId, publicKey);
         } else if (process.env.RECAPTCHA_CHALLENGE_API_KEY && recaptchaToken) {


### PR DESCRIPTION
Changes:
1. Store linkdrop amount in `Redux` vs `localStorage` since we do not want to persist the amount if the user navigates away from the Wallet (with a `redirectUrl` for example) post claiming the linkdrop.

Additional context here: https://github.com/near/near-wallet/issues/2013

A good place to create linkdrops for testnet: https://near-drop-testnet.onrender.com/