### PR TITLE
Ensure Enterprise ReCAPTCHA loads from `recaptcha.net`

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -31,7 +31,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-google-recaptcha": "^2.1.0",
-    "react-google-recaptcha-v3": "^1.9.5",
+    "react-google-recaptcha-v3-near": "^2.0.0",
     "react-helmet": "^6.1.0",
     "react-localize-redux": "^3.5.3",
     "react-phone-number-input": "2.3.11",

--- a/packages/frontend/src/components/accounts/create/verify_account/VerifyAccountWrapper.js
+++ b/packages/frontend/src/components/accounts/create/verify_account/VerifyAccountWrapper.js
@@ -1,7 +1,7 @@
 import { getLocation } from 'connected-react-router';
 import { PublicKey, KeyType } from 'near-api-js/lib/utils/key_pair';
 import React, { useState, useEffect, useCallback } from 'react';
-import { useGoogleReCaptcha } from 'react-google-recaptcha-v3';
+import { useGoogleReCaptcha } from 'react-google-recaptcha-v3-near';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
@@ -62,7 +62,7 @@ export function VerifyAccountWrapper() {
         }
 
         return executeRecaptcha(event);
-    }, []);
+    }, [executeRecaptcha]);
 
     if (showEnterVerificationCode) {
         return (

--- a/packages/frontend/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
+++ b/packages/frontend/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
@@ -1,7 +1,7 @@
 import { KeyPair } from 'near-api-js';
 import { parseSeedPhrase } from 'near-seed-phrase';
 import React, { Component, createRef } from 'react';
-import { withGoogleReCaptcha } from 'react-google-recaptcha-v3';
+import { withGoogleReCaptcha } from 'react-google-recaptcha-v3-near';
 import { Translate } from 'react-localize-redux';
 import PhoneInput, { isValidPhoneNumber } from 'react-phone-number-input';
 import { connect } from 'react-redux';

--- a/packages/frontend/src/index.js
+++ b/packages/frontend/src/index.js
@@ -3,7 +3,7 @@ import "regenerator-runtime/runtime";
 import { createBrowserHistory } from 'history';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { GoogleReCaptchaProvider } from 'react-google-recaptcha-v3';
+import { GoogleReCaptchaProvider } from 'react-google-recaptcha-v3-near';
 import { LocalizeProvider } from 'react-localize-redux';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';

--- a/packages/frontend/yarn.lock
+++ b/packages/frontend/yarn.lock
@@ -11695,10 +11695,10 @@ react-fast-compare@^3.0.1, react-fast-compare@^3.1.1, react-fast-compare@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-google-recaptcha-v3@^1.9.5:
-  version "1.9.5"
-  resolved "https://registry.yarnpkg.com/react-google-recaptcha-v3/-/react-google-recaptcha-v3-1.9.5.tgz#208834732c1e42a6f8503ab186de12398b8bf63f"
-  integrity sha512-WmrhBMCnJovUPdA5S+9SmYlPTPIDXmUJWlHlOnJAXdU0cyZcVkqwln3kIj/NLl8Y6HH/4lKgno5N/e1N+fEtfg==
+react-google-recaptcha-v3-near@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-google-recaptcha-v3-near/-/react-google-recaptcha-v3-near-2.0.0.tgz#3a4e00c2add7b097468d9096eb5166c9a119c9a0"
+  integrity sha512-ZX+hQmKGUmUgyS/z0iiJRKasnHC6h+1jzlus1xpAzNzu/dpItbY06zBGGUvjhG8aC1akUW0kPtZkuP4LECj6qw==
   dependencies:
     hoist-non-react-statics "^3.3.2"
 


### PR DESCRIPTION
Replaces `react-google-recaptcha-v3` with `react-google-recaptcha-v3-near`, which fixes Enterprise ReCAPTCHA not using `recaptcha.net`.

Hopefully we can undo this and delete the `react-google-recaptcha-v3-near` package entirely, when/if @t49tran accepts/merges this issue/PR:
https://github.com/t49tran/react-google-recaptcha-v3/issues/103