### PR TITLE
Token list display improvements

### DIFF
--- a/packages/frontend/src/components/wallet/ActivityBox.js
+++ b/packages/frontend/src/components/wallet/ActivityBox.js
@@ -44,27 +44,16 @@ const StyledContainer = styled.div`
         overflow: hidden;
         font-weight: 700;
         color: #24272a;
+        min-width: 0;
 
         > span {
             font-weight: normal;
             color: #A2A2A8;
-            max-width: 220px;
             overflow: hidden;
             display: block;
             text-overflow: ellipsis;
             white-space: nowrap;
-
-            @media (max-width: 991px) {
-                max-width: 350px;
-            }
-
-            @media (max-width: 500px) {
-                max-width: 220px;
-            }
-
-            @media (max-width: 355px) {
-                max-width: 150px;
-            }
+            margin-right: 20px;
 
             > span {
                 color: #3F4045;

--- a/packages/frontend/src/components/wallet/TokenAmount.js
+++ b/packages/frontend/src/components/wallet/TokenAmount.js
@@ -4,6 +4,12 @@ import { formatTokenAmount, removeTrailingZeros } from '../../utils/amounts';
 
 const FRAC_DIGITS = 5;
 
+const amountWithCommas = (amount) => {
+    var parts = amount.split('.');
+    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    return parts.join('.');
+};
+
 const formatToken = (amount, decimals) => {
     if (amount === '0') {
         return amount;
@@ -14,7 +20,7 @@ const formatToken = (amount, decimals) => {
     if (formattedAmount === `0.${'0'.repeat(FRAC_DIGITS)}`) {
         return `< ${!FRAC_DIGITS ? `0` : `0.${'0'.repeat((FRAC_DIGITS || 1) - 1)}1`}`;
     }
-    return removeTrailingZeros(formattedAmount).replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
+    return amountWithCommas(removeTrailingZeros(formattedAmount));
 };
 
 const showFullAmount = (amount, decimals, symbol) =>

--- a/packages/frontend/src/components/wallet/TokenAmount.js
+++ b/packages/frontend/src/components/wallet/TokenAmount.js
@@ -4,6 +4,12 @@ import { formatTokenAmount, removeTrailingZeros } from '../../utils/amounts';
 
 const FRAC_DIGITS = 5;
 
+const amountWithCommas = (amount) => {
+    var parts = amount.split('.');
+    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    return parts.join('.');
+};
+
 const formatToken = (amount, decimals) => {
     if (amount === '0') {
         return amount;
@@ -14,7 +20,7 @@ const formatToken = (amount, decimals) => {
     if (formattedAmount === `0.${'0'.repeat(FRAC_DIGITS)}`) {
         return `< ${!FRAC_DIGITS ? `0` : `0.${'0'.repeat((FRAC_DIGITS || 1) - 1)}1`}`;
     }
-    return removeTrailingZeros(formattedAmount);
+    return amountWithCommas(removeTrailingZeros(formattedAmount));
 };
 
 const showFullAmount = (amount, decimals, symbol) =>

--- a/packages/frontend/src/components/wallet/TokenAmount.js
+++ b/packages/frontend/src/components/wallet/TokenAmount.js
@@ -4,12 +4,6 @@ import { formatTokenAmount, removeTrailingZeros } from '../../utils/amounts';
 
 const FRAC_DIGITS = 5;
 
-const amountWithCommas = (amount) => {
-    var parts = amount.split('.');
-    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-    return parts.join('.');
-};
-
 const formatToken = (amount, decimals) => {
     if (amount === '0') {
         return amount;
@@ -20,7 +14,7 @@ const formatToken = (amount, decimals) => {
     if (formattedAmount === `0.${'0'.repeat(FRAC_DIGITS)}`) {
         return `< ${!FRAC_DIGITS ? `0` : `0.${'0'.repeat((FRAC_DIGITS || 1) - 1)}1`}`;
     }
-    return amountWithCommas(removeTrailingZeros(formattedAmount));
+    return removeTrailingZeros(formattedAmount).replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
 };
 
 const showFullAmount = (amount, decimals, symbol) =>

--- a/packages/frontend/src/components/wallet/TokenBox.js
+++ b/packages/frontend/src/components/wallet/TokenBox.js
@@ -43,6 +43,7 @@ const StyledContainer = styled.div`
     .desc {
         display: flex;
         flex-direction: column;
+        align-items: flex-start;
         margin-left: 14px;
 
         .symbol {
@@ -136,7 +137,7 @@ const TokenBox = ({ token, onClick }) => {
                             target='_blank'
                             rel='noopener noreferrer'
                         >
-                            {token.symbol}
+                            {token.name || token.symbol}
                         </a>
                     </span>
                     :
@@ -159,6 +160,7 @@ const TokenBox = ({ token, onClick }) => {
                 <TokenAmount 
                     token={token} 
                     className='balance'
+                    withSymbol={true}
                 />
             }
         </StyledContainer>

--- a/packages/frontend/src/components/wallet/TokenBox.js
+++ b/packages/frontend/src/components/wallet/TokenBox.js
@@ -9,10 +9,9 @@ import TokenAmount from './TokenAmount';
 
 const StyledContainer = styled.div`
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     padding: 15px 14px;
-    min-height: 80px;
 
     @media (max-width: 767px) {
         margin: 0 -14px;
@@ -33,6 +32,7 @@ const StyledContainer = styled.div`
         overflow: hidden;
         border-radius: 50%;
         box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.15);
+        align-self: center;
 
         img, svg {
             height: 32px;
@@ -45,11 +45,19 @@ const StyledContainer = styled.div`
         flex-direction: column;
         align-items: flex-start;
         margin-left: 14px;
+        display: block;
+        min-width: 0;
 
         .symbol {
             font-weight: 700;
             font-size: 16px;
             color: #24272a;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            display: block;
+            margin-right: 10px;
+
 
             a {
                 color: inherit;
@@ -58,7 +66,10 @@ const StyledContainer = styled.div`
 
         .fiat-rate {
             color: #72727A;
-            margin-top: 5px;
+            margin-top: 6px;
+            white-space: nowrap;
+            display: block;
+            width: fit-content;
 
             > span {
                 background-color: #F0F0F1;
@@ -76,7 +87,7 @@ const StyledContainer = styled.div`
         font-weight: 600;
         color: #24272a;
         text-align: right;
-        min-height: 47px;
+        white-space: nowrap;
 
         .fiat-amount {
             font-size: 14px;

--- a/packages/frontend/src/components/wallet/Wallet.js
+++ b/packages/frontend/src/components/wallet/Wallet.js
@@ -51,7 +51,7 @@ const StyledContainer = styled(Container)`
 
         &.tokens {
             color: #72727A;
-            margin-top: 40px;
+            margin-top: 20px;
             margin-bottom: 15px;
             display: flex;
             align-items: center;


### PR DESCRIPTION
Changes:
1. Show token name on the left side of the list, and add token symbol next to the amount, on the right side of the list.
2. Add comma formatting for larger token amounts - e.g.  1000000.000 nUSDC --> 100,000.000 nUSDC
3. Adds ellipsis treatment to token name when needed

<img width="394" alt="Screen Shot 2021-08-18 at 6 54 08 PM" src="https://user-images.githubusercontent.com/24921205/129995119-3fdd3e87-c546-4b1e-b844-7f5537eaa629.png">

