### PR TITLE
bug: use --frozen-lockfile to install packages according to yarn.lock versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "packages/*"
   ],
   "scripts": {
-    "lint": "cd packages/frontend && yarn && yarn lint",
-    "build": "cd packages/frontend && yarn && yarn build",
-    "test": "cd packages/frontend && yarn && yarn test"
+    "lint": "cd packages/frontend && yarn install --frozen-lockfile && yarn lint",
+    "build": "cd packages/frontend && yarn install --frozen-lockfile && yarn build",
+    "test": "cd packages/frontend && yarn install --frozen-lockfile && yarn test"
   },
   "devDependencies": {
     "lerna": "^4.0.0"


### PR DESCRIPTION
This PR updates the `scripts` in `package.json` to replace instances of `yarn` (implicit `install`) with: `yarn install --frozen-lockfile`. Addresses #2311 