### PR TITLE
Look up staking pools via indexer

### DIFF
--- a/packages/frontend/src/actions/staking.js
+++ b/packages/frontend/src/actions/staking.js
@@ -19,11 +19,9 @@ import {
     stakingMethods,
     shuffle
 } from '../utils/staking';
-import { wallet } from '../utils/wallet';
+import { ACCOUNT_HELPER_URL, wallet } from '../utils/wallet';
 import { WalletError } from '../utils/walletError';
 import { getBalance } from './account';
-
-let ghValidators;
 
 const {
     transactions: {
@@ -311,14 +309,10 @@ export const { staking } = createActions({
             if (!accountIds) {
                 const rpcValidators = [...current_validators, ...next_validators, ...current_proposals].map(({ account_id }) => account_id);
 
-                // TODO use indexer - getting all historic validators from raw GH script .json
                 const networkId = wallet.connection.provider.connection.url.indexOf('mainnet') > -1 ? 'mainnet' : 'testnet';
-                if (!ghValidators) {
-                    ghValidators = (await fetch(`https://raw.githubusercontent.com/frol/near-validators-scoreboard/scoreboard-${networkId}/validators_scoreboard.json`).then((r) => r.json()))
-                    .map(({ account_id }) => account_id);
-                }
+                const allStakingPools = (await fetch(`${ACCOUNT_HELPER_URL}/stakingPools`).then((r) => r.json()));
 
-                accountIds = [...new Set([...rpcValidators, ...ghValidators])]
+                accountIds = [...new Set([...rpcValidators, ...allStakingPools])]
                     .filter((v) => v.indexOf('nfvalidator') === -1 && v.indexOf(networkId === 'mainnet' ? '.near' : '.m0') > -1);
             }
 

--- a/packages/frontend/src/components/login/LoginDetails.js
+++ b/packages/frontend/src/components/login/LoginDetails.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { Translate } from 'react-localize-redux';
 import { connect } from 'react-redux';
 import { withRouter, Link } from 'react-router-dom';
@@ -7,7 +7,6 @@ import styled from 'styled-components';
 
 import { showCustomAlert } from '../../actions/status';
 import IconArrowLeft from '../../images/IconArrowLeft';
-import IconProblems from '../../images/IconProblems';
 import { EXPLORER_URL } from '../../utils/wallet';
 
 const CustomGrid = styled(Grid)`


### PR DESCRIPTION
Fixes #2011 

- Removes dependency on github user content JSON file which has not been updated in around 6 months.  This will allow Chinese users to load the staking page without being on a VPN that can access github.com! 🎉 
- Finds staking pools using indexer query by way of `near-contract-helper` (near/near-contract-helper/pull/478)