### PR TITLE
Switch to multistage build for Wallet Dockerfile, shedding 700MB of image size

### DIFF
--- a/packages/frontend/.dockerignore
+++ b/packages/frontend/.dockerignore
@@ -2,3 +2,6 @@
 **/node_modules
 dist
 .cache
+Dockerfile
+Dockerfile.fast
+*.swp

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -1,17 +1,13 @@
 # syntax=docker/dockerfile-upstream:experimental
 
-FROM phusion/baseimage:0.11
-
-ENTRYPOINT ["/sbin/my_init", "--"]
+FROM phusion/baseimage:0.11 as build
 
 RUN curl -o /tmp/node_setup.sh "https://deb.nodesource.com/setup_11.x"
 RUN bash /tmp/node_setup.sh
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo 'deb https://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y \
-    nodejs \
-    nginx \
-    rsync
+    nodejs
 
 # near-wallet
 RUN mkdir /near-wallet
@@ -19,10 +15,21 @@ COPY . /near-wallet/
 WORKDIR /near-wallet
 RUN npm install
 RUN npm run build
+
+# ======================== EXECUTE ==================================
+FROM phusion/baseimage:0.11 as run
+
+ENTRYPOINT ["/sbin/my_init", "--"]
+
+RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo 'deb https://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update -qq && apt-get install -y \
+    nginx
+
 RUN mkdir -p /var/www/html/wallet
-RUN rsync -ar /near-wallet/dist/ /var/www/html/wallet
+COPY --from=build /near-wallet/dist /var/www/html/wallet
 
 # nginx
 RUN rm /etc/nginx/sites-enabled/default
-COPY /scripts/wallet.nginx /etc/nginx/sites-enabled/wallet
-COPY /scripts/init_nginx.sh /etc/my_init.d/
+COPY --from=build /near-wallet/scripts/wallet.nginx /etc/nginx/sites-enabled/wallet
+COPY --from=build /near-wallet/scripts/init_nginx.sh /etc/my_init.d/


### PR DESCRIPTION
…mage size

Drops image size from 1.1GB -> 323MB (and it's still so big just because the Phusion base image is 183MB)