### PR TITLE
fix: use `.replace` to update query params

### DIFF
--- a/packages/frontend/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
+++ b/packages/frontend/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
@@ -202,7 +202,6 @@ class SetupRecoveryMethod extends Component {
             fundCreateAccount,
             createNewAccount,
             validateSecurityCode,
-            saveAccount,
             location,
             setLinkdropAmount,
             redirectTo,

--- a/packages/frontend/src/redux/actions/account.js
+++ b/packages/frontend/src/redux/actions/account.js
@@ -209,7 +209,7 @@ export const allowLogin = () => async (dispatch, getState) => {
         const allKeys = availableKeys.map(key => key.toString());
         const url = new URL(successUrl);
         const originalSearchParams = parse(url.search);
-        window.location = `${url.origin}${url.pathname}?${stringify(
+        window.location = successUrl.replace(url.search, `?${stringify(
             {
                 ...originalSearchParams,
                 account_id: wallet.accountId,
@@ -221,7 +221,7 @@ export const allowLogin = () => async (dispatch, getState) => {
                 skipNull: true,
                 arrayFormat: "comma"
             }
-        )}`;
+        )}`);
     } else {
         await dispatch(withAlert(addAccessKey(wallet.accountId, contractId, publicKey, false, methodNames), { data: { title } }));
         dispatch(redirectTo('/authorized-apps', { globalAlertPreventClear: true }));

--- a/packages/frontend/src/redux/slices/sign/index.js
+++ b/packages/frontend/src/redux/slices/sign/index.js
@@ -83,10 +83,10 @@ export const handleSignTransactions = createAsyncThunk(
 export function addQueryParams(baseUrl, queryParams = {}) {
     const url = new URL(baseUrl);
     const originalSearchParams = parse(url.search);
-    return `${url.origin}${url.pathname}?${stringify({...originalSearchParams, ...queryParams}, {
+    return baseUrl.replace(url.search,`?${stringify({...originalSearchParams, ...queryParams}, {
         skipEmptyString: true,
         skipNull: true,
-    })}`;
+    })}`);
 }
 
 export const removeSuccessTransactions = ({ transactions, successHashes }) => {


### PR DESCRIPTION
Use `.replace` to update query params

Closes #2452