### PR TITLE
Recent activity: Adjust timestamp abbreviations

### DIFF
--- a/packages/frontend/src/components/wallet/ActivityBox.js
+++ b/packages/frontend/src/components/wallet/ActivityBox.js
@@ -224,15 +224,15 @@ const ActionTimeStamp = ({ timeStamp }) => {
         'ago': '',
         'years': 'y',
         'year': 'y',
-        'months': 'mos',
+        'months': 'mo',
         'month': 'mo',
         'weeks': 'w',
         'week': 'w',
         'days': 'd',
         'day': 'd',
-        'hours': 'hrs',
+        'hours': 'hr',
         'hour': 'hr',
-        'minutes': 'mins',
+        'minutes': 'min',
         'minute': 'min',
         'seconds': 's'
     };

--- a/packages/frontend/src/components/wallet/ActivityBox.js
+++ b/packages/frontend/src/components/wallet/ActivityBox.js
@@ -224,16 +224,16 @@ const ActionTimeStamp = ({ timeStamp }) => {
         'ago': '',
         'years': 'y',
         'year': 'y',
-        'months': 'm',
-        'month': 'm',
+        'months': 'mos',
+        'month': 'mo',
         'weeks': 'w',
         'week': 'w',
         'days': 'd',
         'day': 'd',
-        'hours': 'h',
-        'hour': 'h',
-        'minutes': 'm',
-        'minute': 'm',
+        'hours': 'hrs',
+        'hour': 'hr',
+        'minutes': 'mins',
+        'minute': 'min',
         'seconds': 's'
     };
 


### PR DESCRIPTION
We've received feedback from users that timestamps for minutes/months displayed under 'recent activity' on the dashboard are confusing.

Timestamps will now show: `s, min, hr, d, w, mo, y` (suggested by @corwinharrell).


