### PR TITLE
chore: add new project validator factory to regex

### DIFF
--- a/packages/frontend/src/utils/constants.js
+++ b/packages/frontend/src/utils/constants.js
@@ -1,31 +1,31 @@
 export const VALIDATOR_VERSION = 'VALIDATOR';
-export const FARMING_VALIDATOR_VERSION = 'FARMING_VALIDATOR';
+export const PROJECT_VALIDATOR_VERSION = 'PROJECT_VALIDATOR';
 
 export const ValidatorVersion = {
   [VALIDATOR_VERSION]: VALIDATOR_VERSION,
-  [FARMING_VALIDATOR_VERSION]: FARMING_VALIDATOR_VERSION
+  [PROJECT_VALIDATOR_VERSION]: PROJECT_VALIDATOR_VERSION
 };
 
 export const MAINNET = 'mainnet';
 export const TESTNET = 'testnet';
-export const FARMING_VALIDATOR_PREFIXES_MAINNET = ['.pool.near'];
+export const PROJECT_VALIDATOR_PREFIXES_MAINNET = ['.pool.near'];
 export const VALIDATOR_PREFIXES_MAINNET = ['.poolv1.near'];
-export const FARMING_VALIDATOR_PREFIXES_TESTNET = ['.factory01.littlefarm.testnet','.factory.colorpalette.testnet'];
+export const PROJECT_VALIDATOR_PREFIXES_TESTNET = ['.factory01.littlefarm.testnet','.factory.colorpalette.testnet'];
 export const VALIDATOR_PREFIXES_TESTNET = ['.m0'];
 
-export const FARMING_VALIDATOR_REGEXP_TESTNET = new RegExp(`.*(${FARMING_VALIDATOR_PREFIXES_TESTNET.join('|')}|${VALIDATOR_PREFIXES_TESTNET.join('|')})`);
-export const FARMING_VALIDATOR_REGEXP_MAINNET = new RegExp(`.*(${FARMING_VALIDATOR_PREFIXES_MAINNET.join('|')}|${VALIDATOR_PREFIXES_MAINNET.join('|')})`);
+export const PROJECT_VALIDATOR_REGEXP_TESTNET = new RegExp(`.*(${PROJECT_VALIDATOR_PREFIXES_TESTNET.join('|')}|${VALIDATOR_PREFIXES_TESTNET.join('|')})`);
+export const PROJECT_VALIDATOR_REGEXP_MAINNET = new RegExp(`.*(${PROJECT_VALIDATOR_PREFIXES_MAINNET.join('|')}|${VALIDATOR_PREFIXES_MAINNET.join('|')})`);
 
 export const getFarmingValidatorPrefixes = (networkId) => {
   switch (networkId) {
     case (MAINNET): {
-      return FARMING_VALIDATOR_PREFIXES_MAINNET;
+      return PROJECT_VALIDATOR_PREFIXES_MAINNET;
     }
     case (TESTNET): {
-      return FARMING_VALIDATOR_PREFIXES_TESTNET;
+      return PROJECT_VALIDATOR_PREFIXES_TESTNET;
     }
     default: {
-      return FARMING_VALIDATOR_PREFIXES_TESTNET;
+      return PROJECT_VALIDATOR_PREFIXES_TESTNET;
     }
   }
 };
