### PR TITLE
FIX broken import of MIN_BALANCE_FOR_GAS

### DIFF
--- a/packages/frontend/src/redux/reducers/selectors/balance.js
+++ b/packages/frontend/src/redux/reducers/selectors/balance.js
@@ -1,6 +1,6 @@
 import BN from 'bn.js';
 
-import { MIN_BALANCE_FOR_GAS } from '../../../utils/wallet';
+import { MIN_BALANCE_FOR_GAS } from '../../../config';
 
 export const selectProfileBalance = (walletAccount) => {
     const balance = walletAccount?.balance;


### PR DESCRIPTION
Hotfix broken import of `MIN_BALANCE_FOR_GAS`. This is causing `reservedForTransactions` to be zero.