### PR TITLE
ADD tests for login with dapp flows

### DIFF
--- a/packages/e2e-tests/global-setup.js
+++ b/packages/e2e-tests/global-setup.js
@@ -1,0 +1,11 @@
+const testDapp = require("./testDapp/server");
+const { testDappPort } = require("./utils/config");
+
+module.exports = async () => {
+    const testDappServer = await testDapp.listen(testDappPort, () => {
+        console.log(`Test dapp started and Listening on port ${testDappPort}`);
+    });
+    return async () => {
+        await testDappServer.close();
+    };
+};

--- a/packages/e2e-tests/loginWithDapp/models/Login.js
+++ b/packages/e2e-tests/loginWithDapp/models/Login.js
@@ -11,11 +11,30 @@ class LoginPage {
         await this.page.waitForURL(/\/login/);
         return testDapp;
     }
+    async navigateToFAKFlow() {
+        const testDapp = new TestDappPage(this.page);
+        await testDapp.navigate();
+        await testDapp.clickSignInWithFAK();
+        await this.page.waitForURL(/\/login/);
+        return testDapp;
+    }
     async allowAccess() {
         await this.page.click(`data-test-id=allowNonFullAccessButton`);
+        await this.page.waitForNavigation();
+    }
+    async allowFullAccess() {
+        await this.page.click(`data-test-id=allowFullAccessButton`);
     }
     async denyAccess() {
         await this.page.click(`data-test-id=denyAccessButton`);
+    }
+    async confirmAccountId(accountId) {
+        await this.page.fill(
+            `data-test-id=FAKRequestAccountIdConfirmationInput`,
+            accountId
+        );
+        await this.page.click(`data-test-id=FAKRequestConfirmAccountIdButton`);
+        await this.page.waitForNavigation();
     }
 }
 

--- a/packages/e2e-tests/loginWithDapp/models/Login.js
+++ b/packages/e2e-tests/loginWithDapp/models/Login.js
@@ -1,42 +1,21 @@
-const { getDefaultConfig } = require("../../utils/account");
-const { testDappURL } = require("../../utils/config");
+const { TestDappPage } = require("./TestDapp");
 
 class LoginPage {
     constructor(page) {
         this.page = page;
     }
     async navigate() {
-        await this.page.goto(testDappURL);
-
-        if (await this.page.$("data-test-id=testDapp-signOutBtn")) {
-            await this.page.click("data-test-id=testDapp-signOutBtn");
-            await this.page.waitForSelector("data-test-id=testDapp-signInBtn");
-        }
-
-        await this.page.click("data-test-id=testDapp-signInBtn");
+        const testDapp = new TestDappPage(this.page);
+        await testDapp.navigate();
+        await testDapp.clickSignIn();
         await this.page.waitForURL(/\/login/);
+        return testDapp;
     }
     async allowAccess() {
-        await this.page.click(`button:text-matches('allow', 'i')`);
+        await this.page.click(`data-test-id=allowNonFullAccessButton`);
     }
     async denyAccess() {
-        await this.page.click(`button:text-matches('deny', 'i')`);
-    }
-    async getAccessKeyForAccountId(accountId) {
-        return this.page.evaluate(
-            (accountId) =>
-                Object.keys(window.localStorage).find((k) =>
-                    new RegExp(accountId).test(k)
-                ),
-            accountId
-        );
-    }
-    async getPendingAccessKeys() {
-        return this.page.evaluate(() =>
-            Object.keys(window.localStorage).filter((k) =>
-                /pending_key/.test(k)
-            )
-        );
+        await this.page.click(`data-test-id=denyAccessButton`);
     }
 }
 

--- a/packages/e2e-tests/loginWithDapp/models/Login.js
+++ b/packages/e2e-tests/loginWithDapp/models/Login.js
@@ -1,54 +1,42 @@
 const { getDefaultConfig } = require("../../utils/account");
