### PR TITLE
allow cross origin images to load

### DIFF
--- a/packages/frontend/src/components/wallet/NFTBox.js
+++ b/packages/frontend/src/components/wallet/NFTBox.js
@@ -132,7 +132,7 @@ const NFTBox = ({ tokenDetails }) => {
                 <div className='tokens'>
                     {ownedTokensMetadata.map(({ token_id, metadata: { mediaUrl, title } }) => {
                         return <div className='nft' key={token_id}>
-                            <img src={mediaUrl} alt='NFT' onError={(e) => {
+                            <img crossOrigin="*" src={mediaUrl} alt='NFT' onError={(e) => {
                                 e.target.onerror = null;
                                 e.target.src = FailedToLoad;
                             }}/>


### PR DESCRIPTION
Some IPFS gateways don't send correct headers e.g. `https://ipfs.io/ipfs/...`

Metadata:
https://media.discordapp.net/attachments/828059346235162655/892095007383777330/unknown.png

Results this in the wallet:
![image](https://user-images.githubusercontent.com/321340/134992173-795b716b-fe11-4272-8a42-56aecd0bd8c3.png)
