### PR TITLE
fix: prevent transaction approval until account matches signer

### DIFF
--- a/packages/frontend/src/components/sign/v2/SignTransactionSummary.js
+++ b/packages/frontend/src/components/sign/v2/SignTransactionSummary.js
@@ -54,6 +54,7 @@ export default ({
     onClickMoreInformation,
     accountUrlReferrer,
     submittingTransaction,
+    isSignerValid,
     isValidCallbackUrl
 }) => {
     const insufficientBalance = availableBalance && transferAmount && new BN(availableBalance).lt(new BN(transferAmount));
@@ -89,7 +90,7 @@ export default ({
                 </FormButton>
                 <FormButton
                     onClick={onClickApprove}
-                    disabled={submittingTransaction || insufficientBalance || !isValidCallbackUrl}
+                    disabled={submittingTransaction || insufficientBalance || !isValidCallbackUrl || !isSignerValid}
                     sending={submittingTransaction}
                 >
                     <Translate id='button.approve' />

--- a/packages/frontend/src/components/sign/v2/SignTransactionSummaryWrapper.js
+++ b/packages/frontend/src/components/sign/v2/SignTransactionSummaryWrapper.js
@@ -17,9 +17,9 @@ export default ({
     onClickApprove,
     submittingTransaction,
     signGasFee,
+    isSignerValid,
     isValidCallbackUrl
 }) => {
-
     const accountLocalStorageAccountId = useSelector(selectAccountLocalStorageAccountId);
     const accountUrlReferrer = useSelector(selectAccountUrlReferrer);
     const availableBalance = useSelector(selectAvailableBalance);
@@ -36,6 +36,7 @@ export default ({
             onClickMoreInformation={onClickMoreInformation}
             accountUrlReferrer={accountUrlReferrer}
             submittingTransaction={submittingTransaction}
+            isSignerValid={isSignerValid}
             isValidCallbackUrl={isValidCallbackUrl}
         />
     );

--- a/packages/frontend/src/routes/SignWrapper.js
+++ b/packages/frontend/src/routes/SignWrapper.js
@@ -51,6 +51,7 @@ export function SignWrapper() {
     const signerId = transactions.length && transactions[0].signerId;
     const signGasFee = new BN(signFeesGasLimitIncludingGasChanges).div(new BN('1000000000000')).toString();
     const submittingTransaction = signStatus === SIGN_STATUS.IN_PROGRESS;
+    const isSignerValid = accountId === signerId;
 
     useEffect(() => {
         if (!transactionBatchisValid) {
@@ -66,7 +67,7 @@ export function SignWrapper() {
 
     useEffect(() => {
             if (
-                accountId !== signerId &&
+                !isSignerValid &&
                 availableAccounts.some(
                     (accountId) => accountId === signerId
                 )
@@ -161,6 +162,7 @@ export function SignWrapper() {
             signGasFee={signGasFee}
             onClickMoreInformation={() => setCurrentDisplay(DISPLAY.TRANSACTION_DETAILS)}
             onClickEditAccount={() => setCurrentDisplay(DISPLAY.ACCOUNT_SELECTION)}
+            isSignerValid={isSignerValid}
             isValidCallbackUrl={isValidCallbackUrl}
         />
     );


### PR DESCRIPTION
This PR adds a flag prop to the transaction signing components to prevent approving transactions when the active account has not yet switched over to the signing account. This will always be temporary since the account is guaranteed to be valid to render the button and the wrapper dispatches the action to switch accounts if the active account does not match the signing account.

Closes #2482 