### PR TITLE
support loading NFT image from data: URI

### DIFF
--- a/packages/frontend/src/services/NonFungibleTokens.js
+++ b/packages/frontend/src/services/NonFungibleTokens.js
@@ -52,7 +52,7 @@ export default class NonFungibleTokens {
                 if (base_uri) {
                     mediaUrl = `${base_uri}/${media}`;
                 } else {
-                    mediaUrl = `https://cloudflare-ipfs.com/ipfs/${media}`;
+                    mediaUrl = (media.substr(0, 10) === 'data:image') ? media : `https://cloudflare-ipfs.com/ipfs/${media}`;
                 }
             } else {
                 mediaUrl = media;

--- a/packages/frontend/src/services/NonFungibleTokens.js
+++ b/packages/frontend/src/services/NonFungibleTokens.js
@@ -52,7 +52,7 @@ export default class NonFungibleTokens {
                 if (base_uri) {
                     mediaUrl = `${base_uri}/${media}`;
                 } else {
-                    mediaUrl = (media.substr(0, 10) === 'data:image') ? media : `https://cloudflare-ipfs.com/ipfs/${media}`;
+                    mediaUrl = media.startsWith('data:image') ? media : `https://cloudflare-ipfs.com/ipfs/${media}`;
                 }
             } else {
                 mediaUrl = media;


### PR DESCRIPTION
This PR updates visualization of NFT for displaying the data which is taken from NFT metadata directly.

Testing plan
===

Tested on `nenene.testnet`
![image](https://user-images.githubusercontent.com/5685493/140183941-f22975ef-d9bc-4030-a371-00ee83e3ba36.png)

Data loaded from metadata: `data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1MCIgaGVpZ2h0PSI1MCI+PGNpcmNsZSBjeD0iMjUiIGN5PSIyNSIgcj0iMjAiIHN0cm9rZT0ib3JhbmdlIiBzdHJva2Utd2lkdGg9IjQiIGZpbGw9InllbGxvdyIgLz48L3N2Zz4=`