### PR TITLE
Ledger confirm TX message: Instruct user to confirm TX details on Ledger

### DIFF
--- a/packages/frontend/src/reducers/ledger/index.js
+++ b/packages/frontend/src/reducers/ledger/index.js
@@ -126,7 +126,7 @@ const ledgerActions = handleActions({
                 ...state.modal,
                 show: !state.signInWithLedgerStatus && payload.show,
                 action: payload.action,
-                textId: `ledgerSignTxModal.${payload.action}`
+                textId: 'ledgerSignTxModal.DEFAULT'
             },
             txSigned: undefined
         };

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -460,7 +460,8 @@
         "STAKE": "You will need to confirm staking on your Ledger",
         "UNSTAKE": "You will need to confirm unstaking on your Ledger",
         "WITHDRAW": "You will need to confirm withdrawal on your Ledger",
-        "DISABLE_LEDGER": "You will need to confirm public key details on your Ledger."
+        "DISABLE_LEDGER": "You will need to confirm public key details on your Ledger.",
+        "DEFAULT": "You will need to confirm the transaction details on your Ledger."
     },
 
     "button": {


### PR DESCRIPTION
Always show "You will need to confirm the transaction details on your Ledger." in the `LedgerConfirmActionModal` when asking user to confirm the TX. The component has been relying on proper translation strings for every action to be signed with the Ledger, and some actions have not had strings available (or translated), which has degraded the UX with a `no translation found...` or instructions in the wrong language.

In addition, the 'confirm instruction string' has only been a conclusion of the TX that needs to be signed, not listing the specific TX info that the user should expect to see and confirm on the Ledger.

Improvement opportunity: [**Show explicit list of TXs and all information**](https://github.com/near/near-wallet/issues/1898) that the user should expect to confirm on the Ledger device, not relying on translated strings, but raw data.