### PR TITLE
fix(recovery): bypass key creation during recovery when account is active or available

### DIFF
--- a/packages/frontend/src/components/accounts/RecoverWithLink.js
+++ b/packages/frontend/src/components/accounts/RecoverWithLink.js
@@ -84,6 +84,8 @@ const UserName = styled.span`
 const ButtonWrapper = styled.div`
     display: flex;
     flex-direction: column;
+    align-items: flex-end;
+    justify-content: space-evenly;
     margin-top: 30px;
 
     @media (min-width: 768px) {
@@ -96,17 +98,12 @@ const ButtonWrapper = styled.div`
             max-width: 300px;
         }
 
-        &:first-of-type {
-            margin-top: 0 !important;
-        }
-
         &:last-of-type {
             margin-top: 25px;
             position: relative;
             overflow: hidden;
 
             @media (min-width: 768px) {
-                margin-left: 25px;
                 margin-top: 0;
             }
 
@@ -137,6 +134,7 @@ class RecoverWithLink extends Component {
         this.state = {
             accountId: this.props.accountId,
             isSwitchingAccount: false,
+            isTargetAccountSelected: false,
             seedPhrase: this.props.seedPhrase,
             successSnackbar: false,
             successView: true
@@ -179,14 +177,18 @@ class RecoverWithLink extends Component {
         );
     }
 
+    handleContinueWithoutRecovery = async () => {
+        this.props.redirectTo('/');
+    }
+
     componentDidUpdate() {
-        const { accountId, isSwitchingAccount } = this.state;
+        const { accountId, isSwitchingAccount, isTargetAccountSelected } = this.state;
         const { isAccountActive, isAccountAvailable } = this.props;
 
         // redirect user to home page if active account is being recovered
         // switch to account being recovered if already in the set of available accounts
-        if (isAccountActive) {
-            this.props.redirectTo('/');
+        if (isAccountActive && !isTargetAccountSelected) {
+            this.setState({ isTargetAccountSelected: true });
         } else if (isAccountAvailable && !isSwitchingAccount) {
             // reset flag to ensure account switch is only dispatched once
             this.setState({ isSwitchingAccount: true });
@@ -196,7 +198,7 @@ class RecoverWithLink extends Component {
     }
 
     render() {
-        const { accountId, isSwitchingAccounts, successSnackbar, successView } = this.state;
+        const { accountId, isSwitchingAccounts, isTargetAccountSelected, successSnackbar, successView } = this.state;
         const { mainLoader, history, continueSending } = this.props;
 
         if (successView) {
@@ -208,14 +210,23 @@ class RecoverWithLink extends Component {
                             <Title>{translate('recoverWithLink.title')}</Title>
                             <Desc>{translate('recoverWithLink.pOne')} <UserName>{accountId}</UserName></Desc>
                             <Desc last>{translate('recoverWithLink.pTwo')}</Desc>
+                            <Desc last>{translate('recoverWithLink.pThree')}</Desc>
                             <ButtonWrapper>
+                                <FormButton
+                                    onClick={this.handleContinueWithoutRecovery}
+                                    disabled={!isTargetAccountSelected}
+                                    sending={isSwitchingAccounts}
+                                    sendingString='button.switching'
+                                >
+                                    {translate('button.switchToAccount')}
+                                </FormButton>
                                 <FormButton
                                     onClick={this.handleContinue}
                                     disabled={mainLoader || isSwitchingAccounts}
                                     sending={continueSending}
                                     sendingString='button.recovering'
                                 >
-                                    {translate('button.continue')}
+                                    {translate('button.recoverAccount')}
                                 </FormButton>
                                 <Button onClick={this.handleCopyUrl}>
                                     {translate('button.copyUrl')}

--- a/packages/frontend/src/components/accounts/RecoverWithLink.js
+++ b/packages/frontend/src/components/accounts/RecoverWithLink.js
@@ -196,7 +196,7 @@ class RecoverWithLink extends Component {
     }
 
     render() {
-        const { accountId, successSnackbar, successView } = this.state;
+        const { accountId, isSwitchingAccounts, successSnackbar, successView } = this.state;
         const { mainLoader, history, continueSending } = this.props;
 
         if (successView) {
@@ -211,7 +211,7 @@ class RecoverWithLink extends Component {
                             <ButtonWrapper>
                                 <FormButton
                                     onClick={this.handleContinue}
-                                    disabled={mainLoader}
+                                    disabled={mainLoader || isSwitchingAccounts}
                                     sending={continueSending}
                                     sendingString='button.recovering'
                                 >

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -264,6 +264,8 @@
         "staking": "Staking",
         "startOver": "Start over",
         "subscribe": "Subscribe",
+        "switchToAccount": "Switch To Account",
+        "switching": "Switching Account",
         "topUp": "Top Up",
         "transferring": "Transferring",
         "tryAgain": "Try Again",
@@ -824,8 +826,9 @@
     "recoverWithLink": {
         "errorP": "Please check your email or phone for the most recent message. Links in all earlier messages are invalid.",
         "errorTitle": "Link Expired",
-        "pOne": "Click \"Continue\" to restore your account:",
+        "pOne": "Click \"Recover Account\" to restore your account:",
         "pTwo": "If this isn't your preferred browser, copy the URL and complete this process in your browser of choice.",
+        "pThree": "If the account is already active, you may instead switch to your account. This option will not create additional access keys.",
         "snackbarCopySuccess": "Recover URL copied",
         "title": "Restore Account"
     },


### PR DESCRIPTION
This PR modifies the link recovery component to check on update whether the account being recovered is already in the account state (i.e. already has keys for in the current browser's localStorage). If it is already the active account, the user is redirected to the root page. If it is not currently active but is in the set of available accounts, then the current account is switched to that the account being recovered.

Recovering accounts in browsers without a key in localStorage will still require the creation of an access key from the seed phrase in the link.

To test using the preview link:
- Visit https://near-wallet-pr-2503.onrender.com/recover-with-link/pr2503_test.testnet/virtual%20arrive%20cliff%20hunt%20stand%20cupboard%20syrup%20bachelor%20safe%20basic%20dawn%20inside.
- Verify that the `Continue` button allows you to recover the account.
- Visit the link again, this time verifying that you are redirected to the account page because you are logged into the account already.

Closes #2494 