### PR TITLE
Fix deleting lockup account and Staking page

### DIFF
--- a/packages/frontend/src/components/profile/Profile.js
+++ b/packages/frontend/src/components/profile/Profile.js
@@ -212,7 +212,7 @@ export function Profile({ match }) {
 
     return (
         <StyledContainer>
-            {isOwner && (hasLockup || profileBalance?.lockupIdExists) && new BN(profileBalance.lockupBalance.unlocked.availableToTransfer).gte(MINIMUM_AVAILABLE_TO_TRANSFER) &&
+            {isOwner && hasLockup && new BN(profileBalance.lockupBalance.unlocked.availableToTransfer).gte(MINIMUM_AVAILABLE_TO_TRANSFER) &&
                 <LockupAvailTransfer
                     available={profileBalance.lockupBalance.unlocked.availableToTransfer || '0'}
                     onTransfer={handleTransferFromLockup}
@@ -237,6 +237,13 @@ export function Profile({ match }) {
                             number={2}
                         />
                     )}
+                    {profileBalance?.lockupIdExists &&
+                        <SkeletonLoading
+                            height='323px'
+                            show={!hasLockup}
+                            number={1}
+                        />
+                    }
                     {isOwner && authorizedApps?.length ?
                         <>
                             <hr/>

--- a/packages/frontend/src/components/profile/Profile.js
+++ b/packages/frontend/src/components/profile/Profile.js
@@ -240,7 +240,7 @@ export function Profile({ match }) {
                     {profileBalance?.lockupIdExists &&
                         <SkeletonLoading
                             height='323px'
-                            show={!hasLockup}
+                            show={hasLockup === undefined}
                             number={1}
                         />
                     }

--- a/packages/frontend/src/components/profile/Profile.js
+++ b/packages/frontend/src/components/profile/Profile.js
@@ -18,7 +18,7 @@ import {
     getBalance
 } from '../../redux/actions/account';
 import { selectProfileBalance } from '../../redux/reducers/selectors/balance';
-import { selectAccountAuthorizedApps, selectAccountHas2fa, selectAccountId, selectAccountLedgerKey } from '../../redux/slices/account';
+import { selectAccountAuthorizedApps, selectAccountHas2fa, selectAccountHasLockup, selectAccountId, selectAccountLedgerKey } from '../../redux/slices/account';
 import { actions as recoveryMethodsActions, selectRecoveryMethodsByAccountId } from '../../redux/slices/recoveryMethods';
 import { selectNearTokenFiatValueUSD } from '../../redux/slices/tokenFiatValues';
 import isMobile from '../../utils/isMobile';
@@ -142,6 +142,7 @@ export function Profile({ match }) {
     const account = useAccount(accountId);
     const dispatch = useDispatch();
     const profileBalance = selectProfileBalance(account);
+    const hasLockup = useSelector(selectAccountHasLockup);
 
     const userRecoveryMethods = useSelector((state) => selectRecoveryMethodsByAccountId(state, { accountId: account.accountId }));
     const twoFactor = has2fa && userRecoveryMethods && userRecoveryMethods.filter(m => m.kind.includes('2fa'))[0];
@@ -208,7 +209,7 @@ export function Profile({ match }) {
 
     return (
         <StyledContainer>
-            {isOwner && profileBalance?.lockupIdExists && new BN(profileBalance.lockupBalance.unlocked.availableToTransfer).gte(MINIMUM_AVAILABLE_TO_TRANSFER) &&
+            {isOwner && hasLockup && new BN(profileBalance.lockupBalance.unlocked.availableToTransfer).gte(MINIMUM_AVAILABLE_TO_TRANSFER) &&
                 <LockupAvailTransfer
                     available={profileBalance.lockupBalance.unlocked.availableToTransfer || '0'}
                     onTransfer={handleTransferFromLockup}
@@ -223,6 +224,7 @@ export function Profile({ match }) {
                         <BalanceContainer
                             account={account}
                             profileBalance={profileBalance}
+                            hasLockup={hasLockup}
                             MIN_BALANCE_FOR_GAS_FORMATTED={formatNearAmount(MIN_BALANCE_FOR_GAS)}
                         />
                     ) : (

--- a/packages/frontend/src/components/profile/Profile.js
+++ b/packages/frontend/src/components/profile/Profile.js
@@ -212,7 +212,7 @@ export function Profile({ match }) {
 
     return (
         <StyledContainer>
-            {isOwner && hasLockup && new BN(profileBalance.lockupBalance.unlocked.availableToTransfer).gte(MINIMUM_AVAILABLE_TO_TRANSFER) &&
+            {isOwner && (hasLockup || profileBalance?.lockupIdExists) && new BN(profileBalance.lockupBalance.unlocked.availableToTransfer).gte(MINIMUM_AVAILABLE_TO_TRANSFER) &&
                 <LockupAvailTransfer
                     available={profileBalance.lockupBalance.unlocked.availableToTransfer || '0'}
                     onTransfer={handleTransferFromLockup}

--- a/packages/frontend/src/components/profile/Profile.js
+++ b/packages/frontend/src/components/profile/Profile.js
@@ -19,6 +19,7 @@ import {
 } from '../../redux/actions/account';
 import { selectProfileBalance } from '../../redux/reducers/selectors/balance';
 import { selectAccountAuthorizedApps, selectAccountHas2fa, selectAccountHasLockup, selectAccountId, selectAccountLedgerKey } from '../../redux/slices/account';
+import { selectAllAccountsHasLockup } from '../../redux/slices/allAccounts';
 import { actions as recoveryMethodsActions, selectRecoveryMethodsByAccountId } from '../../redux/slices/recoveryMethods';
 import { selectNearTokenFiatValueUSD } from '../../redux/slices/tokenFiatValues';
 import isMobile from '../../utils/isMobile';
@@ -142,7 +143,9 @@ export function Profile({ match }) {
     const account = useAccount(accountId);
     const dispatch = useDispatch();
     const profileBalance = selectProfileBalance(account);
-    const hasLockup = useSelector(selectAccountHasLockup);
+    const hasLockup = isOwner
+        ? useSelector(selectAccountHasLockup)
+        : useSelector((state) => selectAllAccountsHasLockup(state, { accountId }));
 
     const userRecoveryMethods = useSelector((state) => selectRecoveryMethodsByAccountId(state, { accountId: account.accountId }));
     const twoFactor = has2fa && userRecoveryMethods && userRecoveryMethods.filter(m => m.kind.includes('2fa'))[0];

--- a/packages/frontend/src/components/profile/balances/BalanceContainer.js
+++ b/packages/frontend/src/components/profile/balances/BalanceContainer.js
@@ -132,7 +132,7 @@ const Container = styled.div`
     }
 `;
 
-const BalanceContainer = ({ account, profileBalance, MIN_BALANCE_FOR_GAS_FORMATTED }) => {
+const BalanceContainer = ({ account, profileBalance, hasLockup, MIN_BALANCE_FOR_GAS_FORMATTED }) => {
     return (
         <Container>
             {profileBalance && 
@@ -179,7 +179,7 @@ const BalanceContainer = ({ account, profileBalance, MIN_BALANCE_FOR_GAS_FORMATT
                             </div>
                         </Accordion>
                     </div>
-                    {profileBalance.lockupIdExists &&
+                    {hasLockup &&
                         <div className='border-box'>
                             <div className='title last'>
                                 <h4><Translate id='profile.lockup.lockupId'/></h4>

--- a/packages/frontend/src/components/profile/balances/BalanceContainer.js
+++ b/packages/frontend/src/components/profile/balances/BalanceContainer.js
@@ -179,7 +179,7 @@ const BalanceContainer = ({ account, profileBalance, hasLockup, MIN_BALANCE_FOR_
                             </div>
                         </Accordion>
                     </div>
-                    {(hasLockup || profileBalance.lockupIdExists) &&
+                    {hasLockup &&
                         <div className='border-box'>
                             <div className='title last'>
                                 <h4><Translate id='profile.lockup.lockupId'/></h4>

--- a/packages/frontend/src/components/profile/balances/BalanceContainer.js
+++ b/packages/frontend/src/components/profile/balances/BalanceContainer.js
@@ -179,7 +179,7 @@ const BalanceContainer = ({ account, profileBalance, hasLockup, MIN_BALANCE_FOR_
                             </div>
                         </Accordion>
                     </div>
-                    {hasLockup &&
+                    {(hasLockup || profileBalance.lockupIdExists) &&
                         <div className='border-box'>
                             <div className='title last'>
                                 <h4><Translate id='profile.lockup.lockupId'/></h4>

--- a/packages/frontend/src/components/staking/StakingContainer.js
+++ b/packages/frontend/src/components/staking/StakingContainer.js
@@ -172,8 +172,8 @@ export function StakingContainer({ history, match }) {
     const hasLedger = useSelector(selectLedgerHasLedger);
     const staking = useSelector(selectStakingSlice);
     const nearTokenFiatValueUSD = useSelector(selectNearTokenFiatValueUSD);
+    const hasLockup = useSelector(selectAccountHasLockup);
 
-    const hasLockup = !!staking.lockupId;
     const { currentAccount } = staking;
     const stakingAccounts = staking.accounts;
     const validators = staking.allValidators;

--- a/packages/frontend/src/components/staking/StakingContainer.js
+++ b/packages/frontend/src/components/staking/StakingContainer.js
@@ -8,10 +8,10 @@ import { Mixpanel } from '../../mixpanel/index';
 import { getBalance } from '../../redux/actions/account';
 import {
     updateStaking,
-    staking as stakingActions,
-    handleStakingAction
+    handleStakingAction,
+    handleUpdateCurrent
 } from '../../redux/actions/staking';
-import { selectAccountHas2fa, selectAccountId, selectBalance } from '../../redux/slices/account';
+import { selectAccountHas2fa, selectAccountHasLockup, selectAccountId, selectBalance } from '../../redux/slices/account';
 import { selectLedgerHasLedger } from '../../redux/slices/ledger';
 import { selectStakingSlice } from '../../redux/slices/staking';
 import { selectStatusSlice } from '../../redux/slices/status';
@@ -199,7 +199,7 @@ export function StakingContainer({ history, match }) {
 
     const handleSwitchAccount = (accountId) => {
         setStakingAccountSelected(accountId);
-        dispatch(stakingActions.updateCurrent(accountId));
+        dispatch(handleUpdateCurrent(accountId));
     };
 
     const handleAction = async (action, validator, amount) => {

--- a/packages/frontend/src/redux/actions/account.js
+++ b/packages/frontend/src/redux/actions/account.js
@@ -49,7 +49,7 @@ import {
     selectBalance
 } from '../slices/account';
 import { selectAccountHasLockup } from '../slices/account';
-import { selectAllAccountsBalanceLockedAmount } from '../slices/allAccounts';
+import { selectAllAccountsHasLockup } from '../slices/allAccounts';
 import { selectAvailableAccounts } from '../slices/availableAccounts';
 import { 
     actions as flowLimitationActions,
@@ -77,7 +77,7 @@ export const getProfileStakingDetails = (externalAccountId) => async (dispatch, 
     await dispatch(handleStakingUpdateAccount([], externalAccountId));
 
     const lockupIdExists = externalAccountId
-        ? !!selectAllAccountsBalanceLockedAmount(getState(), { externalAccountId })
+        ? selectAllAccountsHasLockup(getState(), { accountId: externalAccountId })
         : selectAccountHasLockup(getState());
 
     lockupIdExists

--- a/packages/frontend/src/redux/actions/account.js
+++ b/packages/frontend/src/redux/actions/account.js
@@ -34,7 +34,6 @@ import { WalletError } from '../../utils/walletError';
 import refreshAccountOwner from '../sharedThunks/refreshAccountOwner';
 import { 
     selectAccountAccountsBalances,
-    selectAccountBalanceLockedAmount,
     selectAccountId,
     selectAccountUrl,
     selectAccountUrlCallbackUrl,
@@ -49,6 +48,7 @@ import {
     selectAccountUrlTransactions,
     selectBalance
 } from '../slices/account';
+import { selectAccountHasLockup } from '../slices/account';
 import { selectAllAccountsBalanceLockedAmount } from '../slices/allAccounts';
 import { selectAvailableAccounts } from '../slices/availableAccounts';
 import { 
@@ -78,7 +78,7 @@ export const getProfileStakingDetails = (externalAccountId) => async (dispatch, 
 
     const lockupIdExists = externalAccountId
         ? !!selectAllAccountsBalanceLockedAmount(getState(), { externalAccountId })
-        : !!getState().account.hasLockup;
+        : selectAccountHasLockup(getState());
 
     lockupIdExists
         && dispatch(handleStakingUpdateLockup(externalAccountId));

--- a/packages/frontend/src/redux/actions/account.js
+++ b/packages/frontend/src/redux/actions/account.js
@@ -77,7 +77,7 @@ export const getProfileStakingDetails = (accountId) => async (dispatch, getState
 
     const lockupIdExists = accountId
         ? !!selectAllAccountsBalanceLockedAmount(getState(), { accountId })
-        : !!selectAccountBalanceLockedAmount(getState());
+        : !!getState().account.hasLockup;
 
     lockupIdExists
         && dispatch(handleStakingUpdateLockup(accountId));

--- a/packages/frontend/src/redux/actions/account.js
+++ b/packages/frontend/src/redux/actions/account.js
@@ -71,16 +71,17 @@ const {
     handleClearflowLimitation
 } = flowLimitationActions;
 
-export const getProfileStakingDetails = (accountId) => async (dispatch, getState) => {
-    await dispatch(handleGetLockup(accountId));
-    await dispatch(handleStakingUpdateAccount([], accountId));
+export const getProfileStakingDetails = (externalAccountId) => async (dispatch, getState) => {
+    await dispatch(handleGetLockup(externalAccountId));
 
-    const lockupIdExists = accountId
-        ? !!selectAllAccountsBalanceLockedAmount(getState(), { accountId })
+    await dispatch(handleStakingUpdateAccount([], externalAccountId));
+
+    const lockupIdExists = externalAccountId
+        ? !!selectAllAccountsBalanceLockedAmount(getState(), { externalAccountId })
         : !!getState().account.hasLockup;
 
     lockupIdExists
-        && dispatch(handleStakingUpdateLockup(accountId));
+        && dispatch(handleStakingUpdateLockup(externalAccountId));
 };
 
 export const handleRedirectUrl = (previousLocation) => (dispatch, getState) => {

--- a/packages/frontend/src/redux/actions/staking.js
+++ b/packages/frontend/src/redux/actions/staking.js
@@ -9,6 +9,7 @@ import {
 } from '../../config';
 import { getLockupAccountId, getLockupMinBalanceForStorage } from '../../utils/account-with-lockup';
 import { showAlert } from '../../utils/alerts';
+import { setStakingAccountSelected } from '../../utils/localStorage';
 import { 
     STAKING_AMOUNT_DEVIATION,
     MIN_DISPLAY_YOCTO,
@@ -498,5 +499,17 @@ export const updateStaking = (currentAccountId, recentlyStakedValidators) => asy
         await dispatch(handleStakingUpdateLockup());
     }
 
-    dispatch(staking.updateCurrent(currentAccountId || accountId));
+    let currentAccount = getState().staking.accounts.find((account) => account.accountId === currentAccountId);
+    
+    if (!currentAccount) {
+        currentAccount = getState().staking.accounts.find((account) => account.accountId === accountId);
+        setStakingAccountSelected(accountId);
+    }
+
+    dispatch(staking.updateCurrent({ currentAccount }));
+};
+
+export const handleUpdateCurrent = (accountId) => async (dispatch, getState) => {
+    let currentAccount = getState().staking.accounts.find((account) => account.accountId === accountId);
+    dispatch(staking.updateCurrent({ currentAccount }));
 };

--- a/packages/frontend/src/redux/actions/staking.js
+++ b/packages/frontend/src/redux/actions/staking.js
@@ -42,6 +42,7 @@ import {
     selectStakingFindContractByValidatorId,
     selectStakingLockupId
 } from '../slices/staking';
+import { selectStakingCurrentAccountbyAccountId } from '../slices/staking';
 import { getBalance } from './account';
 
 const {
@@ -499,10 +500,10 @@ export const updateStaking = (currentAccountId, recentlyStakedValidators) => asy
         await dispatch(handleStakingUpdateLockup());
     }
 
-    let currentAccount = getState().staking.accounts.find((account) => account.accountId === currentAccountId);
+    let currentAccount = selectStakingCurrentAccountbyAccountId(getState(), { accountId: currentAccountId });
     
     if (!currentAccount) {
-        currentAccount = getState().staking.accounts.find((account) => account.accountId === accountId);
+        currentAccount = selectStakingCurrentAccountbyAccountId(getState(), { accountId });
         setStakingAccountSelected(accountId);
     }
 
@@ -510,6 +511,6 @@ export const updateStaking = (currentAccountId, recentlyStakedValidators) => asy
 };
 
 export const handleUpdateCurrent = (accountId) => async (dispatch, getState) => {
-    let currentAccount = getState().staking.accounts.find((account) => account.accountId === accountId);
+    let currentAccount = selectStakingCurrentAccountbyAccountId(getState(), { accountId });
     dispatch(staking.updateCurrent({ currentAccount }));
 };

--- a/packages/frontend/src/redux/reducers/account/index.js
+++ b/packages/frontend/src/redux/reducers/account/index.js
@@ -199,7 +199,16 @@ const account = handleActions({
                 loading: true
             }
         }
-    })
+    }),
+    [staking.getLockup]: (state, { error, payload, ready }) => 
+        (!ready || error)
+            ? {
+                ...state 
+            }
+            : {
+                ...state,
+                hasLockup: !!payload
+            },
 }, initialState);
 
 export default reduceReducers(

--- a/packages/frontend/src/redux/reducers/account/index.js
+++ b/packages/frontend/src/redux/reducers/account/index.js
@@ -200,13 +200,16 @@ const account = handleActions({
             }
         }
     }),
-    [staking.getLockup]: (state, { error, payload, ready, meta }) => 
-        (!ready || error || !meta.isOwner)
-            ? state
-            : {
-                ...state,
-                hasLockup: !!payload
-            }
+    [staking.getLockup]: (state, { error, payload, ready, meta }) => {
+        if (!ready || error || !meta.isOwner) {
+            return state;
+        }
+
+        return {
+            ...state,
+            hasLockup: !!payload
+        };
+    }
 }, initialState);
 
 export default reduceReducers(

--- a/packages/frontend/src/redux/reducers/account/index.js
+++ b/packages/frontend/src/redux/reducers/account/index.js
@@ -202,9 +202,7 @@ const account = handleActions({
     }),
     [staking.getLockup]: (state, { error, payload, ready }) => 
         (!ready || error)
-            ? {
-                ...state 
-            }
+            ? state
             : {
                 ...state,
                 hasLockup: !!payload

--- a/packages/frontend/src/redux/reducers/account/index.js
+++ b/packages/frontend/src/redux/reducers/account/index.js
@@ -200,13 +200,13 @@ const account = handleActions({
             }
         }
     }),
-    [staking.getLockup]: (state, { error, payload, ready }) => 
-        (!ready || error)
+    [staking.getLockup]: (state, { error, payload, ready, meta }) => 
+        (!ready || error || !meta.isOwner)
             ? state
             : {
                 ...state,
                 hasLockup: !!payload
-            },
+            }
 }, initialState);
 
 export default reduceReducers(

--- a/packages/frontend/src/redux/reducers/allAccounts/index.js
+++ b/packages/frontend/src/redux/reducers/allAccounts/index.js
@@ -43,6 +43,16 @@ const allAccountsReducer = handleActions({
                     }
                 }
             }),
+    [staking.getLockup]: (state, { ready, error, payload, meta }) => 
+        (error || !ready || meta.isOwner)
+            ? state
+            : ({
+                ...state,
+                [meta.accountId]: { 
+                    ...state[meta.accountId],
+                    hasLockup: !!payload
+                }
+            })
 }, initialState);
 
 

--- a/packages/frontend/src/redux/reducers/staking/index.js
+++ b/packages/frontend/src/redux/reducers/staking/index.js
@@ -60,7 +60,7 @@ const stakingHandlers = handleActions({
             }),
     [staking.updateCurrent]: (state, { payload }) => ({
         ...state,
-        currentAccount: state.accounts.find((account) => account.accountId === payload)
+        currentAccount: payload.currentAccount
     }),
     [staking.getLockup]: (state, { ready, error, payload }) => 
         (!ready || error)

--- a/packages/frontend/src/redux/slices/account/index.js
+++ b/packages/frontend/src/redux/slices/account/index.js
@@ -10,6 +10,8 @@ export const selectAccountId = createSelector(selectAccountSlice, (account) => a
 
 export const selectAccountHas2fa = createSelector(selectAccountSlice, (account) => account.has2fa);
 
+export const selectAccountHasLockup = createSelector(selectAccountSlice, (account) => account.hasLockup);
+
 export const selectAccountAuthorizedApps = createSelector(selectAccountSlice, (account) => account.authorizedApps || []);
 
 export const selectAccountFullAccessKeys = createSelector(selectAccountSlice, (account) => account.fullAccessKeys || []);

--- a/packages/frontend/src/redux/slices/allAccounts/index.js
+++ b/packages/frontend/src/redux/slices/allAccounts/index.js
@@ -23,3 +23,8 @@ export const selectAllAccountsBalanceLockedAmount = createSelector(
     [selectAllAccountsBalance],
     (balance) => balance.lockedAmount || ''
 );
+
+export const selectAllAccountsHasLockup = createSelector(
+    [selectAllAccountsByAccountId],
+    (account) => account.hasLockup
+);

--- a/packages/frontend/src/utils/account-with-lockup.js
+++ b/packages/frontend/src/utils/account-with-lockup.js
@@ -104,9 +104,9 @@ export async function transferAllFromLockup(missingAmount) {
     if (missingAmount && !liquidBalance.gt(missingAmount)) {
         throw new WalletError('Not enough tokens.', 'signAndSendTransactions.notEnoughTokens');
     }
-
-    console.info('Attempting to transfer from lockup account ID:', lockupAccountId);
+    
     if(liquidBalance.gt(new BN(0))) {
+        console.info('Attempting to transfer from lockup account ID:', lockupAccountId);
         await this.wrappedAccount.functionCall({
             contractId: lockupAccountId,
             methodName: "transfer",

--- a/packages/frontend/src/utils/account-with-lockup.js
+++ b/packages/frontend/src/utils/account-with-lockup.js
@@ -106,16 +106,18 @@ export async function transferAllFromLockup(missingAmount) {
     }
 
     console.info('Attempting to transfer from lockup account ID:', lockupAccountId);
-    await this.wrappedAccount.functionCall({
-        contractId: lockupAccountId,
-        methodName: "transfer",
-        args: {
-            // NOTE: Move all the liquid tokens to minimize transactions in the long run
-            amount: liquidBalance.toString(),
-            receiver_id: this.wrappedAccount.accountId,
-        },
-        gas: BASE_GAS.mul(new BN(2)),
-    });
+    if(liquidBalance.gt(new BN(0))) {
+        await this.wrappedAccount.functionCall({
+            contractId: lockupAccountId,
+            methodName: "transfer",
+            args: {
+                // NOTE: Move all the liquid tokens to minimize transactions in the long run
+                amount: liquidBalance.toString(),
+                receiver_id: this.wrappedAccount.accountId,
+            },
+            gas: BASE_GAS.mul(new BN(2)),
+        });
+    }
 
     const lockedBalance = new BN(await this.wrappedAccount.viewFunction(lockupAccountId, 'get_locked_amount'));
     if (lockedBalance.eq(new BN(0))) {


### PR DESCRIPTION
Error described in #2245 fixed by changing how `lockupIdExists` in `getProfileStakingDetails` action is set. Additionally handled `staking.getLockup` in `account` reducer to set `hasLockup` value that will help to reason what should be done while setting `lockupIdExists`.`hasLockup` also used in `StakingContainer` component.

Additionally, I found another bug. The problem was that if the user wanted to enter the Staking page after the lockup account was deleted, Wallet crashed. That was because we are storing previously selected `accountId` for Staking page in the local storage - and if the user has previously selected lockup account, we were trying to load staking details for this lockup account - that was failing. 

Fixed it by adding functionality that will detect if the lockup account stored in local storage exists, and if not it will switch to the main account automatically. 