### PR TITLE
fix: restore support for optional redirect URLs

### DIFF
--- a/packages/frontend/src/utils/helper-api.js
+++ b/packages/frontend/src/utils/helper-api.js
@@ -10,7 +10,7 @@ export async function getAccountIds(publicKey) {
 
 export function isUrlNotJavascriptProtocol(url) {
     if (!url) {
-        return false;
+        return true;
     }
 
     const urlProtocol = new URL(url).protocol;


### PR DESCRIPTION
Bugfix: Restore behaviour which permits optional redirect urls in some routes (such as login)