### PR TITLE
Revert "Fix Parse error"

### DIFF
--- a/packages/frontend/src/utils/wallet.js
+++ b/packages/frontend/src/utils/wallet.js
@@ -720,11 +720,8 @@ class Wallet {
         return decorateWithLockup(account);
     }
 
-    async getBalance(accountId = this.accountId, limitedAccountData = false) {
-        if (!accountId) {
-            return false;
-        }
-
+    async getBalance(accountId, limitedAccountData = false) {
+        accountId = accountId || this.accountId;
         const account = await this.getAccount(accountId);
         return await account.getAccountBalance(limitedAccountData);
     }


### PR DESCRIPTION
Reverts near/near-wallet#2149

This PR broke balance loading on the main dashboard -- it spins indefinitely and never loads NEAR token balance when this code is changed.

My suspicion is that the existing logic relied on an empty string being falsy to fall back to `this.accountId`, but function signature's defaults check _existence_, not falsyness, to identify if they should be applied.

cc: @marcinbodnar 