### PR TITLE
fix: add 'empty' contract to enable 2fa button whitelist

### DIFF
--- a/packages/frontend/src/components/profile/two_factor/TwoFactorAuth.js
+++ b/packages/frontend/src/components/profile/two_factor/TwoFactorAuth.js
@@ -5,7 +5,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { MULTISIG_MIN_AMOUNT } from '../../../config';
+import { MULTISIG_MIN_AMOUNT, ALLOW_2FA_ENABLE_HASHES } from '../../../config';
 import { disableMultisig } from '../../../redux/actions/account';
 import { selectAccountSlice } from '../../../redux/slices/account';
 import { actions as recoveryMethodsActions } from '../../../redux/slices/recoveryMethods';
@@ -67,7 +67,7 @@ const Container = styled(Card)`
 const TwoFactorAuth = ({ twoFactor, history }) => {
     const [confirmDisable, setConfirmDisable] = useState(false);
     const account = useSelector(selectAccountSlice);
-    const existingContract = (account?.code_hash !== '11111111111111111111111111111111');
+    const existingContract = !ALLOW_2FA_ENABLE_HASHES.includes(account?.code_hash);
     const nearTokenFiatValueUSD = useSelector(selectNearTokenFiatValueUSD);
     const dispatch = useDispatch();
     const confirmDisabling = useSelector((state) => selectActionsPending(state, { types: ['DISABLE_MULTISIG'] }));

--- a/packages/frontend/src/config/configFromEnvironment.js
+++ b/packages/frontend/src/config/configFromEnvironment.js
@@ -18,6 +18,9 @@ module.exports = {
     ACCOUNT_HELPER_URL: process.env.REACT_APP_ACCOUNT_HELPER_URL,
     ACCOUNT_ID_SUFFIX: process.env.REACT_APP_ACCOUNT_ID_SUFFIX,
     ACCESS_KEY_FUNDING_AMOUNT: process.env.REACT_APP_ACCESS_KEY_FUNDING_AMOUNT,
+    ALLOW_2FA_ENABLE_HASHES: parseCommaSeperatedStringAsArrayFromShell(
+        process.env.ALLOW_2FA_ENABLE_HASHES
+    ),
     BROWSER_MIXPANEL_TOKEN: process.env.BROWSER_MIXPANEL_TOKEN,
     DISABLE_CREATE_ACCOUNT: parseBooleanFromShell(
         process.env.DISABLE_CREATE_ACCOUNT

--- a/packages/frontend/src/config/environmentDefaults/development.js
+++ b/packages/frontend/src/config/environmentDefaults/development.js
@@ -4,6 +4,10 @@ export default {
     ACCOUNT_HELPER_URL:"https://near-contract-helper.onrender.com",
     ACCOUNT_ID_SUFFIX: "testnet",
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount("0.25"),
+    ALLOW_2FA_ENABLE_HASHES: [
+        'E8jZ1giWcVrps8PcV75ATauu6gFRkcwjNtKp7NKmipZG',
+        '11111111111111111111111111111111'
+    ],
     DISABLE_CREATE_ACCOUNT: false,
     DISABLE_PHONE_RECOVERY: true,
     EXPLORE_APPS_URL: "https://awesomenear.com/",

--- a/packages/frontend/src/config/environmentDefaults/mainnet.js
+++ b/packages/frontend/src/config/environmentDefaults/mainnet.js
@@ -4,6 +4,10 @@ export default {
     ACCOUNT_HELPER_URL: "https://helper.mainnet.near.org",
     ACCOUNT_ID_SUFFIX: "near",
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount("0.25"),
+    ALLOW_2FA_ENABLE_HASHES: [
+      'E8jZ1giWcVrps8PcV75ATauu6gFRkcwjNtKp7NKmipZG',
+      '11111111111111111111111111111111'
+    ],
     BROWSER_MIXPANEL_TOKEN: "d5bbbbcc3a77ef8427f2b806b5689bf8",
     DISABLE_CREATE_ACCOUNT: true,
     DISABLE_PHONE_RECOVERY: true,

--- a/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.js
+++ b/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.js
@@ -4,6 +4,10 @@ export default {
     ACCOUNT_HELPER_URL: "https://helper.mainnet.near.org",
     ACCOUNT_ID_SUFFIX: "near",
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount("0.25"),
+    ALLOW_2FA_ENABLE_HASHES: [
+        'E8jZ1giWcVrps8PcV75ATauu6gFRkcwjNtKp7NKmipZG',
+        '11111111111111111111111111111111'
+    ],
     BROWSER_MIXPANEL_TOKEN: "d5bbbbcc3a77ef8427f2b806b5689bf8",
     DISABLE_CREATE_ACCOUNT: true,
     DISABLE_PHONE_RECOVERY: true,

--- a/packages/frontend/src/config/environmentDefaults/testnet.js
+++ b/packages/frontend/src/config/environmentDefaults/testnet.js
@@ -4,6 +4,10 @@ export default {
     ACCOUNT_HELPER_URL: "https://near-contract-helper.onrender.com",
     ACCOUNT_ID_SUFFIX: "testnet",
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount("0.25"),
+    ALLOW_2FA_ENABLE_HASHES: [
+        'E8jZ1giWcVrps8PcV75ATauu6gFRkcwjNtKp7NKmipZG',
+        '11111111111111111111111111111111'
+    ],
     BROWSER_MIXPANEL_TOKEN: "9edede4b70de19f399736d5840872910",
     DISABLE_CREATE_ACCOUNT: false,
     DISABLE_PHONE_RECOVERY: false,


### PR DESCRIPTION
Add empty contract `E8jZ1giWcVrps8PcV75ATauu6gFRkcwjNtKp7NKmipZG` to enable 2fa button whitelist. Similar to [#736](https://github.com/near/near-api-js/pull/736) in near-api-js but in wallet scope. Temporary patch to disable button only.