### PR TITLE
feat: add account selection functionality to /sign

### DIFF
--- a/packages/frontend/src/components/sign/v2/SignTransaction.js
+++ b/packages/frontend/src/components/sign/v2/SignTransaction.js
@@ -4,6 +4,7 @@ import { Translate } from 'react-localize-redux';
 import styled from 'styled-components';
 
 import Balance from '../../common/balance/Balance';
+import FormButton from '../../common/FormButton';
 import Tooltip from '../../common/Tooltip';
 
 const StyledContainer = styled.div`
@@ -50,6 +51,14 @@ const StyledContainer = styled.div`
             }
         }
 
+        .left {
+            text-align: left;
+
+            .link {
+                font-weight: normal;
+            }
+        }
+
         &.from {
             .near-amount {
                 color: #72727A;
@@ -81,7 +90,8 @@ export default ({
     transferAmount,
     sender,
     estimatedFees,
-    availableBalance
+    availableBalance,
+    onClickEditAccount
 }) => {
     const isTransferTransaction = new BN(transferAmount).gt(new BN(0));
     return (
@@ -94,7 +104,16 @@ export default ({
                 />
             }
             <div className={`account from ${!isTransferTransaction ? 'no-border' : ''}`}>
-                <Translate id='transfer.from' />
+                <div className='left'>
+                    <Translate id='transfer.from' />
+                    {' • '}
+                    <FormButton
+                        className="link"
+                        onClick={onClickEditAccount}
+                    >
+                        <Translate id="button.edit" />
+                    </FormButton>
+                </div>
                 <div className='right'>
                     <div className='account-id'>{sender}</div>
                     <Balance

--- a/packages/frontend/src/components/sign/v2/SignTransactionSummary.js
+++ b/packages/frontend/src/components/sign/v2/SignTransactionSummary.js
@@ -52,6 +52,7 @@ export default ({
     onClickCancel,
     onClickApprove,
     onClickMoreInformation,
+    onClickEditAccount,
     accountUrlReferrer,
     submittingTransaction
 }) => {
@@ -71,6 +72,7 @@ export default ({
                 sender={accountLocalStorageAccountId}
                 estimatedFees={estimatedFees}
                 availableBalance={availableBalance}
+                onClickEditAccount={onClickEditAccount}
             />
             <FormButton
                 className='link'

--- a/packages/frontend/src/components/sign/v2/SignTransactionSummaryWrapper.js
+++ b/packages/frontend/src/components/sign/v2/SignTransactionSummaryWrapper.js
@@ -13,6 +13,7 @@ import SignTransactionSummary from './SignTransactionSummary';
 
 export default ({
     onClickMoreInformation,
+    onClickEditAccount,
     onClickCancel,
     onClickApprove,
     submittingTransaction,
@@ -33,6 +34,7 @@ export default ({
             onClickCancel={onClickCancel}
             onClickApprove={onClickApprove}
             onClickMoreInformation={onClickMoreInformation}
+            onClickEditAccount={onClickEditAccount}
             accountUrlReferrer={accountUrlReferrer}
             submittingTransaction={submittingTransaction}
         />

--- a/packages/frontend/src/routes/SignWrapper.js
+++ b/packages/frontend/src/routes/SignWrapper.js
@@ -45,7 +45,7 @@ export function SignWrapper() {
     const availableAccounts = useSelector(selectAvailableAccounts);
     const accountAccountsBalances = useSelector(selectAccountAccountsBalances);
     const transactions = useSelector(selectSignTransactions);
-    const accountId = useSelector(selectAccountId)
+    const accountId = useSelector(selectAccountId);
 
     const signGasFee = new BN(signFeesGasLimitIncludingGasChanges).div(new BN('1000000000000')).toString();
     const submittingTransaction = signStatus === SIGN_STATUS.IN_PROGRESS;


### PR DESCRIPTION
Adds account selection functionality to `/sign` wallet integration point. Closes #2399, #2396, #2431, #2402:


<img width="300" alt="Screen Shot 2022-01-25 at 12 51 29 AM" src="https://user-images.githubusercontent.com/5849204/150863246-aa3deb3d-33b0-4546-8393-4fb454d56bfc.png"><img width="300" alt="Screen Shot 2022-01-25 at 12 52 04 AM" src="https://user-images.githubusercontent.com/5849204/150863261-90c1fb14-ec78-4f46-b3a5-8e367f8c4354.png">

