### PR TITLE
Fungible token list: sort alphabetically

### DIFF
--- a/packages/frontend/src/hooks/fungibleTokensIncludingNEAR.js
+++ b/packages/frontend/src/hooks/fungibleTokensIncludingNEAR.js
@@ -19,7 +19,7 @@ const fungibleTokensIncludingNEAR = (tokens, balance, nearTokenFiatValueUSD) => 
 export const useFungibleTokensIncludingNEAR = function () {
     const balance = useSelector(selectBalance);
     const accountId = useSelector(selectAccountId);
-    const tokens = useSelector((state) => selectTokensWithMetadataForAccountId(state, { accountId })).sort((a, b) => a.name.localeCompare(b.name));
+    const tokens = useSelector((state) => selectTokensWithMetadataForAccountId(state, { accountId }));
     const nearTokenFiatValueUSD = useSelector(selectNearTokenFiatValueUSD);
 
     const balanceToDisplay = balance?.balanceAvailable;

--- a/packages/frontend/src/hooks/fungibleTokensIncludingNEAR.js
+++ b/packages/frontend/src/hooks/fungibleTokensIncludingNEAR.js
@@ -28,7 +28,7 @@ export const useFungibleTokensIncludingNEAR = function () {
     );
 
     useEffect(() => {
-        setFungibleTokensList(fungibleTokensIncludingNEAR(tokens, balanceToDisplay, nearTokenFiatValueUSD));
+        setFungibleTokensList(fungibleTokensIncludingNEAR(tokens.sort((a, b) => a.name.localeCompare(b.name)), balanceToDisplay, nearTokenFiatValueUSD));
     }, [tokens, balanceToDisplay]);
 
     return fungibleTokensList;

--- a/packages/frontend/src/hooks/fungibleTokensIncludingNEAR.js
+++ b/packages/frontend/src/hooks/fungibleTokensIncludingNEAR.js
@@ -19,7 +19,7 @@ const fungibleTokensIncludingNEAR = (tokens, balance, nearTokenFiatValueUSD) => 
 export const useFungibleTokensIncludingNEAR = function () {
     const balance = useSelector(selectBalance);
     const accountId = useSelector(selectAccountId);
-    const tokens = useSelector((state) => selectTokensWithMetadataForAccountId(state, { accountId }));
+    const tokens = useSelector((state) => selectTokensWithMetadataForAccountId(state, { accountId })).sort((a, b) => a.name.localeCompare(b.name));
     const nearTokenFiatValueUSD = useSelector(selectNearTokenFiatValueUSD);
 
     const balanceToDisplay = balance?.balanceAvailable;
@@ -28,7 +28,7 @@ export const useFungibleTokensIncludingNEAR = function () {
     );
 
     useEffect(() => {
-        setFungibleTokensList(fungibleTokensIncludingNEAR(tokens.sort((a, b) => a.name.localeCompare(b.name)), balanceToDisplay, nearTokenFiatValueUSD));
+        setFungibleTokensList(fungibleTokensIncludingNEAR(tokens, balanceToDisplay, nearTokenFiatValueUSD));
     }, [tokens, balanceToDisplay]);
 
     return fungibleTokensList;

--- a/packages/frontend/src/redux/slices/tokens/index.js
+++ b/packages/frontend/src/redux/slices/tokens/index.js
@@ -157,6 +157,7 @@ export const selectTokensWithMetadataForAccountId = createSelector(
     [selectAllContractMetadata, selectOwnedTokensForAccount],
     (allContractMetadata, ownedTokensForAccount) => Object.entries(ownedTokensForAccount)
         .filter(([_, { balance }]) => !new BN(balance).isZero())
+        .sort(([a], [b]) => allContractMetadata[a].name.localeCompare(allContractMetadata[b].name))
         .map(([contractName, { balance }]) => ({
             ...initialOwnedTokenState,
             contractName,


### PR DESCRIPTION
The fungible token list is randomly sorted on each page reload, which makes it hard to locate a specific token. This fix sorts the fungible token list alphabetically by `token.name` so that it's easier to locate tokens.