### PR TITLE
fix: Fix staking account selector button alignment

### DIFF
--- a/packages/frontend/src/components/common/radio_button/RadioButton.js
+++ b/packages/frontend/src/components/common/radio_button/RadioButton.js
@@ -29,9 +29,11 @@ const Root = styled.div`
             width: 100%;
             height: 100%;
             position: absolute;
-            top: 0;
             pointer-events: none;
             z-index: 0;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%,-50%);
         }
 
         margin-right: 20px;

--- a/packages/frontend/src/components/wallet/ActivitiesWrapper.js
+++ b/packages/frontend/src/components/wallet/ActivitiesWrapper.js
@@ -110,7 +110,7 @@ const ActivitiesWrapper = () => {
             <h2 className={classNames({'dots': activityLoader})}><Translate id='dashboard.activity' /></h2>
             {transactions.map((transaction, i) => (
                 <ActivityBox
-                    key={`${transaction.hash_with_index}-${transaction.kind}`}
+                    key={`${transaction.hash_with_index}-${transaction.block_hash}-${transaction.kind}`}
                     transaction={transaction}
                     actionArgs={transaction.args}
                     actionKind={transaction.kind}


### PR DESCRIPTION
Fixes misaligned button on `/staking`

<img width="125" alt="Screen Shot 2022-02-23 at 2 20 03 PM" src="https://user-images.githubusercontent.com/24921205/155418823-a5886fbc-1325-4f8b-b7d7-944d9a4839c7.png">
