### PR TITLE
feat: add script to disable 2fa using seedphrase

### DIFF
--- a/packages/frontend/tools/disable-2fa-with-seedphrase/README.md
+++ b/packages/frontend/tools/disable-2fa-with-seedphrase/README.md
@@ -1,0 +1,13 @@
+## Disable 2fa with seedphrase
+
+This script allows the user to disable NEAR Wallet 2fa using the provided seedphrase
+
+## Prerequisites
+
+* [near-cli](https://github.com/near/near-cli) needs to be installed
+
+## Usage
+
+```shell=
+NEAR_WALLET_ENV=mainnet ./disable-2fa-with-seedphrase.sh --accountId="testAccount.near" --seedPhrase='lorem ipsum dolor sit amet consectetur adipiscing elit nunc efficitur est'
+```

--- a/packages/frontend/tools/disable-2fa-with-seedphrase/disable-2fa-with-seedphrase.sh
+++ b/packages/frontend/tools/disable-2fa-with-seedphrase/disable-2fa-with-seedphrase.sh
@@ -1,0 +1,24 @@
+#/bin/bash 
+for i in "$@"; do
+  case $i in
+    --accountId=*)
+      ACCOUNTID="${i#*=}"
+      shift
+      ;;
+    --seedPhrase=*)
+      SEEDPHRASE="${i#*=}"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$SEEDPHRASE" ] || [ -z "$ACCOUNTID" ]
+then
+      echo "Both accountId and seedphrase are required"
+      exit 1
+fi
+
+near generate-key $ACCOUNTID --seedPhrase="$SEEDPHRASE"
+curl "https://raw.githubusercontent.com/near/near-wallet/master/packages/frontend/src/wasm/main.wasm" --output ./main.wasm
+near deploy --accountId $ACCOUNTID --wasmFile main.wasm
+rm -rf main.wasm


### PR DESCRIPTION
Add script allows the user to disable NEAR Wallet 2fa using the provided seedphrase