@@ -33,32 +33,32 @@ export const getFarmingValidatorPrefixes = (networkId) => {
 export const getValidatorRegExp = (networkId) => {
   switch (networkId) {
     case (MAINNET): {
-      return FARMING_VALIDATOR_REGEXP_MAINNET;
+      return PROJECT_VALIDATOR_REGEXP_MAINNET;
     }
     case (TESTNET): {
-      return FARMING_VALIDATOR_REGEXP_TESTNET;
+      return PROJECT_VALIDATOR_REGEXP_TESTNET;
     }
     default: {
-      return FARMING_VALIDATOR_REGEXP_TESTNET;
+      return PROJECT_VALIDATOR_REGEXP_TESTNET;
     }
   }
 };
 
 export const getValidationVersion = (networkId, accountId) => {
   const prefixes = getValidationNetworkPrefixes(networkId);
-  return prefixes.some((prefix) => accountId.indexOf(prefix) !== -1) ? FARMING_VALIDATOR_VERSION : VALIDATOR_VERSION;
+  return prefixes.some((prefix) => accountId.indexOf(prefix) !== -1) ? PROJECT_VALIDATOR_VERSION : VALIDATOR_VERSION;
 };
 
 export const getValidationNetworkPrefixes = (networkId) => {
   switch (networkId) {
     case (MAINNET): {
-      return FARMING_VALIDATOR_PREFIXES_MAINNET;
+      return PROJECT_VALIDATOR_PREFIXES_MAINNET;
     }
     case (TESTNET): {
-      return FARMING_VALIDATOR_PREFIXES_TESTNET;
+      return PROJECT_VALIDATOR_PREFIXES_TESTNET;
     }
     default: {
-      return FARMING_VALIDATOR_PREFIXES_TESTNET;
+      return PROJECT_VALIDATOR_PREFIXES_TESTNET;
     }
   }
 };

--- a/packages/frontend/src/utils/constants.js
+++ b/packages/frontend/src/utils/constants.js
@@ -46,7 +46,7 @@ export const getValidatorRegExp = (networkId) => {
 
 export const getValidationVersion = (networkId, accountId) => {
   const prefixes = getValidationNetworkPrefixes(networkId);
-  return prefixes.some((prefix) => accountId.indexOf(prefix)) ? FARMING_VALIDATOR_VERSION : VALIDATOR_VERSION;
+  return prefixes.some((prefix) => accountId.indexOf(prefix) !== -1) ? FARMING_VALIDATOR_VERSION : VALIDATOR_VERSION;
 };
 
 export const getValidationNetworkPrefixes = (networkId) => {

--- a/packages/frontend/src/utils/constants.js
+++ b/packages/frontend/src/utils/constants.js
@@ -1,31 +1,31 @@
 export const VALIDATOR_VERSION = 'VALIDATOR';
-export const PROJECT_VALIDATOR_VERSION = 'PROJECT_VALIDATOR';
+export const FARMING_VALIDATOR_VERSION = 'FARMING_VALIDATOR';
 
 export const ValidatorVersion = {
   [VALIDATOR_VERSION]: VALIDATOR_VERSION,
-  [PROJECT_VALIDATOR_VERSION]: PROJECT_VALIDATOR_VERSION
+  [FARMING_VALIDATOR_VERSION]: FARMING_VALIDATOR_VERSION
 };
 
 export const MAINNET = 'mainnet';
 export const TESTNET = 'testnet';
-export const PROJECT_VALIDATOR_PREFIX_MAINNET = '.pool.near';
-export const VALIDATOR_PREFIX_MAINNET = '.poolv1.near';
-export const PROJECT_VALIDATOR_PREFIX_TESTNET = ['.factory01.littlefarm.testnet','.factory.colorpalette.testnet'].join('|');
-export const VALIDATOR_PREFIX_TESTNET = '.m0';
+export const FARMING_VALIDATOR_PREFIXES_MAINNET = ['.pool.near'];
+export const VALIDATOR_PREFIXES_MAINNET = ['.poolv1.near'];
+export const FARMING_VALIDATOR_PREFIXES_TESTNET = ['.factory01.littlefarm.testnet','.factory.colorpalette.testnet'];
+export const VALIDATOR_PREFIXES_TESTNET = ['.m0'];
 
-export const PROJECT_VALIDATOR_REGEXP_TESTNET = new RegExp(`.*(${PROJECT_VALIDATOR_PREFIX_TESTNET}|${VALIDATOR_PREFIX_TESTNET})`);
-export const PROJECT_VALIDATOR_REGEXP_MAINNET = new RegExp(`.*(${PROJECT_VALIDATOR_PREFIX_MAINNET}|${VALIDATOR_PREFIX_MAINNET})`);
+export const FARMING_VALIDATOR_REGEXP_TESTNET = new RegExp(`.*(${FARMING_VALIDATOR_PREFIXES_TESTNET.join('|')}|${VALIDATOR_PREFIXES_TESTNET.join('|')})`);
+export const FARMING_VALIDATOR_REGEXP_MAINNET = new RegExp(`.*(${FARMING_VALIDATOR_PREFIXES_MAINNET.join('|')}|${VALIDATOR_PREFIXES_MAINNET.join('|')})`);
 
-export const getProjectValidatorPrefix = (networkId) => {
+export const getFarmingValidatorPrefixes = (networkId) => {
   switch (networkId) {
     case (MAINNET): {
-      return PROJECT_VALIDATOR_PREFIX_MAINNET;
+      return FARMING_VALIDATOR_PREFIXES_MAINNET;
     }
     case (TESTNET): {
-      return PROJECT_VALIDATOR_PREFIX_TESTNET;
+      return FARMING_VALIDATOR_PREFIXES_TESTNET;
     }
     default: {
-      return PROJECT_VALIDATOR_PREFIX_TESTNET;
+      return FARMING_VALIDATOR_PREFIXES_TESTNET;
     }
   }
 };
@@ -33,32 +33,32 @@ export const getProjectValidatorPrefix = (networkId) => {
 export const getValidatorRegExp = (networkId) => {
   switch (networkId) {
     case (MAINNET): {
-      return PROJECT_VALIDATOR_REGEXP_MAINNET;
+      return FARMING_VALIDATOR_REGEXP_MAINNET;
     }
     case (TESTNET): {
-      return PROJECT_VALIDATOR_REGEXP_TESTNET;
+      return FARMING_VALIDATOR_REGEXP_TESTNET;
     }
     default: {
-      return PROJECT_VALIDATOR_REGEXP_TESTNET;
+      return FARMING_VALIDATOR_REGEXP_TESTNET;
     }
   }
 };
 
 export const getValidationVersion = (networkId, accountId) => {
-  const prefix = getValidationNetworkPrefix(networkId);
-  return accountId.indexOf(prefix) === -1 ? VALIDATOR_VERSION : PROJECT_VALIDATOR_VERSION;
+  const prefixes = getValidationNetworkPrefixes(networkId);
+  return prefixes.some((prefix) => accountId.indexOf(prefix)) ? FARMING_VALIDATOR_VERSION : VALIDATOR_VERSION;
 };
 
-export const getValidationNetworkPrefix = (networkId) => {
+export const getValidationNetworkPrefixes = (networkId) => {
   switch (networkId) {
     case (MAINNET): {
-      return PROJECT_VALIDATOR_PREFIX_MAINNET;
+      return FARMING_VALIDATOR_PREFIXES_MAINNET;
     }
     case (TESTNET): {
-      return PROJECT_VALIDATOR_PREFIX_TESTNET;
+      return FARMING_VALIDATOR_PREFIXES_TESTNET;
     }
     default: {
-      return PROJECT_VALIDATOR_PREFIX_TESTNET;
+      return FARMING_VALIDATOR_PREFIXES_TESTNET;
     }
   }
 };

--- a/packages/frontend/src/utils/constants.js
+++ b/packages/frontend/src/utils/constants.js
@@ -10,7 +10,7 @@ export const MAINNET = 'mainnet';
 export const TESTNET = 'testnet';
 export const PROJECT_VALIDATOR_PREFIX_MAINNET = '.pool.near';
 export const VALIDATOR_PREFIX_MAINNET = '.poolv1.near';
-export const PROJECT_VALIDATOR_PREFIX_TESTNET = '.factory01.littlefarm.testnet';
+export const PROJECT_VALIDATOR_PREFIX_TESTNET = ['.factory01.littlefarm.testnet','.factory.colorpalette.testnet'].join('|');
 export const VALIDATOR_PREFIX_TESTNET = '.m0';
 
 export const PROJECT_VALIDATOR_REGEXP_TESTNET = new RegExp(`.*(${PROJECT_VALIDATOR_PREFIX_TESTNET}|${VALIDATOR_PREFIX_TESTNET})`);


### PR DESCRIPTION
This PR adds support for validators using wallet factory `factory.colorpalette.testnet` as well as aurora's `factory01.littlefarm.testnet`