### PR TITLE
Always require account ID and phrase in the URL to land on /recover-with-link

### DIFF
--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -354,7 +354,7 @@ class Routing extends Component {
                             />
                             <Route
                                 exact
-                                path='/recover-with-link/:accountId?/:seedPhrase?'
+                                path='/recover-with-link/:accountId/:seedPhrase'
                                 component={RecoverWithLinkWithRouter}
                             />
                             <Route

--- a/packages/frontend/src/components/accounts/RecoverWithLink.js
+++ b/packages/frontend/src/components/accounts/RecoverWithLink.js
@@ -245,8 +245,8 @@ const mapDispatchToProps = {
 
 const mapStateToProps = ({ account, status }, { match }) => ({
     ...account,
-    accountId: match.params.accountId || '',
-    seedPhrase: match.params.seedPhrase || '',
+    accountId: match.params.accountId,
+    seedPhrase: match.params.seedPhrase,
     mainLoader: status.mainLoader
 });
 


### PR DESCRIPTION
Changes:
1. Always require `accountId` and `seedPhrase` from URL params to land on the `/recover-with-link` page.