### PR TITLE
Create w/ link + coin-op 1.5: handle error

### DIFF
--- a/packages/frontend/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
+++ b/packages/frontend/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
@@ -307,6 +307,7 @@ class SetupRecoveryMethod extends Component {
             }
         } catch (e) {
             this.setState({ settingUpNewAccount: false });
+            throw e;
         }
     }
 

--- a/packages/frontend/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
+++ b/packages/frontend/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
@@ -140,16 +140,16 @@ class SetupRecoveryMethod extends Component {
         const { option, phoneNumber, email, country } = this.state;
 
         switch (option) {
-        case 'email':
-            return validateEmail(email);
-        case 'phone':
-            return isApprovedCountryCode(country) && isValidPhoneNumber(phoneNumber);
-        case 'phrase':
-            return true;
-        case 'ledger':
-            return true;
-        default:
-            return false;
+            case 'email':
+                return validateEmail(email);
+            case 'phone':
+                return isApprovedCountryCode(country) && isValidPhoneNumber(phoneNumber);
+            case 'phrase':
+                return true;
+            case 'ledger':
+                return true;
+            default:
+                return false;
         }
     }
 
@@ -205,7 +205,8 @@ class SetupRecoveryMethod extends Component {
             validateSecurityCode,
             saveAccount,
             location,
-            setLinkdropAmount
+            setLinkdropAmount,
+            redirectTo
         } = this.props;
 
         const fundingOptions = parseFundingOptions(location.search);
