### PR TITLE
handleAsyncThunkStatus helper function to handle repeated patterns for the status state object

### DIFF
--- a/packages/frontend/src/components/accounts/SetupSeedPhrase.js
+++ b/packages/frontend/src/components/accounts/SetupSeedPhrase.js
@@ -215,7 +215,7 @@ class SetupSeedPhrase extends Component {
     }
 
     render() {
-        const { recoveryMethods, recoveryMethodsLoader, history, accountId, location } = this.props;
+        const { recoveryMethods, recoveryMethodsLoader, history, accountId, location } = this.props;
         const hasSeedPhraseRecovery = recoveryMethodsLoader || recoveryMethods.filter(m => m.kind === 'phrase').length > 0;
         const { seedPhrase, enterWord, wordId, submitting, localAlert, isNewAccount, successSnackbar } = this.state;
 
@@ -296,7 +296,7 @@ const mapDispatchToProps = {
 };
 
 const mapStateToProps = (state, { match }) => {
-    const { accountId } = match.params;
+    const { accountId } = match.params;
     
     return {
         ...selectAccountSlice(state),

--- a/packages/frontend/src/components/wallet/ActivityDetailModal.js
+++ b/packages/frontend/src/components/wallet/ActivityDetailModal.js
@@ -137,7 +137,7 @@ const ActivityDetailModal = ({
     } = transaction;
 
     const dispatch = useDispatch();
-    const getTransactionStatusConditions = () => checkStatus && !document.hidden && dispatch(transactionsActions.fetchTransactionStatus({ hash, signer_id, accountId }));
+    const getTransactionStatusConditions = () => checkStatus && !document.hidden && dispatch(transactionsActions.fetchTransactionStatus({ hash, signer_id, accountId }));
 
     useEffect(() => {
         getTransactionStatusConditions();

--- a/packages/frontend/src/redux/slices/availableAccounts/index.js
+++ b/packages/frontend/src/redux/slices/availableAccounts/index.js
@@ -24,7 +24,7 @@ const availableAccountsSlice = createSlice({
             set(state, ['items'], Object.keys((action.payload && action.payload.accounts) || {}).sort());
         });
         handleAsyncThunkStatus({
-            asyncThunk: `refreshAccountOwner`,
+            asyncThunk: refreshAccountOwner,
             buildStatusPath: () => ['status'],
             builder
         });

--- a/packages/frontend/src/redux/slices/availableAccounts/index.js
+++ b/packages/frontend/src/redux/slices/availableAccounts/index.js
@@ -25,7 +25,7 @@ const availableAccountsSlice = createSlice({
         });
         handleAsyncThunkStatus({
             asyncThunk: `refreshAccountOwner`,
-            buildStatusPath: ({ meta: { arg: { accountId }}}) => ['status'],
+            buildStatusPath: () => ['status'],
             builder
         });
     })

--- a/packages/frontend/src/redux/slices/availableAccounts/index.js
+++ b/packages/frontend/src/redux/slices/availableAccounts/index.js
@@ -3,6 +3,7 @@ import set from 'lodash.set';
 import { createSelector } from 'reselect';
 
 import refreshAccountOwner from '../../sharedThunks/refreshAccountOwner';
+import handleAsyncThunkStatus from '../handleAsyncThunkStatus';
 import initialErrorState from '../initialErrorState';
 
 const SLICE_NAME = 'availableAccounts';
@@ -19,22 +20,13 @@ const availableAccountsSlice = createSlice({
     name: SLICE_NAME,
     initialState,
     extraReducers: ((builder) => {
-        builder.addCase(refreshAccountOwner.pending, (state) => {
-            set(state, ['status', 'loading'], true);
-            set(state, ['status', 'error'], initialErrorState);
-        });
         builder.addCase(refreshAccountOwner.fulfilled, (state, action) => {
-            set(state, ['status', 'loading'], false);
-            set(state, ['status', 'error'], initialErrorState);
-
             set(state, ['items'], Object.keys((action.payload && action.payload.accounts) || {}).sort());
         });
-        builder.addCase(refreshAccountOwner.rejected, (state, { error }) => {
-            set(state, ['status', 'loading'], false);
-            set(state, ['status', 'error'], {
-                message: error?.message || 'An error was encountered.',
-                code: error?.code
-            });
+        handleAsyncThunkStatus({
+            asyncThunk: `refreshAccountOwner`,
+            buildStatusPath: ({ meta: { arg: { accountId }}}) => ['status'],
+            builder
         });
     })
 });

--- a/packages/frontend/src/redux/slices/handleAsyncThunkStatus.js
+++ b/packages/frontend/src/redux/slices/handleAsyncThunkStatus.js
@@ -1,0 +1,41 @@
+import set from 'lodash.set';
+
+import initialErrorState from './initialErrorState';
+
+/**
+ * Automatically handle status part of reducer based on initialErrorState
+ *
+ * @param asyncThunk string representing async thunk type
+ * @param buildStatusPath array of strings representing the path to status state, needed because in a few cases we want to place the status object in more than one place
+ * @param builder objct provides addCase, addMatcher, addDefaultCase functions
+ */
+export default ({
+    asyncThunk,
+    buildStatusPath,
+    builder
+}) => builder
+    // TODO: use the same status object to all reducers, which will allow simplifying buildStatusPath 
+    .addMatcher(
+        (action) => action.type === `${asyncThunk}/pending`,
+        (state, action) => {
+            set(state, [...buildStatusPath(action), 'loading'], true);
+            set(state, [...buildStatusPath(action), 'error'], initialErrorState);
+        }
+    )
+    .addMatcher(
+        (action) => action.type === `${asyncThunk}/fulfilled`,
+        (state, action) => {
+            set(state, [...buildStatusPath(action), 'loading'], false);
+            set(state, [...buildStatusPath(action), 'error'], initialErrorState);
+        }
+    )
+    .addMatcher(
+        (action) => action.type === `${asyncThunk}/rejected`,
+        (state, action) => {
+            set(state, [...buildStatusPath(action), 'loading'], false);
+            set(state, [...buildStatusPath(action), 'error'], {
+                message: action.error?.message || 'An error was encountered.',
+                code: action.error?.code
+            });
+        }
+    );

--- a/packages/frontend/src/redux/slices/handleAsyncThunkStatus.js
+++ b/packages/frontend/src/redux/slices/handleAsyncThunkStatus.js
@@ -14,7 +14,8 @@ export default ({
     buildStatusPath,
     builder
 }) => builder
-    // TODO: use the same status object to all reducers, which will allow simplifying buildStatusPath 
+    // TODO: use the same status object to all reducers, which will allow simplifying buildStatusPath
+    // TODO: consider to keying `loading` and `error` by thunk typePrefix, this could be useful if we would need to track status of several thunks independently in one slice
     .addMatcher(
         (action) => action.type === `${asyncThunk.typePrefix}/pending`,
         (state, action) => {

--- a/packages/frontend/src/redux/slices/handleAsyncThunkStatus.js
+++ b/packages/frontend/src/redux/slices/handleAsyncThunkStatus.js
@@ -5,7 +5,7 @@ import initialErrorState from './initialErrorState';
 /**
  * Automatically handle status part of reducer based on initialErrorState
  *
- * @param asyncThunk string representing async thunk type
+ * @param asyncThunk actionCreator that is used to get the action type for matcher purpose
  * @param buildStatusPath array of strings representing the path to status state, needed because in a few cases we want to place the status object in more than one place
  * @param builder objct provides addCase, addMatcher, addDefaultCase functions
  */
@@ -16,21 +16,21 @@ export default ({
 }) => builder
     // TODO: use the same status object to all reducers, which will allow simplifying buildStatusPath 
     .addMatcher(
-        (action) => action.type === `${asyncThunk}/pending`,
+        (action) => action.type === `${asyncThunk.typePrefix}/pending`,
         (state, action) => {
             set(state, [...buildStatusPath(action), 'loading'], true);
             set(state, [...buildStatusPath(action), 'error'], initialErrorState);
         }
     )
     .addMatcher(
-        (action) => action.type === `${asyncThunk}/fulfilled`,
+        (action) => action.type === `${asyncThunk.typePrefix}/fulfilled`,
         (state, action) => {
             set(state, [...buildStatusPath(action), 'loading'], false);
             set(state, [...buildStatusPath(action), 'error'], initialErrorState);
         }
     )
     .addMatcher(
-        (action) => action.type === `${asyncThunk}/rejected`,
+        (action) => action.type === `${asyncThunk.typePrefix}/rejected`,
         (state, action) => {
             set(state, [...buildStatusPath(action), 'loading'], false);
             set(state, [...buildStatusPath(action), 'error'], {

--- a/packages/frontend/src/redux/slices/ledger/index.js
+++ b/packages/frontend/src/redux/slices/ledger/index.js
@@ -8,6 +8,7 @@ import { showAlertToolkit } from "../../../utils/alerts";
 import { setLedgerHdPath } from "../../../utils/localStorage";
 import { wallet } from "../../../utils/wallet";
 import refreshAccountOwner from "../../sharedThunks/refreshAccountOwner";
+import initialErrorState from "../initialErrorState";
 
 const SLICE_NAME = 'ledger';
 
@@ -18,7 +19,11 @@ export const LEDGER_MODAL_STATUS = {
 };
 
 const initialState = {
-    modal: {}
+    modal: {},
+    status: {
+        loading: false,
+        error: initialErrorState
+    }
 };
 
 const getLedgerAccountIds = createAsyncThunk(

--- a/packages/frontend/src/redux/slices/ledger/index.js
+++ b/packages/frontend/src/redux/slices/ledger/index.js
@@ -8,6 +8,7 @@ import { showAlertToolkit } from "../../../utils/alerts";
 import { setLedgerHdPath } from "../../../utils/localStorage";
 import { wallet } from "../../../utils/wallet";
 import refreshAccountOwner from "../../sharedThunks/refreshAccountOwner";
+import handleAsyncThunkStatus from "../handleAsyncThunkStatus";
 import initialErrorState from "../initialErrorState";
 
 const SLICE_NAME = 'ledger';
@@ -170,6 +171,11 @@ const ledgerSlice = createSlice({
                 }
             }
         );
+        handleAsyncThunkStatus({
+            asyncThunk: signInWithLedger,
+            buildStatusPath: () => ['status'],
+            builder
+        });
     })
 });
 

--- a/packages/frontend/src/redux/slices/nft/index.js
+++ b/packages/frontend/src/redux/slices/nft/index.js
@@ -163,7 +163,7 @@ const nftSlice = createSlice({
         },
         extraReducers: ((builder) => {
             handleAsyncThunkStatus({
-                asyncThunk: `${SLICE_NAME}/fetchOwnedNFTsForContract`,
+                asyncThunk: fetchOwnedNFTsForContract,
                 buildStatusPath: ({ meta: { arg: { accountId, contractName }}}) => ['ownedTokens', 'byAccountId', accountId, 'byContractName', contractName],
                 builder
             });

--- a/packages/frontend/src/redux/slices/nft/index.js
+++ b/packages/frontend/src/redux/slices/nft/index.js
@@ -5,6 +5,7 @@ import { createSelector } from 'reselect';
 
 import NonFungibleTokens from '../../../services/NonFungibleTokens';
 import createParameterSelector from '../createParameterSelector';
+import handleAsyncThunkStatus from '../handleAsyncThunkStatus';
 import initialErrorState from '../initialErrorState';
 
 const { getLikelyTokenContracts, getMetadata, getTokens, getNumberOfTokens } = NonFungibleTokens;
@@ -161,32 +162,10 @@ const nftSlice = createSlice({
             }
         },
         extraReducers: ((builder) => {
-            builder.addCase(fetchOwnedNFTsForContract.pending, (state, { meta }) => {
-                debugLog('REDUCER/fetchOwnedNFTsForContract.pending');
-
-                const { accountId, contractName } = meta.arg;
-
-                set(state, ['ownedTokens', 'byAccountId', accountId, 'byContractName', contractName, 'loading'], true);
-                set(state, ['ownedTokens', 'byAccountId', accountId, 'byContractName', contractName, 'error'], initialErrorState);
-            });
-            builder.addCase(fetchOwnedNFTsForContract.fulfilled, (state, { meta }) => {
-                debugLog('REDUCER/fetchOwnedNFTsForContract.fulfilled');
-
-                const { accountId, contractName } = meta.arg;
-
-                set(state, ['ownedTokens', 'byAccountId', accountId, 'byContractName', contractName, 'loading'], false);
-                set(state, ['ownedTokens', 'byAccountId', accountId, 'byContractName', contractName, 'error'], initialErrorState);
-            });
-            builder.addCase(fetchOwnedNFTsForContract.rejected, (state, { meta, error }) => {
-                debugLog('REDUCER/fetchOwnedNFTsForContract.fulfilled');
-                
-                const { accountId, contractName } = meta.arg;
-
-                set(state, ['ownedTokens', 'byAccountId', accountId, 'byContractName', contractName, 'loading'], false);
-                set(state, ['ownedTokens', 'byAccountId', accountId, 'byContractName', contractName, 'error'], {
-                    message: error?.message || 'An error was encountered.',
-                    code: error?.code
-                });
+            handleAsyncThunkStatus({
+                asyncThunk: `${SLICE_NAME}/fetchOwnedNFTsForContract`,
+                buildStatusPath: ({ meta: { arg: { accountId, contractName }}}) => ['ownedTokens', 'byAccountId', accountId, 'byContractName', contractName],
+                builder
             });
         })
     }

--- a/packages/frontend/src/redux/slices/nft/index.js
+++ b/packages/frontend/src/redux/slices/nft/index.js
@@ -24,9 +24,11 @@ const initialState = {
 };
 
 const initialOwnedTokenState = {
-    error: initialErrorState,
-    loading: false,
-    tokens: []
+    tokens: [],
+    status: {
+        loading: false,
+        error: initialErrorState
+    }
 };
 
 async function getCachedContractMetadataOrFetch(contractName, state) {
@@ -164,7 +166,7 @@ const nftSlice = createSlice({
         extraReducers: ((builder) => {
             handleAsyncThunkStatus({
                 asyncThunk: fetchOwnedNFTsForContract,
-                buildStatusPath: ({ meta: { arg: { accountId, contractName }}}) => ['ownedTokens', 'byAccountId', accountId, 'byContractName', contractName],
+                buildStatusPath: ({ meta: { arg: { accountId, contractName }}}) => ['ownedTokens', 'byAccountId', accountId, 'byContractName', contractName, 'status'],
                 builder
             });
         })
@@ -234,7 +236,7 @@ const selectTokensListForAccountForContract = createSelector(
 
 export const selectLoadingTokensForAccountForContract = createSelector(
     selectOwnedTokensForAccountForContract,
-    (ownedTokensByAccountByContract) => ownedTokensByAccountByContract.loading
+    (ownedTokensByAccountByContract) => ownedTokensByAccountByContract.status.loading
 );
 
 export const selectHasFetchedAllTokensForAccountForContract = createSelector(

--- a/packages/frontend/src/redux/slices/recoveryMethods/index.js
+++ b/packages/frontend/src/redux/slices/recoveryMethods/index.js
@@ -52,7 +52,7 @@ const recoveryMethodsSlice = createSlice({
         },
         extraReducers: ((builder) => {
             handleAsyncThunkStatus({
-                asyncThunk: `${SLICE_NAME}/fetchRecoveryMethods`,
+                asyncThunk: fetchRecoveryMethods,
                 buildStatusPath: ({ meta: { arg: { accountId }}}) => ['byAccountId', accountId, 'status'],
                 builder
             });

--- a/packages/frontend/src/redux/slices/recoveryMethods/index.js
+++ b/packages/frontend/src/redux/slices/recoveryMethods/index.js
@@ -4,6 +4,7 @@ import { createSelector } from 'reselect';
 
 import { wallet } from '../../../utils/wallet';
 import createParameterSelector from '../createParameterSelector';
+import handleAsyncThunkStatus from '../handleAsyncThunkStatus';
 import initialErrorState from '../initialErrorState';
 
 const SLICE_NAME = 'recoveryMethods';
@@ -50,26 +51,10 @@ const recoveryMethodsSlice = createSlice({
             }
         },
         extraReducers: ((builder) => {
-            builder.addCase(fetchRecoveryMethods.pending, (state, { meta }) => {
-                const { accountId } = meta.arg;
-    
-                set(state, ['byAccountId', accountId, 'status', 'loading'], true);
-                set(state, ['byAccountId', accountId, 'status', 'error'], initialErrorState);
-            });
-            builder.addCase(fetchRecoveryMethods.fulfilled, (state,  { meta }) => {
-                const { accountId } = meta.arg;
-    
-                set(state, ['byAccountId', accountId, 'status', 'loading'], false);
-                set(state, ['byAccountId', accountId, 'status', 'error'], initialErrorState);
-            });
-            builder.addCase(fetchRecoveryMethods.rejected, (state, { meta, error }) => {
-                const { accountId } = meta.arg;
-                
-                set(state, ['byAccountId', accountId, 'status', 'loading'], false);
-                set(state, ['byAccountId', accountId, 'status', 'error'], {
-                    message: error?.message || 'An error was encountered.',
-                    code: error?.code
-                });
+            handleAsyncThunkStatus({
+                asyncThunk: `${SLICE_NAME}/fetchRecoveryMethods`,
+                buildStatusPath: ({ meta: { arg: { accountId }}}) => ['byAccountId', accountId, 'status'],
+                builder
             });
         })
     }

--- a/packages/frontend/src/redux/slices/sign/index.js
+++ b/packages/frontend/src/redux/slices/sign/index.js
@@ -134,7 +134,7 @@ export const getFirstTransactionWithFunctionCallAction = ({ transactions }) => {
 };
 
 export const increaseGasForFirstTransaction = ({ transactions }) => {
-    const transaction = getFirstTransactionWithFunctionCallAction({ transactions });
+    const transaction = getFirstTransactionWithFunctionCallAction({ transactions });
 
     if (!transaction) {
         return transactions;

--- a/packages/frontend/src/redux/slices/tokenFiatValues/index.js
+++ b/packages/frontend/src/redux/slices/tokenFiatValues/index.js
@@ -15,9 +15,11 @@ const fetchTokenFiatValues = createAsyncThunk(
 );
 
 const initialState = {
-    loading: false,
-    error: initialErrorState,
-    tokens: {}
+    tokens: {},
+    status: {
+        loading: false,
+        error: initialErrorState
+    }
 };
 
 const tokenFiatValuesSlice = createSlice({
@@ -34,7 +36,7 @@ const tokenFiatValuesSlice = createSlice({
             });
             handleAsyncThunkStatus({
                 asyncThunk: fetchTokenFiatValues,
-                buildStatusPath: () => [],
+                buildStatusPath: () => ['status'],
                 builder
             });
         })
@@ -49,8 +51,8 @@ export const actions = {
 };
 
 // Future: Refactor to track loading state and error states _per token type_, when we actually support multiple tokens
-export const selectFiatValueLoadingState = (state) => state.loading;
-export const selectFiatValueErrorState = (state) => state.error;
+export const selectFiatValueLoadingState = (state) => state.status.loading;
+export const selectFiatValueErrorState = (state) => state.status.error;
 
 export const selectAllTokenFiatValues = (state) => state[SLICE_NAME];
 export const selectNearTokenFiatData = createSelector(selectAllTokenFiatValues, ({ tokens }) => tokens.near || {});

--- a/packages/frontend/src/redux/slices/tokenFiatValues/index.js
+++ b/packages/frontend/src/redux/slices/tokenFiatValues/index.js
@@ -33,8 +33,8 @@ const tokenFiatValuesSlice = createSlice({
                 merge(state.tokens, action.payload);
             });
             handleAsyncThunkStatus({
-                asyncThunk: `${SLICE_NAME}/fetchTokenFiatValues`,
-                buildStatusPath: () => '',
+                asyncThunk: fetchTokenFiatValues,
+                buildStatusPath: () => [],
                 builder
             });
         })

--- a/packages/frontend/src/redux/slices/tokenFiatValues/index.js
+++ b/packages/frontend/src/redux/slices/tokenFiatValues/index.js
@@ -4,6 +4,7 @@ import { createSelector } from 'reselect';
 
 import { ACCOUNT_HELPER_URL } from '../../../config';
 import sendJson from '../../../tmp_fetch_send_json';
+import handleAsyncThunkStatus from '../handleAsyncThunkStatus';
 import initialErrorState from '../initialErrorState';
 
 const SLICE_NAME = 'tokenFiatValues';
@@ -23,31 +24,18 @@ const tokenFiatValuesSlice = createSlice({
         name: SLICE_NAME,
         initialState,
         extraReducers: ((builder) => {
-            builder.addCase(fetchTokenFiatValues.pending, (state, action) => {
-                state.loading = true;
-                state.error = initialErrorState;
-            });
-
             builder.addCase(fetchTokenFiatValues.fulfilled, (state, action) => {
                 // Payload of .fulfilled is in the same shape as the store; just merge it!
                 // { near: { usd: x, lastUpdatedTimestamp: 1212312321, ... }
-
-                state.loading = false;
-                state.error = initialErrorState;
 
                 // Using merge instead of `assign()` so in the future we don't blow away previously loaded token
                 // prices when we load new ones with different token names
                 merge(state.tokens, action.payload);
             });
-
-            builder.addCase(fetchTokenFiatValues.rejected, (state, { error }) => {
-                state.loading = false;
-
-                // TODO: Localize this?
-                state.error = {
-                    message: error?.message || 'An error was encountered.',
-                    code: error?.code
-                };
+            handleAsyncThunkStatus({
+                asyncThunk: `${SLICE_NAME}/fetchTokenFiatValues`,
+                buildStatusPath: () => '',
+                builder
             });
         })
     }

--- a/packages/frontend/src/redux/slices/tokens/index.js
+++ b/packages/frontend/src/redux/slices/tokens/index.js
@@ -7,6 +7,7 @@ import { WHITELISTED_CONTRACTS } from '../../../config';
 import FungibleTokens from '../../../services/FungibleTokens';
 import { selectBalance } from '../account';
 import createParameterSelector from '../createParameterSelector';
+import handleAsyncThunkStatus from '../handleAsyncThunkStatus';
 import initialErrorState from '../initialErrorState';
 import { selectNearTokenFiatValueUSD } from '../tokenFiatValues';
 
@@ -112,26 +113,10 @@ const tokensSlice = createSlice({
         },
     },
     extraReducers: ((builder) => {
-        builder.addCase(fetchOwnedTokensForContract.pending, (state, { meta }) => {
-            const { accountId, contractName } = meta.arg;
-
-            set(state, ['ownedTokens', 'byAccountId', accountId, contractName, 'loading'], true);
-            set(state, ['ownedTokens', 'byAccountId', accountId, contractName, 'error'], initialErrorState);
-        });
-        builder.addCase(fetchOwnedTokensForContract.fulfilled, (state, { meta }) => {
-            const { accountId, contractName } = meta.arg;
-
-            set(state, ['ownedTokens', 'byAccountId', accountId, contractName, 'loading'], false);
-            set(state, ['ownedTokens', 'byAccountId', accountId, contractName, 'error'], initialErrorState);
-        });
-        builder.addCase(fetchOwnedTokensForContract.rejected, (state, { meta, error }) => {
-            const { accountId, contractName } = meta.arg;
-
-            set(state, ['ownedTokens', 'byAccountId', accountId, contractName, 'loading'], false);
-            set(state, ['ownedTokens', 'byAccountId', accountId, contractName, 'error'], {
-                message: error?.message || 'An error was encountered.',
-                code: error?.code
-            });
+        handleAsyncThunkStatus({
+            asyncThunk: `${SLICE_NAME}/fetchOwnedTokensForContract`,
+            buildStatusPath: ({ meta: { arg: { accountId, contractName }}}) => ['ownedTokens', 'byAccountId', accountId, contractName],
+            builder
         });
     })
 });

--- a/packages/frontend/src/redux/slices/tokens/index.js
+++ b/packages/frontend/src/redux/slices/tokens/index.js
@@ -114,7 +114,7 @@ const tokensSlice = createSlice({
     },
     extraReducers: ((builder) => {
         handleAsyncThunkStatus({
-            asyncThunk: `${SLICE_NAME}/fetchOwnedTokensForContract`,
+            asyncThunk: fetchOwnedTokensForContract,
             buildStatusPath: ({ meta: { arg: { accountId, contractName }}}) => ['ownedTokens', 'byAccountId', accountId, contractName],
             builder
         });

--- a/packages/frontend/src/redux/slices/tokens/index.js
+++ b/packages/frontend/src/redux/slices/tokens/index.js
@@ -24,8 +24,10 @@ const initialState = {
 
 const initialOwnedTokenState = {
     balance: '',
-    loading: false,
-    error: initialErrorState
+    status: {
+        loading: false,
+        error: initialErrorState
+    }
 };
 
 async function getCachedContractMetadataOrFetch(contractName, state) {
@@ -115,7 +117,7 @@ const tokensSlice = createSlice({
     extraReducers: ((builder) => {
         handleAsyncThunkStatus({
             asyncThunk: fetchOwnedTokensForContract,
-            buildStatusPath: ({ meta: { arg: { accountId, contractName }}}) => ['ownedTokens', 'byAccountId', accountId, contractName],
+            buildStatusPath: ({ meta: { arg: { accountId, contractName }}}) => ['ownedTokens', 'byAccountId', accountId, contractName, 'status'],
             builder
         });
     })
@@ -183,12 +185,12 @@ export const selectTokensWithMetadataForAccountId = createSelector(
 export const selectTokensLoading = createSelector(
     [selectOwnedTokensSlice, getAccountIdParam],
     (ownedTokens, accountId) => Object.entries(ownedTokens.byAccountId[accountId] || {})
-        .some(([_, { loading }]) => loading)
+        .some(([_, { status: { loading } }]) => loading)
 );
 
 const selectOneTokenLoading = createSelector(
     [selectOneTokenFromOwnedTokens],
-    (token) => token.loading
+    (token) => token.status.loading
 );
 
 export const selectNEARAsTokenWithMetadata = createSelector(

--- a/packages/frontend/src/redux/slices/transactions/index.js
+++ b/packages/frontend/src/redux/slices/transactions/index.js
@@ -4,6 +4,7 @@ import { createSelector } from 'reselect';
 
 import { getTransactions, transactionExtraInfo } from '../../../utils/explorer-api';
 import createParameterSelector from '../createParameterSelector';
+import handleAsyncThunkStatus from '../handleAsyncThunkStatus';
 import initialErrorState from '../initialErrorState';
 
 const SLICE_NAME = 'transactions';
@@ -88,26 +89,10 @@ const transactionsSlice = createSlice({
         }
     },
     extraReducers: ((builder) => {
-        builder.addCase(fetchTransactions.pending, (state, { meta }) => {
-            const { accountId } = meta.arg;
-
-            set(state, ['byAccountId', accountId, 'status', 'loading'], true);
-            set(state, ['byAccountId', accountId, 'status', 'error'], initialErrorState);
-        });
-        builder.addCase(fetchTransactions.fulfilled, (state,  { meta }) => {
-            const { accountId } = meta.arg;
-
-            set(state, ['byAccountId', accountId, 'status', 'loading'], false);
-            set(state, ['byAccountId', accountId, 'status', 'error'], initialErrorState);
-        });
-        builder.addCase(fetchTransactions.rejected, (state, { meta, error }) => {
-            const { accountId } = meta.arg;
-            
-            set(state, ['byAccountId', accountId, 'status', 'loading'], false);
-            set(state, ['byAccountId', accountId, 'status', 'error'], {
-                message: error?.message || 'An error was encountered.',
-                code: error?.code
-            });
+        handleAsyncThunkStatus({
+            asyncThunk: `${SLICE_NAME}/fetchTransactions`,
+            buildStatusPath: ({ meta: { arg: { accountId }}}) => ['byAccountId', accountId, 'status'],
+            builder
         });
     })
 });

--- a/packages/frontend/src/redux/slices/transactions/index.js
+++ b/packages/frontend/src/redux/slices/transactions/index.js
@@ -28,8 +28,8 @@ const fetchTransactions = createAsyncThunk(
         const { actions: { setTransactions, updateTransactions } } = transactionsSlice;
 
         !selectTransactionsByAccountId(getState(), { accountId }).length
-            ? dispatch(setTransactions({ transactions, accountId }))
-            : dispatch(updateTransactions({ transactions, accountId }));
+            ? dispatch(setTransactions({ transactions, accountId }))
+            : dispatch(updateTransactions({ transactions, accountId }));
     }
 );
 
@@ -45,7 +45,7 @@ const fetchTransactionStatus = createAsyncThunk(
         }
         const checkStatus = ['SuccessValue', 'Failure'].includes(status);
         const { actions: { updateTransactionStatus } } = transactionsSlice;
-        dispatch(updateTransactionStatus({ status, checkStatus, accountId, hash }));
+        dispatch(updateTransactionStatus({ status, checkStatus, accountId, hash }));
     }
 );
 

--- a/packages/frontend/src/redux/slices/transactions/index.js
+++ b/packages/frontend/src/redux/slices/transactions/index.js
@@ -90,7 +90,7 @@ const transactionsSlice = createSlice({
     },
     extraReducers: ((builder) => {
         handleAsyncThunkStatus({
-            asyncThunk: `${SLICE_NAME}/fetchTransactions`,
+            asyncThunk: fetchTransactions,
             buildStatusPath: ({ meta: { arg: { accountId }}}) => ['byAccountId', accountId, 'status'],
             builder
         });


### PR DESCRIPTION
Creating `handleAsyncThunkStatus` helper function that simplifies and allows to automatically handle status objects for reducers. 

It's prepared using `addMatcher` because we need to handle situations when we would like to use `.pending`/`.fulfilled`/`.rejected` for additional functionality. And it's not allowed to use more than one `addCase` for the same action status.