### PR TITLE
Disallow foxtrot commits

### DIFF
--- a/.git-hooks/helpers/detect-foxtrot-merge
+++ b/.git-hooks/helpers/detect-foxtrot-merge
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+#usage:
+#   foxtrot-merge-detector [<branch>]
+#
+# If foxtrot merge detected for branch (current branch if no branch),
+# exit with 1.
+
+# foxtrot merges:
+# See http://bit-booster.blogspot.cz/2016/02/no-foxtrots-allowed.html
+# https://stackoverflow.com/questions/35962754/git-how-can-i-prevent-foxtrot-merges-in-my-master-branch
+
+remoteBranch=$(git rev-parse --abbrev-ref "$1"@{u} 2>/dev/null)
+# no remote tracking branch, exit
+if [[ -z "$remoteBranch" ]]; then
+    echo "no remote tracking branch, no foxtrot merge detected"
+    exit 0
+fi
+branch=$(git rev-parse --abbrev-ref "${1-@}" 2>/dev/null)
+# branch commit does not cover remote branch commit, exit
+if ! $(git merge-base --is-ancestor $remoteBranch $branch); then
+    echo "branch commit does not cover remote branch commit, no foxtrot merge detected"
+    exit 0
+fi
+remoteBranchCommit=$(git rev-parse $remoteBranch)
+# branch commit is same as remote branch commit, exit
+if [[ $(git rev-parse $branch) == $remoteBranchCommit ]]; then
+    echo "branch commit is same as remote branch commit, no foxtrot merge detected"
+    exit 0
+fi
+# remote branch commit is first-parent of branch, exit
+if [[ $(git log --first-parent --pretty='%P' $remoteBranchCommit..$branch | \
+    cut -d' ' -f1 | \
+    grep $remoteBranchCommit | wc -l) -eq 1 ]]; then
+    echo "remote branch commit is first-parent of branch, no foxtrot merge detected"
+    exit 0
+fi
+# foxtrot merge detected if here
+exit 1

--- a/.git-hooks/helpers/detect-foxtrot-merge
+++ b/.git-hooks/helpers/detect-foxtrot-merge
@@ -9,6 +9,8 @@
 # foxtrot merges:
 # See http://bit-booster.blogspot.cz/2016/02/no-foxtrots-allowed.html
 # https://stackoverflow.com/questions/35962754/git-how-can-i-prevent-foxtrot-merges-in-my-master-branch
+# https://git-blame.blogspot.com/2012/03/fun-with-first-parent.html
+# https://stackoverflow.com/questions/35962754/how-can-i-prevent-foxtrot-merges-in-my-master-branch
 
 remoteBranch=$(git rev-parse --abbrev-ref "$1"@{u} 2>/dev/null)
 # no remote tracking branch, exit

--- a/.git-hooks/helpers/detect-foxtrot-merge
+++ b/.git-hooks/helpers/detect-foxtrot-merge
@@ -15,26 +15,26 @@
 remoteBranch=$(git rev-parse --abbrev-ref "$1"@{u} 2>/dev/null)
 # no remote tracking branch, exit
 if [[ -z "$remoteBranch" ]]; then
-    echo "no remote tracking branch, no foxtrot merge detected"
+    # echo "no remote tracking branch, no foxtrot merge detected"
     exit 0
 fi
 branch=$(git rev-parse --abbrev-ref "${1-@}" 2>/dev/null)
 # branch commit does not cover remote branch commit, exit
 if ! $(git merge-base --is-ancestor $remoteBranch $branch); then
-    echo "branch commit does not cover remote branch commit, no foxtrot merge detected"
+    # echo "branch commit does not cover remote branch commit, no foxtrot merge detected"
     exit 0
 fi
 remoteBranchCommit=$(git rev-parse $remoteBranch)
 # branch commit is same as remote branch commit, exit
 if [[ $(git rev-parse $branch) == $remoteBranchCommit ]]; then
-    echo "branch commit is same as remote branch commit, no foxtrot merge detected"
+    # echo "branch commit is same as remote branch commit, no foxtrot merge detected"
     exit 0
 fi
 # remote branch commit is first-parent of branch, exit
 if [[ $(git log --first-parent --pretty='%P' $remoteBranchCommit..$branch | \
     cut -d' ' -f1 | \
     grep $remoteBranchCommit | wc -l) -eq 1 ]]; then
