### PR TITLE
Recover w/ seed phrase: fix loader

### DIFF
--- a/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
@@ -45,6 +45,7 @@ const StyledContainer = styled(Container)`
 class RecoverAccountSeedPhrase extends Component {
     state = {
         seedPhrase: this.props.seedPhrase,
+        recoveringAccount: false
     }
 
     // TODO: Use some validation framework?
@@ -82,8 +83,13 @@ class RecoverAccountSeedPhrase extends Component {
 
         await Mixpanel.withTracking("IE-SP Recovery with seed phrase",
             async () => {
+                this.setState({ recoveringAccount: true });
                 await recoverAccountSeedPhrase(seedPhrase);
                 await refreshAccount();
+            }, (e) => {
+                throw e;
+            }, () => {
+                this.setState({ recoveringAccount: false });
             }
         );
 

--- a/packages/frontend/src/components/accounts/RecoverAccountSeedPhraseForm.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountSeedPhraseForm.js
@@ -6,11 +6,11 @@ import classNames from '../../utils/classNames';
 import FormButton from '../common/FormButton';
 
 const RecoverAccountSeedPhraseForm = ({
-    mainLoader,
     isLegit,
     handleChange,
     seedPhrase,
-    localAlert
+    localAlert,
+    recoveringAccount
 }) => (
         <>
             <h4><Translate id='recoverSeedPhrase.seedPhraseInput.title' /></h4>
@@ -21,7 +21,7 @@ const RecoverAccountSeedPhraseForm = ({
                         onChange={e => handleChange(e.target.value)}
                         className={classNames([{'success': localAlert && localAlert.success}, {'problem': localAlert && localAlert.success === false}])}
                         placeholder={translate('recoverSeedPhrase.seedPhraseInput.placeholder')}
-                        disabled={mainLoader}
+                        disabled={recoveringAccount}
                         data-test-id="seedPhraseRecoveryInput"
                         required
                         tabIndex='2'
@@ -32,7 +32,7 @@ const RecoverAccountSeedPhraseForm = ({
             <FormButton
                 type='submit'
                 color='blue'
-                disabled={!isLegit || mainLoader}
+                disabled={!isLegit || recoveringAccount}
                 sending={actionsPending(['RECOVER_ACCOUNT_SEED_PHRASE', 'REFRESH_ACCOUNT_OWNER'])}
                 sendingString='button.recovering'
             >


### PR DESCRIPTION
**Problem**
Seed phrase form is sometimes initially disabled when landing on `/recover-seed-phrase` because of potential background data loading for an existing account (`mainLoader`)

**Fix**
Replacing `mainLoader` with `recoveringAccount` state to avoid false positive loading state.