### PR TITLE
fix: Modify 'explore apps' link URL

### DIFF
--- a/packages/frontend/src/config/environmentDefaults/development.js
+++ b/packages/frontend/src/config/environmentDefaults/development.js
@@ -6,7 +6,7 @@ export default {
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount("0.25"),
     DISABLE_CREATE_ACCOUNT: false,
     DISABLE_PHONE_RECOVERY: true,
-    EXPLORE_APPS_URL: "https://awesomenear.com/trending/",
+    EXPLORE_APPS_URL: "https://awesomenear.com/",
     EXPLORE_DEFI_URL: "https://awesomenear.com/categories/defi/",
     EXPLORER_URL:"https://explorer.testnet.near.org",
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,

--- a/packages/frontend/src/config/environmentDefaults/mainnet.js
+++ b/packages/frontend/src/config/environmentDefaults/mainnet.js
@@ -7,7 +7,7 @@ export default {
     BROWSER_MIXPANEL_TOKEN: "d5bbbbcc3a77ef8427f2b806b5689bf8",
     DISABLE_CREATE_ACCOUNT: true,
     DISABLE_PHONE_RECOVERY: true,
-    EXPLORE_APPS_URL: "https://awesomenear.com/trending/",
+    EXPLORE_APPS_URL: "https://awesomenear.com/",
     EXPLORE_DEFI_URL: "https://awesomenear.com/categories/defi/",
     EXPLORER_URL: "https://explorer.mainnet.near.org",
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,

--- a/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.js
+++ b/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.js
@@ -7,7 +7,7 @@ export default {
     BROWSER_MIXPANEL_TOKEN: "d5bbbbcc3a77ef8427f2b806b5689bf8",
     DISABLE_CREATE_ACCOUNT: true,
     DISABLE_PHONE_RECOVERY: true,
-    EXPLORE_APPS_URL: "https://awesomenear.com/trending/",
+    EXPLORE_APPS_URL: "https://awesomenear.com/",
     EXPLORE_DEFI_URL: "https://awesomenear.com/categories/defi/",
     EXPLORER_URL: "https://explorer.mainnet.near.org",
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,

--- a/packages/frontend/src/config/environmentDefaults/testnet.js
+++ b/packages/frontend/src/config/environmentDefaults/testnet.js
@@ -7,7 +7,7 @@ export default {
     BROWSER_MIXPANEL_TOKEN: "9edede4b70de19f399736d5840872910",
     DISABLE_CREATE_ACCOUNT: false,
     DISABLE_PHONE_RECOVERY: false,
-    EXPLORE_APPS_URL: "https://awesomenear.com/trending/",
+    EXPLORE_APPS_URL: "https://awesomenear.com/",
     EXPLORE_DEFI_URL: "https://awesomenear.com/categories/defi/",
     EXPLORER_URL: "https://explorer.testnet.near.org",
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,


### PR DESCRIPTION
[https://awesomenear.com/trending/](https://awesomenear.com/trending/)

Removing the 'trending' category as it's not active anymore.