### PR TITLE
App Login: fix double encoded URLs

### DIFF
--- a/packages/frontend/src/redux/actions/account.js
+++ b/packages/frontend/src/redux/actions/account.js
@@ -90,10 +90,13 @@ export const handleRefreshUrl = (prevRouter) => (dispatch, getState) => {
     const { pathname, search } = prevRouter?.location || getState().router.location;
     const currentPage = pathname.split('/')[pathname[1] === '/' ? 2 : 1];
 
+    // Decode twice in case some URI components have been encoded twice
+    const decodedSearch = decodeURIComponent(decodeURIComponent(search));
+
     if ([...WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS, WALLET_LOGIN_URL, WALLET_SIGN_URL, WALLET_LINKDROP_URL].includes(currentPage)) {
         const parsedUrl = {
             referrer: document.referrer && new URL(document.referrer).hostname,
-            ...parse(search),
+            ...parse(decodedSearch),
             redirect_url: prevRouter ? prevRouter.location.pathname : undefined
         };
         if ([WALLET_CREATE_NEW_ACCOUNT_URL, WALLET_LINKDROP_URL].includes(currentPage) && search !== '') {


### PR DESCRIPTION
Part of App login URLs may be double encoded, which currently causes parsing issues in the Wallet. This is fixed by double decoding the whole URL before parsing.

Example testing link (Testnet): https://sc-testnet.satori.art/#/NKC-Syd128r9PfGpyRxwt

Using the above testnet link will result in a double encoded `success_url`, which throws an error on the UI on wallet.testnet.near.org.

Use this PR testnet link: https://near-wallet-pr-2244.onrender.com/