-    echo "remote branch commit is first-parent of branch, no foxtrot merge detected"
+    # echo "remote branch commit is first-parent of branch, no foxtrot merge detected"
     exit 0
 fi
 # foxtrot merge detected if here

--- a/.git-hooks/helpers/detect-foxtrot-merge
+++ b/.git-hooks/helpers/detect-foxtrot-merge
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #usage:
 #   foxtrot-merge-detector [<branch>]

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+Color_Off='\033[0m'       # Text Reset
+Yellow='\033[0;33m'       # Yellow
+
+./.git-hooks/helpers/detect-foxtrot-merge
+# check exit code and exit if needed
+exitcode=$?
+if [ $exitcode -ne 0 ]; then
+    echo -e "  ${Yellow}WARNING:${Color_Off} foxtrot merge detected; do not merge master branch into feature branches."
+    # swallow exit code
+fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,27 @@
-#!/bin/sh
+#!/bin/bash
 # This runs the prepush script on any modified packages
 . "$(dirname "$0")/_/husky.sh"
 
 npx lerna run --concurrency 1 --stream prepush --exclude-dependents
+
+remote="$1"
+url="$2"
+z40=0000000000000000000000000000000000000000
+while read local_ref local_sha remote_ref remote_sha
+do
+    if [ "$local_sha" = $z40 ]; then
+        # handle delete, do nothing
+        :
+    else
+        # ex $local_ref as "refs/heads/dev"
+        branch=$(git rev-parse --abbrev-ref "$local_ref")
+        ./.git-hooks/helpers/detect-foxtrot-merge "$branch"
+        # check exit code and exit if needed
+        exitcode=$?
+        if [ $exitcode -ne 0 ]; then
+            echo 1>&2 "fatal: foxtrot merge detected, aborting push"
+            echo 1>&2 "fatal: branch $branch"
+            exit $exitcode
+        fi
+    fi
+done

--- a/.husky/pre-receive
+++ b/.husky/pre-receive
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright (c) 2016 G. Sylvie Davies. http://bit-booster.com/
+# Copyright (c) 2016 torek. http://stackoverflow.com/users/1256452/torek
+# License: MIT license. https://opensource.org/licenses/MIT
+while read oldrev newrev refname
+do
+if [ "$refname" = "refs/heads/master" ]; then
+   MATCH=`git log --first-parent --pretty='%H %P' $oldrev..$newrev |
+     grep $oldrev |
+     awk '{ print $2 }'`
+   if [ "$oldrev" = "$MATCH" ]; then
+     exit 0
+   else
+     echo "*** PUSH REJECTED! FOXTROT MERGE BLOCKED!!! ***"
+     exit 1
+   fi
+fi
+done


### PR DESCRIPTION
Adds hooks to warn you when you have just created a foxtrot commit, and to block pushing branches to the remote that contain those commits.  

Apart from the issue of bundling up changes that were not part of the feature branch's changeset into that branch, making it difficult or impossible to revert a merged branch without possibly breaking other code, this is going to be especially critical as we start generating changelog output using conventional commit contents, as not being able to follow the 'first parent' path can create serious problems with tooling that tries to generate changelog diffs automatically.

Further reading at:
https://git-blame.blogspot.com/2012/03/fun-with-first-parent.html
http://bit-booster.blogspot.cz/2016/02/no-foxtrots-allowed.html
https://stackoverflow.com/questions/35962754/how-can-i-prevent-foxtrot-merges-in-my-master-branch

The one major downside to rebasing is when you have many commits in a branch that have the _same_ conflict to be resolved while resolving the rebase; it can be tedious to re-apply the same merge resolution to multiple commits.  You can handle this by doing an interactive rebase where you squash multiple commits together so you don't need to resolve the conflict multiple times, but that is not always a good idea.  In cases like this, take advantage of the `rerere` git option to have git automatically apply a previous conflict resolution for you in cases where it detects the same conflict has been encountered in multiple commits during the rebase.
Reference: https://stackoverflow.com/questions/49500943/what-is-git-rerere-and-how-does-it-work