### PR TITLE
Upgrade near api js 0.43.1

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -22,7 +22,7 @@
     "lodash.throttle": "^4.1.1",
     "lodash.update": "^4.10.2",
     "mixpanel-browser": "^2.41.0",
-    "near-api-js": "^0.39.0",
+    "near-api-js": "^0.43.1",
     "near-ledger-js": "^0.1.2",
     "near-seed-phrase": "^0.2.0",
     "prop-types": "^15.7.2",

--- a/packages/frontend/src/redux/actions/staking.js
+++ b/packages/frontend/src/redux/actions/staking.js
@@ -50,25 +50,47 @@ export const { staking } = createActions({
                     const selectedValidatorId = await contract.get_staking_pool_account_id();
                     if (validatorId !== selectedValidatorId) {
                         if (selectedValidatorId !== null) {
-                            await signAndSendTransaction(lockupId, [
-                                functionCall('unselect_staking_pool', {}, STAKING_GAS_BASE, '0')
-                            ]);
+                            await signAndSendTransaction({
+                                receiverId: lockupId,
+                                actions: [
+                                    functionCall('unselect_staking_pool', {}, STAKING_GAS_BASE, '0')
+                                ],
+                            });
                         }
-                        await signAndSendTransaction(lockupId, [
-                            functionCall('select_staking_pool', { staking_pool_account_id: validatorId }, STAKING_GAS_BASE * 3, '0')
-                        ]);
+                        await signAndSendTransaction({
+                            receiverId: lockupId,
+                            actions: [
+                                functionCall(
+                                    "select_staking_pool",
+                                    { staking_pool_account_id: validatorId },
+                                    STAKING_GAS_BASE * 3,
+                                    "0"
+                                ),
+                            ],
+                        });
                     }
-                    return await signAndSendTransaction(lockupId, [
-                        functionCall('deposit_and_stake', { amount }, STAKING_GAS_BASE * 5, '0')
-                    ]);
+                    return await signAndSendTransaction({
+                        receiverId: lockupId,
+                        actions: [
+                            functionCall(
+                                "deposit_and_stake",
+                                { amount },
+                                STAKING_GAS_BASE * 5,
+                                "0"
+                            ),
+                        ],
+                    });
                 },
                 () => showAlert({ onlyError: true })
             ],
             ACCOUNT: [
                 async (validatorId, amount, accountId, contract) => {
-                    const result = await signAndSendTransaction(validatorId, [
-                        functionCall('deposit_and_stake', {}, STAKING_GAS_BASE * 5, amount)
-                    ]);
+                    const result = await signAndSendTransaction({
+                        receiverId: validatorId,
+                        actions: [
+                            functionCall('deposit_and_stake', {}, STAKING_GAS_BASE * 5, amount)
+                        ],
+                    });
                     // wait for chain/explorer to index results
                     await new Promise((r) => setTimeout(r, EXPLORER_DELAY));
                     await updateStakedBalance(validatorId, accountId, contract);
@@ -81,13 +103,19 @@ export const { staking } = createActions({
             LOCKUP: [
                 async (lockupId, amount) => {
                     if (amount) {
-                        return await signAndSendTransaction(lockupId, [
-                            functionCall('unstake', { amount }, STAKING_GAS_BASE * 5, '0')
-                        ]);
+                        return await signAndSendTransaction({
+                            receiverId: lockupId,
+                            actions: [
+                                functionCall('unstake', { amount }, STAKING_GAS_BASE * 5, '0')
+                            ],
+                        });
                     }
-                    return await signAndSendTransaction(lockupId, [
-                        functionCall('unstake_all', {}, STAKING_GAS_BASE * 5, '0')
-                    ]);
+                    return await signAndSendTransaction({
+                        receiverId: lockupId,
+                        actions: [
+                            functionCall('unstake_all', {}, STAKING_GAS_BASE * 5, '0')
+                        ],
+                    });
                 },
                 () => showAlert({ onlyError: true })
             ],
@@ -95,13 +123,19 @@ export const { staking } = createActions({
                 async (validatorId, amount, accountId, contract) => {
                     let result;
                     if (amount) {
-                        result = await signAndSendTransaction(validatorId, [
-                            functionCall('unstake', { amount }, STAKING_GAS_BASE * 5, '0')
-                        ]);
+                        result = await signAndSendTransaction({
+                            receiverId: validatorId,
+                            actions: [
+                                functionCall('unstake', { amount }, STAKING_GAS_BASE * 5, '0')
+                            ],
+                        });
                     } else {
-                        result = await signAndSendTransaction(validatorId, [
-                            functionCall('unstake_all', {}, STAKING_GAS_BASE * 5, '0')
-                        ]);
+                        result = await signAndSendTransaction({
+                            receiverId: validatorId,
+                            actions: [
+                                functionCall('unstake_all', {}, STAKING_GAS_BASE * 5, '0')
+                            ],
+                        });
                     }
                     // wait for explorer to index results
                     await new Promise((r) => setTimeout(r, EXPLORER_DELAY));
@@ -116,13 +150,19 @@ export const { staking } = createActions({
                 async (lockupId, amount) => {
                     let result;
                     if (amount) {
-                        result = await signAndSendTransaction(lockupId, [
-                            functionCall('withdraw_from_staking_pool', { amount }, STAKING_GAS_BASE * 5, '0')
-                        ]);
+                        result = await signAndSendTransaction({
+                            receiverId: lockupId,
+                            actions: [
+                                functionCall('withdraw_from_staking_pool', { amount }, STAKING_GAS_BASE * 5, '0')
+                            ],
+                        });
                     } else {
-                        result = await signAndSendTransaction(lockupId, [
-                            functionCall('withdraw_all_from_staking_pool', {}, STAKING_GAS_BASE * 7, '0')
-                        ]);
+                        result = await signAndSendTransaction({
+                            receiverId: lockupId,
+                            actions: [
+                                functionCall('withdraw_all_from_staking_pool', {}, STAKING_GAS_BASE * 7, '0')
+                            ],
+                        });
                     }
                     if (result === false) {
                         throw new WalletError('Unable to withdraw pending balance from validator', 'staking.noWithdraw');
@@ -135,13 +175,19 @@ export const { staking } = createActions({
                 async (validatorId, amount) => {
                     let result;
                     if (amount) {
-                        result = await signAndSendTransaction(validatorId, [
-                            functionCall('withdraw', { amount }, STAKING_GAS_BASE * 5, '0')
-                        ]);
+                        result = await signAndSendTransaction({
+                            receiverId: validatorId,
+                            actions: [
+                                functionCall('withdraw', { amount }, STAKING_GAS_BASE * 5, '0')
+                            ],
+                        });
                     } else {
-                        result = await signAndSendTransaction(validatorId, [
-                            functionCall('withdraw_all', {}, STAKING_GAS_BASE * 7, '0')
-                        ]);
+                        result = await signAndSendTransaction({
+                            receiverId: validatorId,
+                            actions: [
+                                functionCall('withdraw_all', {}, STAKING_GAS_BASE * 7, '0')
+                            ],
+                        });
                     }
                     if (result === false) {
                         throw new WalletError('Unable to withdraw pending balance from validator', 'staking.noWithdraw');

--- a/packages/frontend/src/services/FungibleTokens.js
+++ b/packages/frontend/src/services/FungibleTokens.js
@@ -128,28 +128,36 @@ export default class FungibleTokens {
                 }
             }
 
-            return await account.signAndSendTransaction(contractName, [
-                functionCall('ft_transfer', {
-                    amount,
-                    memo: memo,
-                    receiver_id: receiverId,
-                }, FT_TRANSFER_GAS, FT_TRANSFER_DEPOSIT)
-            ]);
+            return await account.signAndSendTransaction({
+                receiverId: contractName,
+                actions: [
+                    functionCall(
+                        "ft_transfer",
+                        {
+                            amount,
+                            memo: memo,
+                            receiver_id: receiverId,
+                        },
+                        FT_TRANSFER_GAS,
+                        FT_TRANSFER_DEPOSIT
+                    ),
+                ],
+            });
         } else {
             return await account.sendMoney(receiverId, amount);
         }
     }
 
     async transferStorageDeposit({ account, contractName, receiverId, storageDepositAmount }) {
-        return account.signAndSendTransaction(
-            contractName,
-            [
+        return account.signAndSendTransaction({
+            receiverId: contractName,
+            actions: [
                 functionCall('storage_deposit', {
                     account_id: receiverId,
                     registration_only: true,
                 }, FT_STORAGE_DEPOSIT_GAS, storageDepositAmount)
             ]
-        );
+        });
     }
 }
 

--- a/packages/frontend/src/utils/account-with-lockup.js
+++ b/packages/frontend/src/utils/account-with-lockup.js
@@ -27,8 +27,17 @@ export function decorateWithLockup(account) {
     return decorated;
 }
 
-async function signAndSendTransaction(receiverId, actions) {
-    const { available: balance } = await this.wrappedAccount.getAccountBalance();
+async function signAndSendTransaction(...args) {
+    if(args.length === 1) return signAndSendTransactionV2.bind(this,...args);
+    else return signAndSendTransactionV1.bind(this, ...args);
+}
+
+async function signAndSendTransactionV1(receiverId, actions) {
+    return signAndSendTransactionV2({ receiverId, actions })
+}
+
+async function signAndSendTransactionV2({ receiverId, actions }) {
+    const { available: balance } = await this.wrappedAccount.getAccountBalance()
 
     // TODO: Extract code to compute total cost of transaction
     const total = actions.map(action => action?.transfer?.deposit || action?.functionCall?.deposit)
@@ -43,7 +52,7 @@ async function signAndSendTransaction(receiverId, actions) {
         await this.transferAllFromLockup(missingAmount);
     }
 
-    return await this.wrappedAccount.signAndSendTransaction.call(this, receiverId, actions);
+    return await this.wrappedAccount.signAndSendTransaction.call(this, { receiverId, actions });
 }
 
 async function deleteLockupAccount(lockupAccountId) {

--- a/packages/frontend/src/utils/account-with-lockup.js
+++ b/packages/frontend/src/utils/account-with-lockup.js
@@ -28,8 +28,8 @@ export function decorateWithLockup(account) {
 }
 
 async function signAndSendTransaction(...args) {
-    if(args.length === 1) return signAndSendTransactionV2.bind(this,...args);
-    else return signAndSendTransactionV1.bind(this, ...args);
+    if(args.length === 1) return signAndSendTransactionV2.apply(this, args);
+    else return signAndSendTransactionV1.apply(this, args);
 }
 
 async function signAndSendTransactionV1(receiverId, actions) {

--- a/packages/frontend/src/utils/account-with-lockup.js
+++ b/packages/frontend/src/utils/account-with-lockup.js
@@ -33,7 +33,7 @@ async function signAndSendTransaction(...args) {
 }
 
 async function signAndSendTransactionV1(receiverId, actions) {
-    return signAndSendTransactionV2({ receiverId, actions })
+    return signAndSendTransactionV2.call(this, { receiverId, actions })
 }
 
 async function signAndSendTransactionV2({ receiverId, actions }) {

--- a/packages/frontend/src/utils/account-with-lockup.js
+++ b/packages/frontend/src/utils/account-with-lockup.js
@@ -33,11 +33,11 @@ async function signAndSendTransaction(...args) {
 }
 
 async function signAndSendTransactionV1(receiverId, actions) {
-    return signAndSendTransactionV2.call(this, { receiverId, actions })
+    return signAndSendTransactionV2.call(this, { receiverId, actions });
 }
 
 async function signAndSendTransactionV2({ receiverId, actions }) {
-    const { available: balance } = await this.wrappedAccount.getAccountBalance()
+    const { available: balance } = await this.wrappedAccount.getAccountBalance();
 
     // TODO: Extract code to compute total cost of transaction
     const total = actions.map(action => action?.transfer?.deposit || action?.functionCall?.deposit)

--- a/packages/frontend/src/utils/account-with-lockup.js
+++ b/packages/frontend/src/utils/account-with-lockup.js
@@ -27,17 +27,9 @@ export function decorateWithLockup(account) {
     return decorated;
 }
 
-async function signAndSendTransaction(...args) {
-    if(args.length === 1) return signAndSendTransactionV2.apply(this, args);
-    else return signAndSendTransactionV1.apply(this, args);
-}
-
-async function signAndSendTransactionV1(receiverId, actions) {
-    return signAndSendTransactionV2.call(this, { receiverId, actions });
-}
-
-async function signAndSendTransactionV2({ receiverId, actions }) {
+async function signAndSendTransaction(signAndSendTransactionOptions) {
     const { available: balance } = await this.wrappedAccount.getAccountBalance();
+    const { actions } = signAndSendTransactionOptions;
 
     // TODO: Extract code to compute total cost of transaction
     const total = actions.map(action => action?.transfer?.deposit || action?.functionCall?.deposit)
@@ -52,7 +44,7 @@ async function signAndSendTransactionV2({ receiverId, actions }) {
         await this.transferAllFromLockup(missingAmount);
     }
 
-    return await this.wrappedAccount.signAndSendTransaction.call(this, { receiverId, actions });
+    return await this.wrappedAccount.signAndSendTransaction.call(this, signAndSendTransactionOptions);
 }
 
 async function deleteLockupAccount(lockupAccountId) {

--- a/packages/frontend/src/utils/account-with-lockup.js
+++ b/packages/frontend/src/utils/account-with-lockup.js
@@ -50,9 +50,14 @@ async function signAndSendTransaction(signAndSendTransactionOptions) {
 async function deleteLockupAccount(lockupAccountId) {
     console.info('Destroying lockup account to claim remaining funds', lockupAccountId);
     const newKeyPair = KeyPair.fromRandom('ed25519');
-    await this.wrappedAccount.functionCall(lockupAccountId, 'add_full_access_key', {
-        new_public_key: newKeyPair.publicKey.toString()
-    }, BASE_GAS.mul(new BN(2)));
+    await this.wrappedAccount.functionCall({
+        contractId: lockupAccountId,
+        methodName: "add_full_access_key",
+        args: {
+            new_public_key: newKeyPair.publicKey.toString(),
+        },
+        gas: BASE_GAS.mul(new BN(2)),
+    });
 
     const tmpKeyStore = new InMemoryKeyStore();
     await tmpKeyStore.setKey(this.connection.networkId, lockupAccountId, newKeyPair);
@@ -64,12 +69,20 @@ async function deleteLockupAccount(lockupAccountId) {
 export async function transferAllFromLockup(missingAmount) {
     let lockupAccountId = getLockupAccountId(this.accountId);
     if (!(await this.wrappedAccount.viewFunction(lockupAccountId, 'are_transfers_enabled'))) {
-        await this.wrappedAccount.functionCall(lockupAccountId, 'check_transfers_vote', {}, BASE_GAS.mul(new BN(3)));
+        await this.wrappedAccount.functionCall({
+            contractId: lockupAccountId,
+            methodName: "check_transfers_vote",
+            gas: BASE_GAS.mul(new BN(3)),
+        });
     }
 
     const poolAccountId = await this.wrappedAccount.viewFunction(lockupAccountId, 'get_staking_pool_account_id');
     if (poolAccountId) {
-        await this.wrappedAccount.functionCall(lockupAccountId, 'refresh_staking_pool_balance', {}, BASE_GAS.mul(new BN(3)));
+        await this.wrappedAccount.functionCall({
+            contractId: lockupAccountId,
+            methodName: "refresh_staking_pool_balance",
+            gas: BASE_GAS.mul(new BN(3)),
+        });
     }
 
     let liquidBalance = new BN(await this.wrappedAccount.viewFunction(lockupAccountId, 'get_liquid_owners_balance'));
@@ -79,11 +92,16 @@ export async function transferAllFromLockup(missingAmount) {
     }
 
     console.info('Attempting to transfer from lockup account ID:', lockupAccountId);
-    await this.wrappedAccount.functionCall(lockupAccountId, 'transfer', {
-        // NOTE: Move all the liquid tokens to minimize transactions in the long run
-        amount: liquidBalance.toString(),
-        receiver_id: this.wrappedAccount.accountId
-    }, BASE_GAS.mul(new BN(2)));
+    await this.wrappedAccount.functionCall({
+        contractId: lockupAccountId,
+        methodName: "transfer",
+        args: {
+            // NOTE: Move all the liquid tokens to minimize transactions in the long run
+            amount: liquidBalance.toString(),
+            receiver_id: this.wrappedAccount.accountId,
+        },
+        gas: BASE_GAS.mul(new BN(2)),
+    });
 
     const lockedBalance = new BN(await this.wrappedAccount.viewFunction(lockupAccountId, 'get_locked_amount'));
     if (lockedBalance.eq(new BN(0))) {
@@ -93,7 +111,11 @@ export async function transferAllFromLockup(missingAmount) {
         }
 
         if (poolAccountId) {
-            await this.wrappedAccount.functionCall(lockupAccountId, 'unselect_staking_pool', {}, BASE_GAS.mul(new BN(2)));
+            await this.wrappedAccount.functionCall({
+                contractId: lockupAccountId,
+                methodName: "unselect_staking_pool",
+                gas: BASE_GAS.mul(new BN(2)),
+            });
         }
 
         await this.deleteLockupAccount(lockupAccountId);

--- a/packages/frontend/src/utils/staking.js
+++ b/packages/frontend/src/utils/staking.js
@@ -61,8 +61,8 @@ export const lockupMethods = {
     ]
 };
 
-export async function signAndSendTransaction(receiverId, actions) {
-    return (await wallet.getAccount(wallet.accountId)).signAndSendTransaction(receiverId, actions);
+export async function signAndSendTransaction(signAndSendTransactionOptions) {
+    return (await wallet.getAccount(wallet.accountId)).signAndSendTransaction(signAndSendTransactionOptions);
 }
 
 export async function updateStakedBalance(validatorId, account_id, contract) {

--- a/packages/frontend/src/utils/wallet.js
+++ b/packages/frontend/src/utils/wallet.js
@@ -436,11 +436,19 @@ class Wallet {
         newPublicKey,
         newInitialBalance
     }) {
-        const { status: { SuccessValue: createResultBase64 }, transaction: { hash: transactionHash } } =
-            await account.functionCall(ACCOUNT_ID_SUFFIX, 'create_account', {
+        const {
+            status: { SuccessValue: createResultBase64 },
+            transaction: { hash: transactionHash },
+        } = await account.functionCall({
+            contractId: ACCOUNT_ID_SUFFIX,
+            methodName: "create_account",
+            args: {
                 new_account_id: newAccountId,
-                new_public_key: newPublicKey.toString().replace(/^ed25519:/, '')
-            }, LINKDROP_GAS, newInitialBalance);
+                new_public_key: newPublicKey.toString().replace(/^ed25519:/, ""),
+            },
+            gas: LINKDROP_GAS,
+            attachedDeposit: newInitialBalance,
+        });
         const createResult = JSON.parse(Buffer.from(createResultBase64, 'base64'));
         if (!createResult) {
             throw new WalletError('Creating account has failed', 'createAccount.returnedFalse', { transactionHash });

--- a/packages/frontend/src/utils/wallet.js
+++ b/packages/frontend/src/utils/wallet.js
@@ -1053,7 +1053,7 @@ class Wallet {
             // See https://github.com/near/near-wallet/issues/1856
             const recreateTransaction = account.deployMultisig || true;
             if (recreateTransaction) {
-                ({ status, transaction } = await account.signAndSendTransaction(receiverId, actions));
+                ({ status, transaction } = await account.signAndSendTransaction({ receiverId, actions }));
             } else {
                 // TODO: Maybe also only take receiverId and actions as with multisig path?
                 const [, signedTransaction] = await nearApiJs.transactions.signTransaction(receiverId, nonce, actions, blockHash, this.connection.signer, accountId, NETWORK_ID);

--- a/packages/frontend/yarn.lock
+++ b/packages/frontend/yarn.lock
@@ -2604,20 +2604,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/bn.js@^4.11.5":
-  version "4.11.6"
-  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
-  integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
-  dependencies:
-    "@types/node" "*"
-
-"@types/bn.js@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.0.tgz#32c5d271503a12653c62cf4d2b45e6eab8cebc68"
-  integrity sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/braces@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.0.tgz#7da1c0d44ff1c7eb660a36ec078ea61ba7eb42cb"
@@ -4071,15 +4057,15 @@ bluebird@^3.3.5, bluebird@^3.5.5:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
+bn.js@5.2.0, bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
+  integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
-
-bn.js@^5.0.0, bn.js@^5.1.1:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
-  integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
 body-parser@1.19.0:
   version "1.19.0"
@@ -4102,13 +4088,12 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-borsh@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/borsh/-/borsh-0.3.1.tgz#c31c3a149610e37913deada80e89073fb15cf55b"
-  integrity sha512-gJoSTnhwLxN/i2+15Y7uprU8h3CKI+Co4YKZKvrGYUy0FwHWM20x5Sx7eU8Xv4HQqV+7rb4r3P7K1cBIQe3q8A==
+borsh@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/borsh/-/borsh-0.6.0.tgz#a7c9eeca6a31ca9e0607cb49f329cb659eb791e1"
+  integrity sha512-sl5k89ViqsThXQpYa9XDtz1sBl3l1lI313cFUY1HKr+wvMILnb+58xpkqTNrYbelh99dY7K8usxoCusQmqix9Q==
   dependencies:
-    "@types/bn.js" "^4.11.5"
-    bn.js "^5.0.0"
+    bn.js "^5.2.0"
     bs58 "^4.0.0"
     text-encoding-utf-8 "^1.0.2"
 
@@ -6022,14 +6007,14 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-error-polyfill@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/error-polyfill/-/error-polyfill-0.1.2.tgz#05b27de7d126cbc9d42a96f45faab28a98a0b28b"
-  integrity sha512-8uhnXlJuhFkmIfhw2tAHtWQGpXcw5rrc0dhuY3bhn8tBHvh6l0oL9VJvR2suqx9eltglKKhVPv8luPQy+UxLTA==
+error-polyfill@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/error-polyfill/-/error-polyfill-0.1.3.tgz#df848b61ad8834f7a5db69a70b9913df86721d15"
+  integrity sha512-XHJk60ufE+TG/ydwp4lilOog549iiQF2OAPhkk9DdiYWMrltz5yhDz/xnKuenNwP7gy3dsibssO5QpVhkrSzzg==
   dependencies:
     capability "^0.2.5"
     o3 "^1.0.3"
-    u3 "^0.1.0"
+    u3 "^0.1.1"
 
 error-stack-parser@^2.0.6:
   version "2.0.6"
@@ -9844,17 +9829,16 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-near-api-js@^0.39.0:
-  version "0.39.0"
-  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-0.39.0.tgz#8c6b040e92f01266f35d358aee3914f26af2d83f"
-  integrity sha512-RX2oLOg438QCY3UQLb6FMkXmInFQIS0S+xg/auNZP292ySsMTKppoD07g/ExEFbW8Uyej8/TvjhBjKxnDBUigQ==
+near-api-js@^0.43.1:
+  version "0.43.1"
+  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-0.43.1.tgz#aa3f1669afae9eb37f65b02dca3f28472ebe4bb7"
+  integrity sha512-bgFuboD/a3eintaWqWMN9oWcGHkxbrKiJhxkJwHmwJrYx49y9QvWwEtoxeHSjKskJHUVXGKvaYRsc9XirrJ5JQ==
   dependencies:
-    "@types/bn.js" "^5.1.0"
-    bn.js "^5.0.0"
-    borsh "^0.3.1"
+    bn.js "5.2.0"
+    borsh "^0.6.0"
     bs58 "^4.0.0"
     depd "^2.0.0"
-    error-polyfill "^0.1.2"
+    error-polyfill "^0.1.3"
     http-errors "^1.7.2"
     js-sha256 "^0.9.0"
     mustache "^4.0.0"
@@ -13803,10 +13787,10 @@ u2f-api@0.2.7:
   resolved "https://registry.yarnpkg.com/u2f-api/-/u2f-api-0.2.7.tgz#17bf196b242f6bf72353d9858e6a7566cc192720"
   integrity sha512-fqLNg8vpvLOD5J/z4B6wpPg4Lvowz1nJ9xdHcCzdUPKcFE/qNCceV2gNZxSJd5vhAZemHr/K/hbzVA0zxB5mkg==
 
-u3@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/u3/-/u3-0.1.0.tgz#0060927663b68353c539cda99e9511d6687edd9d"
-  integrity sha1-AGCSdmO2g1PFOc2pnpUR1mh+3Z0=
+u3@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/u3/-/u3-0.1.1.tgz#5f52044f42ee76cd8de33148829e14528494b73b"
+  integrity sha512-+J5D5ir763y+Am/QY6hXNRlwljIeRMZMGs0cT6qqZVVzzT3X3nFPXVyPOFRMOR4kupB0T8JnCdpWdp6Q/iXn3w==
 
 ua-parser-js@^0.7.18:
   version "0.7.24"


### PR DESCRIPTION
Upgrade `near-api-js` to latest. 

Continues work done in https://github.com/near/near-wallet/pull/1728 and <s>adds `.call` to maintain `this` context [here](https://github.com/near/near-wallet/pull/2248/commits/a47b710f9c891f2a67dd981f58025de7e00d0f19#diff-46f345c520c144e0d8300842ff78d012a61770029e9d262aaf62632d95960486R36)</s> removes v1 usages of account `signAndSendTransaction` and `functionCall` in favor of v2 APIs.