### PR TITLE
ADD modifications to lockup balance display

### DIFF
--- a/packages/frontend/src/config.js
+++ b/packages/frontend/src/config.js
@@ -1,4 +1,3 @@
-import BN from 'bn.js';
 import * as nearApiJs from 'near-api-js';
 
 export const ACCOUNT_HELPER_URL = process.env.REACT_APP_ACCOUNT_HELPER_URL || 'https://near-contract-helper.onrender.com';

--- a/packages/frontend/src/config.js
+++ b/packages/frontend/src/config.js
@@ -16,7 +16,6 @@ export const LINKDROP_GAS = process.env.LINKDROP_GAS || '100000000000000';
 export const LOCKUP_ACCOUNT_ID_SUFFIX = process.env.LOCKUP_ACCOUNT_ID_SUFFIX || 'lockup.near';
 export const MIN_BALANCE_FOR_GAS = process.env.REACT_APP_MIN_BALANCE_FOR_GAS || nearApiJs.utils.format.parseNearAmount('0.05');
 export const MIN_BALANCE_TO_CREATE = process.env.MIN_BALANCE_TO_CREATE || nearApiJs.utils.format.parseNearAmount('0.1');
-export const MIN_LOCKUP_AMOUNT = new BN(process.env.MIN_LOCKUP_AMOUNT || nearApiJs.utils.format.parseNearAmount('35.00001'));
 export const MOONPAY_API_KEY = process.env.MOONPAY_API_KEY || 'pk_test_wQDTsWBsvUm7cPiz9XowdtNeL5xasP9';
 export const MOONPAY_API_URL = process.env.MOONPAY_API_URL || 'https://api.moonpay.com';
 export const MOONPAY_BUY_URL = process.env.MOONPAY_BUY_URL || 'https://buy.moonpay.io?apiKey=';

--- a/packages/frontend/src/redux/actions/staking.js
+++ b/packages/frontend/src/redux/actions/staking.js
@@ -4,11 +4,10 @@ import { createActions } from 'redux-actions';
 
 import {
     ACCOUNT_HELPER_URL,
-    MIN_LOCKUP_AMOUNT,
     REACT_APP_USE_TESTINGLOCKUP,
     STAKING_GAS_BASE,
 } from '../../config';
