### PR TITLE
Add UI for shared passphrase when creating a new account

### DIFF
--- a/packages/frontend/src/components/GlobalStyle.js
+++ b/packages/frontend/src/components/GlobalStyle.js
@@ -256,6 +256,24 @@ export default createGlobalStyle`
         }
     }
 
+    .input-label {
+        font-size: 14px;
+        color: #72727A;
+        margin-bottom: 8px;
+    }
+
+    textarea {
+        border: 2px solid #E5E5E6;
+        border-radius: 8px;
+        width: 100%;
+        padding: 14px;
+        line-height: 180%;
+        font-size: 16px;
+        ::placeholder {
+            color: #A2A2A8;
+        }
+    }
+
     .input-sub-label {
         font-size: 12px;
         font-style: italic;

--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -19,14 +19,11 @@ import { handleClearAlert } from '../redux/reducers/status';
 import { selectAccountSlice } from '../redux/slices/account';
 import { actions as tokenFiatValueActions } from '../redux/slices/tokenFiatValues';
 import { CreateImplicitAccountWrapper } from '../routes/CreateImplicitAccountWrapper';
-import { GeneratePassphraseWrapper } from '../routes/GeneratePassphraseWrapper';
 import { LoginWrapper } from '../routes/LoginWrapper';
 import { SetupLedgerNewAccountWrapper } from '../routes/SetupLedgerNewAccountWrapper';
 import { SetupPassphraseNewAccountWrapper } from '../routes/SetupPassphraseNewAccountWrapper';
 import { SetupRecoveryImplicitAccountWrapper } from '../routes/SetupRecoveryImplicitAccountWrapper';
-import { SharedPassphraseWrapper } from '../routes/SharedPassphraseWrapper';
 import { SignWrapper } from '../routes/SignWrapper';
-import { VerifyPassphraseWrapper } from '../routes/VerifyPassphraseWrapper';
 import translations_en from '../translations/en.global.json';
 import translations_pt from '../translations/pt.global.json';
 import translations_ru from '../translations/ru.global.json';
@@ -417,21 +414,6 @@ class Routing extends Component {
                                     component={CreateImplicitAccountWrapper}
                                 />
                             }
-                            <Route
-                                exact
-                                path='/generate-passphrase'
-                                component={GeneratePassphraseWrapper}
-                            />
-                            <Route
-                                exact
-                                path='/verify-passphrase'
-                                component={VerifyPassphraseWrapper}
-                            />
-                            <Route
-                                exact
-                                path='/shared-passphrase'
-                                component={SharedPassphraseWrapper}
-                            />
                             <Route
                                 exact
                                 path='/setup-seed-phrase/:accountId/:step'

--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -19,11 +19,14 @@ import { handleClearAlert } from '../redux/reducers/status';
 import { selectAccountSlice } from '../redux/slices/account';
 import { actions as tokenFiatValueActions } from '../redux/slices/tokenFiatValues';
 import { CreateImplicitAccountWrapper } from '../routes/CreateImplicitAccountWrapper';
+import { GeneratePassphraseWrapper } from '../routes/GeneratePassphraseWrapper';
 import { LoginWrapper } from '../routes/LoginWrapper';
 import { SetupLedgerNewAccountWrapper } from '../routes/SetupLedgerNewAccountWrapper';
 import { SetupPassphraseNewAccountWrapper } from '../routes/SetupPassphraseNewAccountWrapper';
 import { SetupRecoveryImplicitAccountWrapper } from '../routes/SetupRecoveryImplicitAccountWrapper';
+import { SharedPassphraseWrapper } from '../routes/SharedPassphraseWrapper';
 import { SignWrapper } from '../routes/SignWrapper';
+import { VerifyPassphraseWrapper } from '../routes/VerifyPassphraseWrapper';
 import translations_en from '../translations/en.global.json';
 import translations_pt from '../translations/pt.global.json';
 import translations_ru from '../translations/ru.global.json';
@@ -414,6 +417,21 @@ class Routing extends Component {
                                     component={CreateImplicitAccountWrapper}
                                 />
                             }
+                            <Route
+                                exact
+                                path='/generate-passphrase'
+                                component={GeneratePassphraseWrapper}
+                            />
+                            <Route
+                                exact
+                                path='/verify-passphrase'
+                                component={VerifyPassphraseWrapper}
+                            />
+                            <Route
+                                exact
+                                path='/shared-passphrase'
+                                component={SharedPassphraseWrapper}
+                            />
                             <Route
                                 exact
                                 path='/setup-seed-phrase/:accountId/:step'

--- a/packages/frontend/src/components/accounts/create/passphrase/GeneratePassphrase.js
+++ b/packages/frontend/src/components/accounts/create/passphrase/GeneratePassphrase.js
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import { Translate } from 'react-localize-redux';
+import styled from 'styled-components';
+
+import RecoveryOption from '../../../accounts/recovery_setup/RecoveryOption';
+import FormButton from '../../../common/FormButton';
+import Container from '../../../common/styled/Container.css';
+
+const StyledContainer = styled(Container)`
+    .active {
+        hr {
+            display none;
+        }
+    }
+    h2 {
+        :last-of-type {
+            margin-bottom: 40px;
+        }
+    }
+    &&& {
+        button {
+            width: 100%;
+            margin-top: 40px;
+        }
+    }
+`;
+
+export default () => {
+    const [recoveryOption, setRecoveryOption] = useState('newPhrase');
+    return (
+        <StyledContainer className='small-centered border'>
+            <h1><Translate id='createAccount.setupPassphrase.generatePassphrase.tite' /></h1>
+            <h2><Translate id='createAccount.setupPassphrase.generatePassphrase.desc' /></h2>
+            <h2><Translate id='createAccount.setupPassphrase.generatePassphrase.descTwo' /></h2>
+            <RecoveryOption
+                onClick={() => setRecoveryOption('newPhrase')}
+                option='newPhrase'
+                active={recoveryOption}
+            />
+            <RecoveryOption
+                onClick={() => setRecoveryOption('existingPhrase')}
+                option='existingPhrase'
+                active={recoveryOption}
+            />
+            <FormButton
+                onClick={() => {}}
+            >
+                <Translate id='button.continue' />
+            </FormButton>
+        </StyledContainer>
+    );
+};

--- a/packages/frontend/src/components/accounts/create/passphrase/SharedPassphrase.js
+++ b/packages/frontend/src/components/accounts/create/passphrase/SharedPassphrase.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Translate } from 'react-localize-redux';
+import styled from 'styled-components';
+
+import FormButton from '../../../common/FormButton';
+import Container from '../../../common/styled/Container.css';
+import SharedPassphraseList from './SharedPassphraseList';
+
+const StyledContainer = styled(Container)`
+    &&& {
+        button {
+            width: 100%;
+            margin-top: 40px;
+        }
+    }
+
+    .shared-passphrase-list {
+        margin: 50px 0 20px 0;
+    }
+`;
+
+export default () => {
+    return (
+        <StyledContainer className='small-centered border'>
+            <h1><Translate id='createAccount.setupPassphrase.sharedPassphrase.tite' /></h1>
+            <h2><Translate id='createAccount.setupPassphrase.sharedPassphrase.desc' data={{ numberOfAccounts: '2' }}/></h2>
+            <h2><Translate id='createAccount.setupPassphrase.sharedPassphrase.descTwo' /></h2>
+            <SharedPassphraseList
+                newAccount='someNewAccount.near'
+                sharedAccounts={['account1.near', 'account2.near']}
+            />
+            <FormButton
+                onClick={() => { }}
+            >
+                <Translate id='button.acceptAndContinue' />
+            </FormButton>
+        </StyledContainer>
+    );
+};

--- a/packages/frontend/src/components/accounts/create/passphrase/SharedPassphraseList.js
+++ b/packages/frontend/src/components/accounts/create/passphrase/SharedPassphraseList.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const StyledContainer = styled.div`
+    background-color: #F0F9FF;
+    border: 2px dashed #8FCDFF;
+    border-radius: 16px;
+    padding: 16px;
+
+    > div {
+        border-radius: 8px;
+        background-color: #FFFFFF;
+        margin-bottom: 8px;
+        padding: 0 16px;
+        height: 52px;
+        color: #72727A;
+        font-weight: 700;
+        display: flex;
+        align-items: center;
+
+        :first-of-type {
+            justify-content: space-between;
+            background-color: #C8F6E0;
+            color: #005A46;
+
+            span {
+                color: #008D6A;
+                font-size: 12px;
+                background-color: #90E9C5;
+                border-radius: 40px;
+                padding: 6px 14px;
+            }
+        }
+
+        :last-of-type {
+            margin-bottom: 0;
+        }
+
+        > div {
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
+        }
+    }
+`;
+
+export default ({ newAccount, sharedAccounts }) => {
+    return (
+        <StyledContainer className='shared-passphrase-list'>
+            <div><div>{newAccount}</div> <span>New</span></div>
+            {
+                sharedAccounts.map(account => <div key={account}><div>{account}</div></div>)
+            }
+        </StyledContainer>
+    );
+};

--- a/packages/frontend/src/components/accounts/create/passphrase/VerifyPassphrase.js
+++ b/packages/frontend/src/components/accounts/create/passphrase/VerifyPassphrase.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Translate } from 'react-localize-redux';
+import styled from 'styled-components';
+
+import FormButton from '../../../common/FormButton';
+import Container from '../../../common/styled/Container.css';
+
+const StyledContainer = styled(Container)`
+    &&& {
+        button {
+            width: 100%;
+            margin-top: 50px;
+        }
+    }
+
+    .input-label {
+        margin-top: 50px;
+    }
+`;
+
+export default () => {
+    return (
+        <StyledContainer className='small-centered border'>
+            <h1><Translate id='createAccount.setupPassphrase.verifyPassphrase.tite' /></h1>
+            <h2><Translate id='createAccount.setupPassphrase.verifyPassphrase.desc' /></h2>
+            <div className='input-label'><Translate id='createAccount.setupPassphrase.verifyPassphrase.yourPassphrase' /></div>
+            <Translate>
+                {({ translate }) => (
+                    <textarea placeholder={translate('createAccount.setupPassphrase.verifyPassphrase.passPhrasePlaceholder')} />
+                )}
+            </Translate>
+            <FormButton
+                onClick={() => { }}
+            >
+                <Translate id='button.verify' />
+            </FormButton>
+        </StyledContainer>
+    );
+};

--- a/packages/frontend/src/components/accounts/recovery_setup/RecoveryOption.js
+++ b/packages/frontend/src/components/accounts/recovery_setup/RecoveryOption.js
@@ -193,7 +193,7 @@ const Icon = ({option, color}) => {
         case 'ledger':
             return <HardwareWalletIcon color={color}/>;
         default:
-            return;
+            return '';
     }
 };
 

--- a/packages/frontend/src/routes/GeneratePassphraseWrapper.js
+++ b/packages/frontend/src/routes/GeneratePassphraseWrapper.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import GeneratePassphrase from '../components/accounts/create/passphrase/GeneratePassphrase';
+
+export function GeneratePassphraseWrapper() {
+    return <GeneratePassphrase/>;
+}

--- a/packages/frontend/src/routes/SharedPassphraseWrapper.js
+++ b/packages/frontend/src/routes/SharedPassphraseWrapper.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import SharedPassphrase from '../components/accounts/create/passphrase/SharedPassphrase';
+
+export function SharedPassphraseWrapper() {
+    return <SharedPassphrase/>;
+}

--- a/packages/frontend/src/routes/VerifyPassphraseWrapper.js
+++ b/packages/frontend/src/routes/VerifyPassphraseWrapper.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import VerifyPassphrase from '../components/accounts/create/passphrase/VerifyPassphrase';
+
+export function VerifyPassphraseWrapper() {
+    return <VerifyPassphrase/>;
+}

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -333,6 +333,24 @@
         "pageText": "Enter an Account ID to use with your NEAR account. Your Account ID will be used for all NEAR operations, including sending and receiving assets.",
         "pageTitle": "Reserve Account ID",
         "recoverItHere": "Import Existing Account",
+        "setupPassphrase": {
+            "generatePassphrase": {
+                "desc": "For the best security, we recommend generating a unique passphrase for each new account in your wallet.",
+                "descTwo": "As a more convenient option, you may instead share an existing passphrase between multiple accounts. You can change this at any time.",
+                "tite": "Generate a New Passphrase?"
+            },
+            "sharedPassphrase": {
+                "desc": "Your passphrase has been verified! Once you’ve funded your new address, your passphrase will be shared by <b>${numberOfAccounts} accounts.</b>",
+                "descTwo": "Whenever this passphrase is used to recover your wallet, the following accounts will be imported:",
+                "tite": "Your Shared Passphrase"
+            },
+            "verifyPassphrase": {
+                "desc": "Enter an existing passphrase below to secure your new account.",
+                "tite": "Verify Your Passphrase",
+                "yourPassphrase": "Your Passphrase",
+                "passPhrasePlaceholder": "bubble word sun join impact exist ramp skull title hollow symbol very"
+            }
+        },
         "step": "Step ${step}/${total}",
         "terms": {
             "agreeBtn": "Agree & Continue",
@@ -1097,9 +1115,13 @@
         "emailDesc": "Receive a verification code and account recovery link via email.",
         "emailPlaceholder": "example@email.com",
         "emailTitle": "Email",
+        "existingPhraseDesc": "Protect your new address by sharing an existing passphrase.",
+        "existingPhraseTitle": "Use an Existing Passphrase",
         "header": "Choose a Security Method",
         "ledgerDesc": "Secure your account with a Ledger hardware device.",
         "ledgerTitle": "Ledger Hardware Wallet",
+        "newPhraseDesc": "Protect your new address with a new and unique passphrase.",
+        "newPhraseTitle": "Generate a New Passphrase",
         "notSupportedPhone": "Unfortunately, we do not offer SMS for your region. Please choose email instead.",
         "phoneDesc": "Receive a verification code and account recovery link via SMS.",
         "phonePlaceholder": "+1 415 797 8554",


### PR DESCRIPTION
This PR adds the necessary UI for enabling 'shared passphrase' while creating a new account. This feature will be finalized and launched once we add necessary UX to manage shared passphrases outside of the account creation flow, as outlined here: https://github.com/near/near-wallet/issues/2348#issuecomment-1034110613.

<img width="849" alt="Screen Shot 2022-02-10 at 4 39 50 PM" src="https://user-images.githubusercontent.com/24921205/153520619-2f98fc3b-ad30-4be2-bdcd-e7e5d2a5e14a.png">

Figma design: https://www.figma.com/file/yR4qz7oAjAiVAJ0hJSnQQj/Onboarding-Exploration?node-id=1%3A606