### PR TITLE
Profile 'Lockup balance': deduct 'staking' balance

### DIFF
--- a/packages/frontend/src/reducers/selectors/balance.js
+++ b/packages/frontend/src/reducers/selectors/balance.js
@@ -46,7 +46,7 @@ export const selectProfileBalance = (walletAccount) => {
         } = balance;
 
         lockupBalance = {
-            lockupBalance: totalBalance.toString(),
+            lockupBalance: new BN(totalBalance).sub(new BN(stakedBalanceLockup)).toString(),
             reservedForStorage: LOCKUP_MIN_BALANCE.toString(),
             inStakingPools: {
                 sum: stakedBalanceLockup.toString(),


### PR DESCRIPTION
Profile 'Lockup balance': deduct 'staking' balance to align with 'Wallet balance'

This is a followup fix for https://github.com/near/near-wallet/pull/2076