-import { getLockupAccountId } from '../../utils/account-with-lockup';
+import { getLockupAccountId, getLockupMinBalanceForStorage } from '../../utils/account-with-lockup';
 import { showAlert } from '../../utils/alerts';
 import { 
     STAKING_AMOUNT_DEVIATION,
@@ -262,9 +261,10 @@ export const { staking } = createActions({
         UPDATE_LOCKUP: async (contract, account_id, exAccountId, accountId, validators) => {
             // use MIN_LOCKUP_AMOUNT vs. actual storage amount
             const deposited = new BN(await contract.get_known_deposited_balance());
+            const { code_hash } = await contract.account.state();
             let totalUnstaked = new BN(await contract.get_owners_balance())
                 .add(new BN(await contract.get_locked_amount()))
-                .sub(MIN_LOCKUP_AMOUNT)
+                .sub(getLockupMinBalanceForStorage(code_hash))
                 .sub(deposited);
 
             // minimum displayable for totalUnstaked 

--- a/packages/frontend/src/redux/reducers/selectors/balance.js
+++ b/packages/frontend/src/redux/reducers/selectors/balance.js
@@ -21,7 +21,7 @@ export const selectProfileBalance = (walletAccount) => {
         stakedBalanceLockup,
         account,
         available,
-        lockupStateStaked
+        lockupReservedForStorage
     } = balance;
 
     const lockupIdExists = !!lockedAmount;
@@ -47,7 +47,7 @@ export const selectProfileBalance = (walletAccount) => {
 
         lockupBalance = {
             lockupBalance: new BN(totalBalance).sub(new BN(stakedBalanceLockup)).toString(),
-            reservedForStorage: lockupStateStaked.toString(),
+            reservedForStorage: lockupReservedForStorage.toString(),
             inStakingPools: {
                 sum: stakedBalanceLockup.toString(),
                 staked: lockupAccount?.totalStaked,

--- a/packages/frontend/src/redux/reducers/selectors/balance.js
+++ b/packages/frontend/src/redux/reducers/selectors/balance.js
@@ -1,7 +1,6 @@
 import BN from 'bn.js';
 
-import { MIN_BALANCE_FOR_GAS } from '../../../config';
-import { LOCKUP_MIN_BALANCE } from '../../../utils/account-with-lockup';
+import { MIN_BALANCE_FOR_GAS } from '../../../utils/wallet';
 
 export const selectProfileBalance = (walletAccount) => {
     const balance = walletAccount?.balance;
@@ -21,7 +20,8 @@ export const selectProfileBalance = (walletAccount) => {
         balanceAvailable,
         stakedBalanceLockup,
         account,
-        available
+        available,
+        lockupStateStaked
     } = balance;
 
     const lockupIdExists = !!lockedAmount;
@@ -47,7 +47,7 @@ export const selectProfileBalance = (walletAccount) => {
 
         lockupBalance = {
             lockupBalance: new BN(totalBalance).sub(new BN(stakedBalanceLockup)).toString(),
-            reservedForStorage: LOCKUP_MIN_BALANCE.toString(),
+            reservedForStorage: lockupStateStaked.toString(),
             inStakingPools: {
                 sum: stakedBalanceLockup.toString(),
                 staked: lockupAccount?.totalStaked,

--- a/packages/frontend/src/utils/account-with-lockup.js
+++ b/packages/frontend/src/utils/account-with-lockup.js
@@ -224,7 +224,7 @@ async function getAccountBalance(limitedAccountData = false) {
                         let totalTime = vestingInformation.vestingEnd.sub(
                             vestingInformation.vestingStart
                         );
-                        unvestedAmount = lockupAmount.mul(timeLeft).div(totalTime);
+                        unvestedAmount = new BN(lockupAmount).mul(timeLeft).div(totalTime);
                     }
                 }
             }

--- a/packages/frontend/src/utils/account-with-lockup.js
+++ b/packages/frontend/src/utils/account-with-lockup.js
@@ -2,6 +2,7 @@ import BN from 'bn.js';
 import sha256 from 'js-sha256';
 import { Account, Connection, InMemorySigner, KeyPair } from 'near-api-js';
 import { InMemoryKeyStore } from 'near-api-js/lib/key_stores';
+import { parseNearAmount } from 'near-api-js/lib/utils/format';
 import { BinaryReader } from 'near-api-js/lib/utils/serialize';
 
 import {
@@ -27,7 +28,7 @@ const LOCKUP_CONTRACT_CODE_HASH_PR_MAP = {
     '3kVY9qcVRoW3B5498SMX6R3rtSLiCdmBzKs7zcnzDJ7Q': 106,
     'Cw7bnyp4B6ypwvgZuMmJtY6rHsxP2D4PC8deqeJ3HP7D': 136,
     '3kSoLAJpMjyHtG1s45YBbAM4vXwgGj5vFAJ4AQWcwCN9': 151
-}
+};
 
 const BASE_GAS = new BN('25000000000000');
 
@@ -200,7 +201,7 @@ async function getAccountBalance(limitedAccountData = false) {
         const { transfer_poll_account_id, transfers_timestamp } = transferInformation;
         let transfersTimestamp = transfer_poll_account_id ? await this.viewFunction(transfer_poll_account_id, 'get_result') : transfers_timestamp;
         transfersTimestamp = transfersTimestamp || (Date.now() * 1000000).toString();
-        const { code_hash: lockupContractCodeHash } = await lockupAccount.state()
+        const { code_hash: lockupContractCodeHash } = await lockupAccount.state();
 
         const hasBrokenTimestamp = LOCKUP_CONTRACT_CODE_HASH_PR_MAP[lockupContractCodeHash] < 136;
 

--- a/packages/frontend/src/utils/account-with-lockup.js
+++ b/packages/frontend/src/utils/account-with-lockup.js
@@ -161,6 +161,10 @@ function subtractReservedForGas(balance) {
     return availableBalance.isNeg() ? '0' : availableBalance.toString();
 }
 
+export function getLockupMinBalanceForStorage(code_hash) {
+    return LOCKUP_CONTRACT_CODE_HASH_PR_MAP[code_hash] <= 151 ? LOCKUP_MIN_BALANCE_OLD : LOCKUP_MIN_BALANCE;
+}
+
 async function getAccountBalance(limitedAccountData = false) {
     const balance = await this.wrappedAccount.getAccountBalance();
 
@@ -285,7 +289,7 @@ async function getAccountBalance(limitedAccountData = false) {
             stakedBalanceLockup: stakedBalanceLockup,
             lockupAccountId,
             stakedBalanceMainAccount,
-            lockupReservedForStorage: LOCKUP_CONTRACT_CODE_HASH_PR_MAP[lockupContractCodeHash] <= 151 ? LOCKUP_MIN_BALANCE_OLD : LOCKUP_MIN_BALANCE
+            lockupReservedForStorage: getLockupMinBalanceForStorage(lockupContractCodeHash)
         };
     } catch (error) {
         if (error.message.match(/ccount ".+" doesn't exist/) || error.message.includes('does not exist while viewing') || error.message.includes('cannot find contract code for account')) {

--- a/packages/frontend/src/utils/account-with-lockup.js
+++ b/packages/frontend/src/utils/account-with-lockup.js
@@ -170,7 +170,7 @@ async function getAccountBalance(limitedAccountData = false) {
     try {
         const lockupAccount = new Account(this.connection, lockupAccountId);
         const lockupBalance = await lockupAccount.getAccountBalance();
-        const lockupStateStaked = new BN(lockupBalance.stateStaked)
+        const lockupStateStaked = new BN(lockupBalance.stateStaked);
         const {
             lockupAmount,
             releaseDuration,
@@ -185,7 +185,7 @@ async function getAccountBalance(limitedAccountData = false) {
 
         const { transfer_poll_account_id, transfers_timestamp } = transferInformation;
         let transfersTimestamp = transfer_poll_account_id ? await this.viewFunction(transfer_poll_account_id, 'get_result') : transfers_timestamp;
-        transfersTimestamp = transfersTimestamp || (Date.now() * 1000000);
+        transfersTimestamp = transfersTimestamp || (Date.now() * 1000000).toString();
 
         const hasBrokenTimestamp = [
             '3kVY9qcVRoW3B5498SMX6R3rtSLiCdmBzKs7zcnzDJ7Q',
@@ -216,7 +216,7 @@ async function getAccountBalance(limitedAccountData = false) {
                 if(dateNowBN.lt(vestingInformation.vestingCliff)){
                     unvestedAmount = new BN(lockupAmount);
                 } else if(dateNowBN.gte(vestingInformation.vestingEnd)) {
-                    unvestedAmount = new BN(0)
+                    unvestedAmount = new BN(0);
                 } else {
                     let timeLeft = vestingInformation.vestingEnd.sub(dateNowBN);
                     let totalTime = vestingInformation.vestingEnd.sub(
@@ -238,7 +238,7 @@ async function getAccountBalance(limitedAccountData = false) {
             totalBalance = totalBalance.add(stakedBalanceLockup);
         }
         
-        const ownersBalance = totalBalance.sub(lockedAmount)
+        const ownersBalance = totalBalance.sub(lockedAmount);
 
         // if acc is deletable (nothing locked && nothing stake) you can transfer the whole amount ohterwise get_liquid_owners_balance
         const isAccDeletable = lockedAmount.isZero() && stakedBalanceLockup.isZero();


### PR DESCRIPTION
* Use [constant](https://github.com/near/core-contracts/blob/master/lockup/src/lib.rs#L33) (3.5 / 35 Ⓝ) conditional on PR # changing lockup_contract.wasm on [core-contracts repo](https://github.com/near/core-contracts) instead of always defaulting to old storage constant (35 Ⓝ)
* If transfers are disabled use current time as enabled timestamp
    * If `lockupTimestamp` was used amount released will be unaffected and will be based only on that timestamp
    * If `lockupDuration` was used amount will be locked since that duration is meant to be added to timestamp when transfers are enabled
* Include calculation of unvested funds in locked amount. Fixes #2014 
* Modify calculation of `liquidOwnersBalance` to use contract call on`get_liquid_owners_balance`
* Add new code hash broken timestamp from account-lookup repo
* Add support for vesting type 3
* Correctly return whole amount as locked if `start_time` is greater than current time. See https://github.com/near/account-lookup/pull/12. Current incorrect display [example](https://wallet.near.org/profile/cgran42.near) vs [account-lookup](https://near.github.io/account-lookup/#cgran42.near).