+const { testDappURL } = require("../../utils/config");
 
 class LoginPage {
     constructor(page) {
         this.page = page;
     }
-    async addNearApiJs() {
-        await this.page.addScriptTag({
-            url: "https://cdn.jsdelivr.net/npm/near-api-js@0.42.0/dist/near-api-js.js",
-        });
-    }
-    async navigate(dappURL) {
-        await this.page.goto(dappURL);
-        await this.addNearApiJs();
+    async navigate() {
+        await this.page.goto(testDappURL);
 
-        const defaultConfig = getDefaultConfig();
-        await this.page.evaluate(
-            async ([bankAccount, defaultConfig]) => {
-                const config = {
-                    ...defaultConfig,
-                    keyStore:
-                        new nearApi.keyStores.BrowserLocalStorageKeyStore(),
-                };
-                const near = await nearApi.connect(config);
-                const wallet = new nearApi.WalletConnection(near);
-                await wallet.requestSignIn(bankAccount);
-            },
-            [process.env.BANK_ACCOUNT, defaultConfig]
-        );
-    }
-    async initializeNearWalletConnection() {
-        await this.addNearApiJs();
-        const defaultConfig = getDefaultConfig();
-        await this.page.evaluate(
-            async ([defaultConfig]) => {
-                const config = {
-                    ...defaultConfig,
-                    keyStore:
-                        new nearApi.keyStores.BrowserLocalStorageKeyStore(),
-                };
-                const near = await nearApi.connect(config);
-                new nearApi.WalletConnection(near);
-            },
-            [defaultConfig]
-        );
+        if (await this.page.$("data-test-id=testDapp-signOutBtn")) {
+            await this.page.click("data-test-id=testDapp-signOutBtn");
+            await this.page.waitForSelector("data-test-id=testDapp-signInBtn");
+        }
+
+        await this.page.click("data-test-id=testDapp-signInBtn");
+        await this.page.waitForURL(/\/login/);
     }
     async allowAccess() {
         await this.page.click(`button:text-matches('allow', 'i')`);
     }
     async denyAccess() {
         await this.page.click(`button:text-matches('deny', 'i')`);
+    }
+    async getAccessKeyForAccountId(accountId) {
+        return this.page.evaluate(
+            (accountId) =>
+                Object.keys(window.localStorage).find((k) =>
+                    new RegExp(accountId).test(k)
+                ),
+            accountId
+        );
+    }
+    async getPendingAccessKeys() {
+        return this.page.evaluate(() =>
+            Object.keys(window.localStorage).filter((k) =>
+                /pending_key/.test(k)
+            )
+        );
     }
 }
 

--- a/packages/e2e-tests/loginWithDapp/models/Login.js
+++ b/packages/e2e-tests/loginWithDapp/models/Login.js
@@ -1,0 +1,55 @@
+const { getDefaultConfig } = require("../../utils/account");
+
+class LoginPage {
+    constructor(page) {
+        this.page = page;
+    }
+    async addNearApiJs() {
+        await this.page.addScriptTag({
+            url: "https://cdn.jsdelivr.net/npm/near-api-js@0.42.0/dist/near-api-js.js",
+        });
+    }
+    async navigate(dappURL) {
+        await this.page.goto(dappURL);
+        await this.addNearApiJs();
+
+        const defaultConfig = getDefaultConfig();
+        await this.page.evaluate(
+            async ([bankAccount, defaultConfig]) => {
+                const config = {
+                    ...defaultConfig,
+                    keyStore:
+                        new nearApi.keyStores.BrowserLocalStorageKeyStore(),
+                };
+                const near = await nearApi.connect(config);
+                const wallet = new nearApi.WalletConnection(near);
+                await wallet.requestSignIn(bankAccount);
+            },
+            [process.env.BANK_ACCOUNT, defaultConfig]
+        );
+    }
+    async initializeNearWalletConnection() {
+        await this.addNearApiJs();
+        const defaultConfig = getDefaultConfig();
+        await this.page.evaluate(
+            async ([defaultConfig]) => {
+                const config = {
+                    ...defaultConfig,
+                    keyStore:
+                        new nearApi.keyStores.BrowserLocalStorageKeyStore(),
+                };
+                const near = await nearApi.connect(config);
+                new nearApi.WalletConnection(near);
+            },
+            [defaultConfig]
+        );
+    }
+    async allowAccess() {
+        await this.page.click(`button:text-matches('allow', 'i')`);
+    }
+    async denyAccess() {
+        await this.page.click(`button:text-matches('deny', 'i')`);
+    }
+}
+
+module.exports = { LoginPage };

--- a/packages/e2e-tests/loginWithDapp/models/TestDapp.js
+++ b/packages/e2e-tests/loginWithDapp/models/TestDapp.js
@@ -10,6 +10,9 @@ class TestDappPage {
     async clickSignIn() {
         await this.page.click("data-test-id=testDapp-signInBtn");
     }
+    async clickSignInWithFAK() {
+        await this.page.click("data-test-id=testDapp-signInWithFAKBtn");
+    }
     async getAccessKeyForAccountId(accountId) {
         return this.page.evaluate(
             (accountId) =>

--- a/packages/e2e-tests/loginWithDapp/models/TestDapp.js
+++ b/packages/e2e-tests/loginWithDapp/models/TestDapp.js
@@ -1,0 +1,31 @@
+const { testDappURL } = require("../../utils/config");
+
+class TestDappPage {
+    constructor(page) {
+        this.page = page;
+    }
+    async navigate() {
+        await this.page.goto(testDappURL);
+    }
+    async clickSignIn() {
+        await this.page.click("data-test-id=testDapp-signInBtn");
+    }
+    async getAccessKeyForAccountId(accountId) {
+        return this.page.evaluate(
+            (accountId) =>
+                Object.keys(window.localStorage).find((k) =>
+                    new RegExp(accountId).test(k)
+                ),
+            accountId
+        );
+    }
+    async getPendingAccessKeys() {
+        return this.page.evaluate(() =>
+            Object.keys(window.localStorage).filter((k) =>
+                /pending_key/.test(k)
+            )
+        );
+    }
+}
+
+module.exports = { TestDappPage };

--- a/packages/e2e-tests/loginWithDapp/signedInUser.spec.js
+++ b/packages/e2e-tests/loginWithDapp/signedInUser.spec.js
@@ -46,7 +46,7 @@ describe("Login with Dapp", () => {
         page,
     }) => {
         const loginPage = new LoginPage(page);
-        await loginPage.navigate();
+        const testDappPage = await loginPage.navigate();
 
         await loginPage.allowAccess();
         await page.waitForNavigation();
@@ -54,11 +54,11 @@ describe("Login with Dapp", () => {
         await expect(page).toMatchURL(new RegExp(testDappURL));
 
         const pendingkeyLocalStorageKeys =
-            await loginPage.getPendingAccessKeys();
+            await testDappPage.getPendingAccessKeys();
         await expect(pendingkeyLocalStorageKeys).toHaveLength(0);
 
         const accesskeyLocalStorageKey =
-            await loginPage.getAccessKeyForAccountId(
+            await testDappPage.getAccessKeyForAccountId(
                 testAccount.account.accountId
             );
         await expect(accesskeyLocalStorageKey).toBeTruthy();
@@ -70,18 +70,18 @@ describe("Login with Dapp", () => {
     });
     test("navigates back to dapp when access is denied", async ({ page }) => {
         const loginPage = new LoginPage(page);
-        await loginPage.navigate();
+        const testDappPage = await loginPage.navigate();
 
         await loginPage.denyAccess();
 
         await expect(page).toMatchURL(new RegExp(testDappURL));
 
         const pendingkeyLocalStorageKeys =
-            await loginPage.getPendingAccessKeys();
+            await testDappPage.getPendingAccessKeys();
         await expect(pendingkeyLocalStorageKeys).not.toHaveLength(0);
 
         const accesskeyLocalStorageKey =
-            await loginPage.getAccessKeyForAccountId(
+            await testDappPage.getAccessKeyForAccountId(
                 testAccount.account.accountId
             );
         await expect(accesskeyLocalStorageKey).toBeFalsy();

--- a/packages/e2e-tests/loginWithDapp/signedInUser.spec.js
+++ b/packages/e2e-tests/loginWithDapp/signedInUser.spec.js
@@ -1,0 +1,96 @@
+const { test, expect } = require("@playwright/test");
+const { HomePage } = require("../register/models/Home");
+
+const { createRandomBankSubAccount } = require("../utils/account");
+const { LoginPage } = require("./models/Login");
+
+const { describe, beforeAll, afterAll, beforeEach } = test;
+
+describe("Login with Dapp", () => {
+    let testAccount;
+
+    beforeAll(async () => {
+        testAccount = await createRandomBankSubAccount();
+    });
+
+    beforeEach(async ({ page }) => {
+        const homePage = new HomePage(page);
+        await homePage.navigate();
+        await homePage.loginWithSeedPhraseLocalStorage(
+            testAccount.account.accountId,
+            testAccount.seedPhrase
+        );
+    });
+
+    afterAll(async () => {
+        testAccount && (await testAccount.delete());
+    });
+
+    test("navigates to login with dapp page", async ({ page }) => {
+        const loginPage = new LoginPage(page);
+        const testDappUrl = `https://near.org`;
+        await loginPage.navigate(testDappUrl);
+
+        await expect(page).toMatchURL(/\/login/);
+        const { hostname: testDappHostname } = new URL(testDappUrl);
+        await expect(page).toMatchText(
+            `data-test-id=requestingAppTitleDisplay`,
+            testDappHostname
+        );
+        const currentlyLoggedInUser = await page.textContent(
+            "data-test-id=currentUser"
+        );
+        await expect(page).not.toHaveSelector(".dots");
+        await expect(page).toMatchText(
+            "data-test-id=dropdownCurrentlySelectedAccount",
+            currentlyLoggedInUser
+        );
+    });
+    test("navigates back to dapp with access key when access is granted", async ({
+        page,
+    }) => {
+        const loginPage = new LoginPage(page);
+        const testDappUrl = `https://near.org`;
+        await loginPage.navigate(testDappUrl);
+
+        await loginPage.allowAccess();
+        await page.waitForNavigation();
+
+        await expect(page).toMatchURL(new RegExp(testDappUrl));
+
+        await loginPage.initializeNearWalletConnection();
+        const localStorageKeys = await page.evaluate(() =>
+            Object.keys(window.localStorage)
+        );
+        const pendingkeyLocalStorageKey = localStorageKeys.find((k) =>
+            /pending_key/.test(k)
+        );
+        const accesskeyLocalStorageKey = localStorageKeys.find((k) =>
+            new RegExp(testAccount.account.accountId).test(k)
+        );
+        await expect(pendingkeyLocalStorageKey).toBeFalsy();
+        await expect(accesskeyLocalStorageKey).toBeTruthy();
+    });
+    test("navigates back to dapp when access is denied", async ({ page }) => {
+        const loginPage = new LoginPage(page);
+        const testDappUrl = `https://near.org`;
+        await loginPage.navigate(testDappUrl);
+
+        await loginPage.denyAccess();
+
+        await expect(page).toMatchURL(new RegExp(testDappUrl));
+
+        await loginPage.initializeNearWalletConnection();
+        const localStorageKeys = await page.evaluate(() =>
+            Object.keys(window.localStorage)
+        );
+        const pendingkeyLocalStorageKey = localStorageKeys.find((k) =>
+            /pending_key/.test(k)
+        );
+        const accesskeyLocalStorageKey = localStorageKeys.find((k) =>
+            new RegExp(testAccount.account.accountId).test(k)
+        );
+        await expect(pendingkeyLocalStorageKey).toBeTruthy();
+        await expect(accesskeyLocalStorageKey).toBeFalsy();
+    });
+});

--- a/packages/e2e-tests/loginWithDapp/signedInUserFAK.spec.js
+++ b/packages/e2e-tests/loginWithDapp/signedInUserFAK.spec.js
@@ -27,9 +27,9 @@ describe("Login with Dapp", () => {
         testAccount && (await testAccount.delete());
     });
 
-    test("navigates to login with dapp page", async ({ page }) => {
+    test("navigates to login with dapp page requesting a full access key", async ({ page }) => {
         const loginPage = new LoginPage(page);
-        await loginPage.navigate();
+        await loginPage.navigateToFAKFlow();
 
         await expect(page).toMatchURL(/\/login/);
 
@@ -37,6 +37,7 @@ describe("Login with Dapp", () => {
             "data-test-id=currentUser"
         );
         await expect(page).not.toHaveSelector(".dots");
+        await expect(page).toHaveSelector("data-test-id=fullAccessKeyRequestLabel");
         await expect(page).toMatchText(
             "data-test-id=dropdownCurrentlySelectedAccount",
             currentlyLoggedInUser
@@ -46,9 +47,12 @@ describe("Login with Dapp", () => {
         page,
     }) => {
         const loginPage = new LoginPage(page);
-        const testDappPage = await loginPage.navigate();
+        const testDappPage = await loginPage.navigateToFAKFlow();
 
-        await loginPage.allowAccess();
+        await loginPage.allowFullAccess();
+        await expect(page).toMatchURL(/\/confirm$/);
+
+        await loginPage.confirmAccountId(testAccount.account.accountId)
 
         await expect(page).toMatchURL(new RegExp(testDappURL));
 
@@ -69,7 +73,7 @@ describe("Login with Dapp", () => {
     });
     test("navigates back to dapp when access is denied", async ({ page }) => {
         const loginPage = new LoginPage(page);
-        const testDappPage = await loginPage.navigate();
+        const testDappPage = await loginPage.navigateToFAKFlow();
 
         await loginPage.denyAccess();
 

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -11,7 +11,8 @@
     "expect-playwright": "^0.7.2",
     "near-api-js": "^0.36.3",
     "near-seed-phrase": "^0.1.0",
-    "playwright": "^1.14.0"
+    "playwright": "^1.14.0",
+    "express": "^4.17.1"
   },
   "scripts": {
     "test": "node -r dotenv/config index.js",

--- a/packages/e2e-tests/playwright.config.js
+++ b/packages/e2e-tests/playwright.config.js
@@ -6,6 +6,7 @@ const { matchers } = require("expect-playwright");
 expect.extend(matchers);
 
 const config = {
+    globalSetup: require.resolve("./global-setup.js"),
     use: {
         baseURL: process.env.WALLET_URL || "https://wallet.testnet.near.org",
         headless: false,

--- a/packages/e2e-tests/register/models/CreateAccount.js
+++ b/packages/e2e-tests/register/models/CreateAccount.js
@@ -1,4 +1,4 @@
-const { getWalletNetwork } = require("../../utils/account");
+const { walletNetwork } = require("../../utils/config");
 
 class CreateAccountPage {
     constructor(page) {
@@ -8,7 +8,7 @@ class CreateAccountPage {
         await this.page.goto(`/create`);
     }
     async acceptTerms() {
-        if (getWalletNetwork() === "mainnet") {
+        if (walletNetwork === "mainnet") {
             await this.page.click("data-test-id=acceptTermsButton");
         }
     }

--- a/packages/e2e-tests/register/seedPhrase.spec.js
+++ b/packages/e2e-tests/register/seedPhrase.spec.js
@@ -3,8 +3,8 @@ const { test, expect } = require("@playwright/test");
 const {
     generateTestAccountId,
     connectToAccountWithSeedphrase,
-    getWalletNetwork,
 } = require("../utils/account");
+const { walletNetwork } = require("../utils/config");
 const { HomePage } = require("./models/Home");
 const { CreateAccountPage } = require("./models/CreateAccount");
 const { SetRecoveryOptionPage } = require("./models/SetRecoveryOption");
@@ -88,7 +88,7 @@ describe("Account Registration Using Seed Phrase", () => {
             .grantPermissions(["clipboard-read", "clipboard-write"])
             .catch(test.skip);
         // skip test on mainnet
-        if (getWalletNetwork() === "mainnet") {
+        if (walletNetwork === "mainnet") {
             test.skip();
         }
 

--- a/packages/e2e-tests/testDapp/index.html
+++ b/packages/e2e-tests/testDapp/index.html
@@ -1,0 +1,8 @@
+<html>
+    <body>
+        <h1>Test Dapp</h1>
+        <div id="content"></div>
+        <script src="/near-api-js.min.js"></script>
+        <script src="/index.js"></script>
+    </body>
+</html>

--- a/packages/e2e-tests/testDapp/index.js
+++ b/packages/e2e-tests/testDapp/index.js
@@ -1,0 +1,39 @@
+const { connect, keyStores, WalletConnection } = nearApi;
+
+(async () => {
+    const { DEFAULT_NEAR_CONFIG, BANK_ACCOUNT } = await fetch(
+        "./configData.json"
+    ).then((res) => res.json());
+
+    const config = {
+        ...DEFAULT_NEAR_CONFIG,
+        keyStore: new keyStores.BrowserLocalStorageKeyStore(),
+    };
+    const near = await connect(config);
+
+    const wallet = new WalletConnection(near);
+
+    const walletAccountId = wallet.getAccountId();
+
+    if (walletAccountId) {
+        document.getElementById("content").innerHTML = `
+          <span data-test-id="testDapp-currentUser">
+            Currently Logged in as: ${walletAccountId}
+          </span>
+          <button id="signOutBtn" data-test-id="testDapp-signOutBtn">
+            Sign in
+          </button>`;
+        document
+            .getElementById("signOutBtn")
+            .addEventListener("click", () => wallet.signOut());
+    } else {
+        document.getElementById(
+            "content"
+        ).innerHTML = `<button id="signInBtn" data-test-id="testDapp-signInBtn">Sign in</button>`;
+        document
+            .getElementById("signInBtn")
+            .addEventListener("click", () =>
+                wallet.requestSignIn(BANK_ACCOUNT)
+            );
+    }
+})();

--- a/packages/e2e-tests/testDapp/index.js
+++ b/packages/e2e-tests/testDapp/index.js
@@ -21,11 +21,14 @@ const { connect, keyStores, WalletConnection } = nearApi;
             Currently Logged in as: ${walletAccountId}
           </span>
           <button id="signOutBtn" data-test-id="testDapp-signOutBtn">
-            Sign in
+            Sign out
           </button>`;
         document
             .getElementById("signOutBtn")
-            .addEventListener("click", () => wallet.signOut());
+            .addEventListener("click", async () => {
+                wallet.signOut();
+                location.reload();
+            });
     } else {
         document.getElementById(
             "content"

--- a/packages/e2e-tests/testDapp/index.js
+++ b/packages/e2e-tests/testDapp/index.js
@@ -32,11 +32,21 @@ const { connect, keyStores, WalletConnection } = nearApi;
     } else {
         document.getElementById(
             "content"
-        ).innerHTML = `<button id="signInBtn" data-test-id="testDapp-signInBtn">Sign in</button>`;
+        ).innerHTML = `
+        <button id="signInBtn" data-test-id="testDapp-signInBtn">
+            Sign in
+        </button>
+        <button id="signInWithFAKBtn" data-test-id="testDapp-signInWithFAKBtn">
+            Sign in with a full access key
+        </button>
+        `;
         document
             .getElementById("signInBtn")
             .addEventListener("click", () =>
                 wallet.requestSignIn(BANK_ACCOUNT)
             );
+        document
+            .getElementById("signInWithFAKBtn")
+            .addEventListener("click", () => wallet.requestSignIn(""));
     }
 })();

--- a/packages/e2e-tests/testDapp/server.js
+++ b/packages/e2e-tests/testDapp/server.js
@@ -1,0 +1,30 @@
+const express = require("express");
+const path = require("path");
+
+const { getDefaultConfig } = require("../utils/account");
+
+const app = express();
+
+app.use(express.static(__dirname));
+
+app.get("/configData.json", function (req, res) {
+    res.json({
+        DEFAULT_NEAR_CONFIG: getDefaultConfig(),
+        BANK_ACCOUNT: process.env.BANK_ACCOUNT,
+    });
+});
+
+app.get("/near-api-js.min.js", function (req, res) {
+    res.sendFile(
+        path.join(
+            __dirname,
+            "../node_modules/near-api-js/dist/near-api-js.min.js"
+        )
+    );
+});
+
+app.get("/", (req, res) => {
+    res.sendFile(__dirname + "/index.html");
+});
+
+module.exports = app;

--- a/packages/e2e-tests/utils/account.js
+++ b/packages/e2e-tests/utils/account.js
@@ -95,5 +95,6 @@ module.exports = {
     generateTestAccountId,
     connectToAccountWithSeedphrase,
     getKeyPairFromSeedPhrase,
-    getWalletNetwork
+    getWalletNetwork,
+    getDefaultConfig,
 };

--- a/packages/e2e-tests/utils/account.js
+++ b/packages/e2e-tests/utils/account.js
@@ -8,10 +8,10 @@ const {
 } = require("near-api-js");
 const { parseSeedPhrase } = require("near-seed-phrase");
 
-const getWalletNetwork = () => process.env.WALLET_NETWORK || "testnet";
+const { walletNetwork } = require("./config");
 
 const getDefaultConfig = () => ({
-    networkId: getWalletNetwork(),
+    networkId: walletNetwork,
     nodeUrl: process.env.NODE_URL || "https://rpc.testnet.near.org",
     walletUrl: process.env.WALLET_URL || "https://wallet.testnet.near.org",
     keyStore: new InMemoryKeyStore(),
@@ -95,6 +95,5 @@ module.exports = {
     generateTestAccountId,
     connectToAccountWithSeedphrase,
     getKeyPairFromSeedPhrase,
-    getWalletNetwork,
     getDefaultConfig,
 };

--- a/packages/e2e-tests/utils/config.js
+++ b/packages/e2e-tests/utils/config.js
@@ -1,0 +1,13 @@
+
+
+const walletNetwork = process.env.WALLET_NETWORK || "testnet";
+
+const testDappPort = process.env.TEST_DAPP_PORT || 3000;
+const testDappURL = `http://localhost:${testDappPort}`;
+
+
+module.exports = {
+  walletNetwork,
+  testDappPort,
+  testDappURL
+}

--- a/packages/e2e-tests/yarn.lock
+++ b/packages/e2e-tests/yarn.lock
@@ -543,6 +543,14 @@ abortcontroller-polyfill@^1.5.0:
   resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.1.tgz#27084bac87d78a7224c8ee78135d05df430c2d2f"
   integrity sha512-yml9NiDEH4M4p0G4AcPkg8AAa4mF3nfYF28VQxaokpO67j9H7gWgmsVWJ/f1Rn+PzsnDYvzJzWIQzCqDKRvWlA==
 
+accepts@~1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
+  integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
+  dependencies:
+    mime-types "~2.1.24"
+    negotiator "0.6.2"
+
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -568,6 +576,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+array-flatten@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+  integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
 
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
@@ -616,6 +629,22 @@ bn.js@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
+
+body-parser@1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
+  integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
+  dependencies:
+    bytes "3.1.0"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.2"
+    http-errors "1.7.2"
+    iconv-lite "0.4.24"
+    on-finished "~2.3.0"
+    qs "6.7.0"
+    raw-body "2.4.0"
+    type-is "~1.6.17"
 
 borsh@^0.3.1:
   version "0.3.1"
@@ -669,6 +698,11 @@ buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
+
+bytes@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
+  integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
 call-bind@^1.0.0:
   version "1.0.2"
@@ -757,12 +791,34 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
+content-disposition@0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.3.tgz#e130caf7e7279087c5616c2007d0485698984fbd"
+  integrity sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==
+  dependencies:
+    safe-buffer "5.1.2"
+
+content-type@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
+  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
+
 convert-source-map@^1.7.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.8.0.tgz#f3373c32d21b4d780dd8004514684fb791ca4369"
   integrity sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==
   dependencies:
     safe-buffer "~5.1.1"
+
+cookie-signature@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
+  integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
+
+cookie@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
+  integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.2.0"
@@ -806,6 +862,13 @@ cross-fetch@^3.0.6:
   dependencies:
     node-fetch "2.6.1"
 
+debug@2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
 debug@4, debug@^4.1.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
@@ -837,6 +900,11 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+destroy@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
+  integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+
 diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
@@ -847,10 +915,20 @@ dotenv@^8.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
+ee-first@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+  integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
 electron-to-chromium@^1.3.793:
   version "1.3.798"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.798.tgz#12b0bb826ddf35486f2ca41c01be4bd6ad1b9b1e"
   integrity sha512-fwsr6oXAORoV9a6Ak2vMCdXfmHIpAGgpOGesulS1cbGgJmrMl3H+GicUyRG3t+z9uHTMrIuMTleFDW+EUFYT3g==
+
+encodeurl@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
+  integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
 end-of-stream@^1.1.0:
   version "1.4.4"
@@ -873,6 +951,11 @@ escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
+escape-html@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -882,6 +965,11 @@ escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
+etag@~1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+  integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
 expect-playwright@^0.7.2:
   version "0.7.2"
@@ -899,6 +987,42 @@ expect@^26.4.2:
     jest-matcher-utils "^26.6.2"
     jest-message-util "^26.6.2"
     jest-regex-util "^26.0.0"
+
+express@^4.17.1:
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
+  integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
+  dependencies:
+    accepts "~1.3.7"
+    array-flatten "1.1.1"
+    body-parser "1.19.0"
+    content-disposition "0.5.3"
+    content-type "~1.0.4"
+    cookie "0.4.0"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "~1.1.2"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "~1.1.2"
+    fresh "0.5.2"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "~2.3.0"
+    parseurl "~1.3.3"
+    path-to-regexp "0.1.7"
+    proxy-addr "~2.0.5"
+    qs "6.7.0"
+    range-parser "~1.2.1"
+    safe-buffer "5.1.2"
+    send "0.17.1"
+    serve-static "1.14.1"
+    setprototypeof "1.1.1"
+    statuses "~1.5.0"
+    type-is "~1.6.18"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
 
 extract-zip@^2.0.1:
   version "2.0.1"
@@ -924,6 +1048,29 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+finalhandler@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
+  integrity sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.3"
+    statuses "~1.5.0"
+    unpipe "~1.0.0"
+
+forwarded@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
+  integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
+
+fresh@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+  integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1014,6 +1161,17 @@ hash-base@^3.0.0:
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
 
+http-errors@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.2.tgz#4f5029cf13239f31036e5b2e55292bcfbcc85c8f"
+  integrity sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.1"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.0"
+
 http-errors@^1.7.2:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.0.tgz#75d1bbe497e1044f51e4ee9e704a62f28d336507"
@@ -1025,6 +1183,17 @@ http-errors@^1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
+http-errors@~1.7.2:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
+  integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.4"
+    setprototypeof "1.1.1"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.0"
+
 https-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
@@ -1032,6 +1201,13 @@ https-proxy-agent@^5.0.0:
   dependencies:
     agent-base "6"
     debug "4"
+
+iconv-lite@0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -1045,6 +1221,16 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+inherits@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+
+ipaddr.js@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
+  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 is-number@^7.0.0:
   version "7.0.0"
@@ -1132,6 +1318,21 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
+media-typer@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+  integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+
+merge-descriptors@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+  integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
+
+methods@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+  integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
+
 micromatch@^4.0.2:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
@@ -1139,6 +1340,23 @@ micromatch@^4.0.2:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.2.3"
+
+mime-db@1.49.0:
+  version "1.49.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.49.0.tgz#f3dfde60c99e9cf3bc9701d687778f537001cbed"
+  integrity sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==
+
+mime-types@~2.1.24:
+  version "2.1.32"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.32.tgz#1d00e89e7de7fe02008db61001d9e02852670fd5"
+  integrity sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==
+  dependencies:
+    mime-db "1.49.0"
+
+mime@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 mime@^2.4.6:
   version "2.4.7"
@@ -1156,6 +1374,16 @@ minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
+ms@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
 ms@2.1.2:
   version "2.1.2"
@@ -1209,6 +1437,11 @@ near-seed-phrase@^0.1.0:
     near-hd-key "^1.0.0"
     tweetnacl "^1.0.2"
 
+negotiator@0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
+  integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
+
 node-fetch@2.6.1, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
@@ -1246,6 +1479,13 @@ object.assign@^4.1.0:
     has-symbols "^1.0.1"
     object-keys "^1.1.1"
 
+on-finished@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
+  integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
+  dependencies:
+    ee-first "1.1.1"
+
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -1253,10 +1493,20 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+parseurl@~1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
+  integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+
+path-to-regexp@0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+  integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
 pbkdf2@^3.0.9:
   version "3.1.1"
@@ -1347,6 +1597,14 @@ proper-lockfile@^4.1.1:
     retry "^0.12.0"
     signal-exit "^3.0.2"
 
+proxy-addr@~2.0.5:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
+  integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
+  dependencies:
+    forwarded "0.2.0"
+    ipaddr.js "1.9.1"
+
 proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
@@ -1360,12 +1618,32 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+qs@6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
+  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
 randombytes@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
+
+range-parser@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
+  integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+
+raw-body@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.0.tgz#a1ce6fb9c9bc356ca52e89256ab59059e13d0332"
+  integrity sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==
+  dependencies:
+    bytes "3.1.0"
+    http-errors "1.7.2"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
 
 react-is@^17.0.1:
   version "17.0.2"
@@ -1401,20 +1679,59 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+safe-buffer@5.1.2, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+"safer-buffer@>= 2.1.2 < 3":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+send@0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"
+  integrity sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==
+  dependencies:
+    debug "2.6.9"
+    depd "~1.1.2"
+    destroy "~1.0.4"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "~1.7.2"
+    mime "1.6.0"
+    ms "2.1.1"
+    on-finished "~2.3.0"
+    range-parser "~1.2.1"
+    statuses "~1.5.0"
+
+serve-static@1.14.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.14.1.tgz#666e636dc4f010f7ef29970a88a674320898b2f9"
+  integrity sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==
+  dependencies:
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    parseurl "~1.3.3"
+    send "0.17.1"
+
+setprototypeof@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
+  integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
 
 setprototypeof@1.2.0:
   version "1.2.0"
@@ -1458,7 +1775,7 @@ stack-utils@^2.0.2, stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-"statuses@>= 1.5.0 < 2":
+"statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
@@ -1511,6 +1828,14 @@ tweetnacl@^1.0.1, tweetnacl@^1.0.2:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
   integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
 
+type-is@~1.6.17, type-is@~1.6.18:
+  version "1.6.18"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
+  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.24"
+
 u3@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/u3/-/u3-0.1.0.tgz#0060927663b68353c539cda99e9511d6687edd9d"
@@ -1521,10 +1846,25 @@ unorm@^1.3.3:
   resolved "https://registry.yarnpkg.com/unorm/-/unorm-1.6.0.tgz#029b289661fba714f1a9af439eb51d9b16c205af"
   integrity sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==
 
+unpipe@1.0.0, unpipe@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+  integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
+
 util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+utils-merge@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
+  integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+vary@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
+  integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
 wrappy@1:
   version "1.0.2"

--- a/packages/frontend/src/components/login/LoginConfirm.js
+++ b/packages/frontend/src/components/login/LoginConfirm.js
@@ -83,6 +83,7 @@ class LoginForm extends Component {
                                             onChange={e => this.handleChange(e.target.value)}
                                             className={`${confirmStatus ? (confirmStatus === 'success' ? 'success' : 'problem') : ''}`}
                                             placeholder={translate('login.confirm.username')}
+                                            data-test-id="FAKRequestAccountIdConfirmationInput"
                                             maxLength='64'
                                             required
                                             autoComplete='off'
@@ -111,6 +112,7 @@ class LoginForm extends Component {
                                 <FormButton
                                     color='blue'
                                     disabled={confirmStatus !== 'problem' && accountId ? false : true}
+                                    data-test-id="FAKRequestConfirmAccountIdButton"
                                     sending={buttonLoader}
                                     type='submit'
                                 >

--- a/packages/frontend/src/components/login/LoginForm.js
+++ b/packages/frontend/src/components/login/LoginForm.js
@@ -51,20 +51,32 @@ const LoginForm = ({
                 >
                     {!accountConfirmationForm && (
                         <Fragment>
-                            <div>{appTitle || <Translate id='sign.unknownApp' />}</div>
-                            {requestAccountIdOnly
-                                ? <Translate id='login.form.accountIdOnly' />
-                                : <>
-                                    <Translate id='login.form.isRequestingTo' />
-                                    <br/>
-                                    <Translate id='login.form.accessYourAccount' />
-                                  </>
+                            <div data-test-id="requestingAppTitleDisplay">
+                                <b>
+                                    {appTitle || (
+                                        <Translate id="sign.unknownApp" />
+                                    )}
+                                </b>
+                            </div>
+                            {requestAccountIdOnly ?
+                                <div className='h2'><Translate id='login.form.accountIdOnly' /></div>
+                            :
+                                <>
+                                    <div className='h2'><Translate id='login.form.isRequestingTo' /> </div>
+                                    <div className='h2'><Translate id='login.form.accessYourAccount' /></div>
+                                </>
                             }
                         </Fragment>
                     )}
                     {accountConfirmationForm && (
                         <Fragment>
-                            <div><b>{appTitle || <Translate id='sign.unknownApp' />}</b></div>
+                            <div data-test-id="requestingAppTitleDisplay">
+                                <b>
+                                    {appTitle || (
+                                        <Translate id="sign.unknownApp" />
+                                    )}
+                                </b>
+                            </div>
                             <div className='h2'><Translate id='login.form.isRequestingFullAccess' /></div>
                             <div className='h2'><Translate id='login.form.toYourAccount' /></div>
                         </Fragment>

--- a/packages/frontend/src/components/login/LoginForm.js
+++ b/packages/frontend/src/components/login/LoginForm.js
@@ -52,19 +52,15 @@ const LoginForm = ({
                     {!accountConfirmationForm && (
                         <Fragment>
                             <div data-test-id="requestingAppTitleDisplay">
-                                <b>
-                                    {appTitle || (
-                                        <Translate id="sign.unknownApp" />
-                                    )}
-                                </b>
+                                {appTitle || <Translate id="sign.unknownApp" />}
                             </div>
-                            {requestAccountIdOnly ?
-                                <div className='h2'><Translate id='login.form.accountIdOnly' /></div>
-                            :
-                                <>
-                                    <div className='h2'><Translate id='login.form.isRequestingTo' /> </div>
-                                    <div className='h2'><Translate id='login.form.accessYourAccount' /></div>
-                                </>
+                            {requestAccountIdOnly
+                                ? <Translate id='login.form.accountIdOnly' />
+                                : <>
+                                    <Translate id='login.form.isRequestingTo' />
+                                    <br/>
+                                    <Translate id='login.form.accessYourAccount' />
+                                  </>
                             }
                         </Fragment>
                     )}

--- a/packages/frontend/src/components/login/LoginForm.js
+++ b/packages/frontend/src/components/login/LoginForm.js
@@ -137,6 +137,7 @@ const LoginForm = ({
                     <FormButton
                         color='gray-white'
                         onClick={handleDeny}
+                        data-test-id="denyAccessButton"
                     >
                         <Translate id='button.deny' />
                     </FormButton>
@@ -148,6 +149,7 @@ const LoginForm = ({
                             onClick={handleAllow}
                             sendingString='button.authorizing'
                             disabled={!account.accountId}
+                            data-test-id="allowNonFullAccessButton"
                         >
                             <Translate id='button.allow' />
                         </FormButton>

--- a/packages/frontend/src/components/login/LoginForm.js
+++ b/packages/frontend/src/components/login/LoginForm.js
@@ -73,7 +73,12 @@ const LoginForm = ({
                                     )}
                                 </b>
                             </div>
-                            <div className='h2'><Translate id='login.form.isRequestingFullAccess' /></div>
+                            <div
+                                className="h2"
+                                data-test-id="fullAccessKeyRequestLabel"
+                            >
+                                <Translate id="login.form.isRequestingFullAccess" />
+                            </div>
                             <div className='h2'><Translate id='login.form.toYourAccount' /></div>
                         </Fragment>
                     )}
@@ -156,6 +161,7 @@ const LoginForm = ({
                             color='blue'
                             sending={buttonLoader}
                             disabled={!account.accountId}
+                            data-test-id="allowFullAccessButton"
                         >
                             <Translate id='button.allow' />
                         </FormButton>

--- a/packages/frontend/src/components/login/SelectAccountDropdown.js
+++ b/packages/frontend/src/components/login/SelectAccountDropdown.js
@@ -159,7 +159,18 @@ const SelectAccountDropdown = ({
             >
                 <Segment basic>
                     <div className='item list-title'>
-                        {dropdown ? translate('button.close') : <div className={classNames({dots: !account.accountId})}>{account.accountId}</div>}
+                        {dropdown ? (
+                            translate("button.close")
+                        ) : (
+                            <div
+                                data-test-id="dropdownCurrentlySelectedAccount"
+                                className={classNames({
+                                    dots: !account.accountId,
+                                })}
+                            >
+                                {account.accountId}
+                            </div>
+                        )}
                         <div className='arrow' />
                     </div>
                     <div className={`${dropdown ? '' : 'hide'}`}>

--- a/packages/frontend/src/components/login/SelectAccountDropdown.js
+++ b/packages/frontend/src/components/login/SelectAccountDropdown.js
@@ -159,9 +159,9 @@ const SelectAccountDropdown = ({
             >
                 <Segment basic>
                     <div className='item list-title'>
-                        {dropdown ? (
-                            translate("button.close")
-                        ) : (
+                        {dropdown 
+                          ? ( translate("button.close") )
+                          : (
                             <div
                                 data-test-id="dropdownCurrentlySelectedAccount"
                                 className={classNames({


### PR DESCRIPTION
- End to end tests and assertions for login with dapp flows. Creates a test account and then asserts an access key exists in local storage for that account after access is granted through the flow and that no pending key exists.
- Added a POM for login page `/login`.