@@ -232,8 +233,6 @@ class SetupRecoveryMethod extends Component {
             // IDENTITY VERIFIED FUNDED ACCOUNT
             if (DISABLE_CREATE_ACCOUNT && !fundingOptions && ENABLE_IDENTITY_VERIFIED_ACCOUNT) {
                 try {
-
-                    // Call function directly to handle error silently
                     await wallet.createIdentityFundedAccount({
                         accountId,
                         kind: method.kind,
@@ -246,7 +245,35 @@ class SetupRecoveryMethod extends Component {
                     });
                 } catch (e) {
                     console.warn(e.code);
-                    await fundCreateAccount(accountId, recoveryKeyPair, method.kind);
+                    const isNewAccount = await checkIsNew(accountId);
+                    if (!isNewAccount) {
+                        const accessKeys = await wallet.getAccessKeys(accountId) || [];
+                        const publicKeys = accessKeys.map(key => key.public_key);
+                        const publicKeyExistsOnAccount = publicKeys.includes(recoveryKeyPair.publicKey.toString());
+
+                        if (publicKeyExistsOnAccount) {
+                            try {
+                                await wallet.saveAndMakeAccountActive(accountId);
+                                await wallet.addLocalKeyAndFinishSetup(accountId, method.kind, recoveryKeyPair.publicKey);
+                            } catch (e) {
+                                showCustomAlert({
+                                    success: false,
+                                    messageCodeHeader: 'error',
+                                    errorMessage: e.message
+                                });
+                                redirectTo('/recover-account');
+                            }
+                        } else {
+                            showCustomAlert({
+                                success: false,
+                                messageCodeHeader: 'error',
+                                messageCode: 'walletErrorCodes.createNewAccount.accountExists.error',
+                                errorMessage: e.message
+                            });
+                        }
+                    } else {
+                        await fundCreateAccount(accountId, recoveryKeyPair, method.kind);
+                    }
                 }
                 return;
             }
@@ -394,11 +421,11 @@ class SetupRecoveryMethod extends Component {
                         this.handleNext();
                         e.preventDefault();
                     }}>
-                        <h1><Translate id='setupRecovery.header'/></h1>
-                        <h2><Translate id='setupRecovery.subHeader'/></h2>
+                        <h1><Translate id='setupRecovery.header' /></h1>
+                        <h2><Translate id='setupRecovery.subHeader' /></h2>
                         <h4>
-                            <Translate id='setupRecovery.advancedSecurity'/>
-                            <Tooltip translate='profile.security.mostSecureDesc' icon='icon-lg'/>
+                            <Translate id='setupRecovery.advancedSecurity' />
+                            <Tooltip translate='profile.security.mostSecureDesc' icon='icon-lg' />
                         </h4>
                         <RecoveryOption
                             onClick={() => this.setState({ option: 'phrase' })}
@@ -407,16 +434,16 @@ class SetupRecoveryMethod extends Component {
                             disabled={this.checkDisabled('phrase')}
                         />
                         {(this.checkNewAccount() || !twoFactor) &&
-                        <RecoveryOption
-                            onClick={() => this.setState({ option: 'ledger' })}
-                            option='ledger'
-                            active={option}
-                            disabled={ledgerKey !== null && accountId === activeAccountId}
-                        />
+                            <RecoveryOption
+                                onClick={() => this.setState({ option: 'ledger' })}
+                                option='ledger'
+                                active={option}
+                                disabled={ledgerKey !== null && accountId === activeAccountId}
+                            />
                         }
                         <h4>
-                            <Translate id='setupRecovery.basicSecurity'/>
-                            <Tooltip translate='profile.security.lessSecureDesc' icon='icon-lg'/>
+                            <Translate id='setupRecovery.basicSecurity' />
+                            <Tooltip translate='profile.security.lessSecureDesc' icon='icon-lg' />
                         </h4>
                         <RecoveryOption
                             onClick={() => {
@@ -479,7 +506,7 @@ class SetupRecoveryMethod extends Component {
                                             ref={this.phoneInput}
                                         />
                                         {!isApprovedCountryCode(country) &&
-                                        <div className='color-red'>{translate('setupRecovery.notSupportedPhone')}</div>
+                                            <div className='color-red'>{translate('setupRecovery.notSupportedPhone')}</div>
                                         }
                                     </>
                                 )}
@@ -493,11 +520,11 @@ class SetupRecoveryMethod extends Component {
                             trackingId='SR Click submit button'
                             data-test-id="submitSelectedRecoveryOption"
                         >
-                            <Translate id='button.continue'/>
+                            <Translate id='button.continue' />
                         </FormButton>
                     </form>
                     {isNewAccount &&
-                    <div className='recaptcha-disclaimer'><Translate id='reCAPTCHA.disclaimer'/></div>
+                        <div className='recaptcha-disclaimer'><Translate id='reCAPTCHA.disclaimer' /></div>
                     }
                 </StyledContainer>
             );
@@ -542,7 +569,7 @@ const mapDispatchToProps = {
 
 const mapStateToProps = (state, { match }) => {
     const accountId = match.params.accountId;
-    
+
     return {
         ...selectAccountSlice(state),
         router: getRouter(state),

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -140,7 +140,10 @@
             "error": "An error occured. Your send transaction was cancelled."
         },
         "createNewAccount": {
-            "error": "Account creation failed. You may want to try again."
+            "error": "Account creation failed. You may want to try again.",
+            "accountExists": {
+                "error": "Account creation failed. Account already exists."
+            }
         }
     },
     "account": {


### PR DESCRIPTION
**Problem**
We've had reports that sometimes creating an identity funded account w/ coin-op 1.5 returns an error, but the account is still successfully created. Currently we automatically send the user to the 'self funded' options page if an error occurs, which causes confusion since the account is already created.

**Solution**
This fix catches the error returned when calling `createIdentityFundedAccount`. Checks if the account exists on chain. If the account exists, it checks that the users public key also exists on the account, to verify ownership. It then attempts to finish the 'post account creation' setup by adding a local key, etc. If that fails, the user is redirected to the `/recover-account` route, for manual account recovery.

If the account exists, but the user is not the owner, an error is displayed on the UI, informing the user that the account already exists.

If the account does not exist, the user is then redirected to the 'self funded' options page (current UX).