### PR TITLE
fix: compute liquid amount locally instead of fetching

### DIFF
--- a/packages/frontend/src/utils/account-with-lockup.js
+++ b/packages/frontend/src/utils/account-with-lockup.js
@@ -271,7 +271,7 @@ async function getAccountBalance(limitedAccountData = false) {
         const isAccDeletable = lockedAmount.isZero() && stakedBalanceLockup.isZero();
         const liquidOwnersBalanceTransfersEnabled = isAccDeletable
             ? new BN(lockupBalance.total)
-            : BN.min(ownersBalance, new BN(lockupBalance.total).sub(new BN(MIN_BALANCE_FOR_GAS)))
+            : BN.min(ownersBalance, new BN(lockupBalance.total).sub(new BN(MIN_BALANCE_FOR_GAS)));
         const liquidOwnersBalance = areTransfersEnabled ? liquidOwnersBalanceTransfersEnabled : new BN(0);
 
         const available = BN.max(new BN(0), new BN(balance.available).add(new BN(liquidOwnersBalance)).sub(new BN(MIN_BALANCE_FOR_GAS)));

--- a/packages/frontend/src/utils/account-with-lockup.js
+++ b/packages/frontend/src/utils/account-with-lockup.js
@@ -206,6 +206,7 @@ async function getAccountBalance(limitedAccountData = false) {
 
         const { transfer_poll_account_id, transfers_timestamp } = transferInformation;
         let transfersTimestamp = transfer_poll_account_id ? await this.viewFunction(transfer_poll_account_id, 'get_result') : transfers_timestamp;
+        let areTransfersEnabled = !!transfersTimestamp;
         transfersTimestamp = transfersTimestamp || (Date.now() * 1000000).toString();
         const { code_hash: lockupContractCodeHash } = await lockupAccount.state();
 
@@ -268,14 +269,10 @@ async function getAccountBalance(limitedAccountData = false) {
 
         // if acc is deletable (nothing locked && nothing stake) you can transfer the whole amount ohterwise get_liquid_owners_balance
         const isAccDeletable = lockedAmount.isZero() && stakedBalanceLockup.isZero();
-        const liquidOwnersBalance = isAccDeletable
+        const liquidOwnersBalanceTransfersEnabled = isAccDeletable
             ? new BN(lockupBalance.total)
-            : new BN(
-                  await this.wrappedAccount.viewFunction(
-                      lockupAccountId,
-                      "get_liquid_owners_balance"
-                  )
-              );
+            : BN.min(ownersBalance, new BN(lockupBalance.total).sub(new BN(MIN_BALANCE_FOR_GAS)))
+        const liquidOwnersBalance = areTransfersEnabled ? liquidOwnersBalanceTransfersEnabled : new BN(0);
 
         const available = BN.max(new BN(0), new BN(balance.available).add(new BN(liquidOwnersBalance)).sub(new BN(MIN_BALANCE_FOR_GAS)));
 


### PR DESCRIPTION
Compute liquid amount locally instead of calling `get_liquid_owners_balance`. This is because `get_liquid_owners_balance` will return 0 when transfers are disabled on the lockup contract. Locally, we can call the transfer voting contract and compute the up to date liquid amount without spending gas to update the lockup contract. Gas will then be spent to update the lockup contract state when the user withdraws from the lockup via the wallet.

Closes #2349