### PR TITLE
WAL-115 Remove option for enabling 2FA with SMS

### DIFF
--- a/packages/frontend/src/components/accounts/two_factor/EnableTwoFactor.js
+++ b/packages/frontend/src/components/accounts/two_factor/EnableTwoFactor.js
@@ -1,7 +1,6 @@
 import { utils } from 'near-api-js';
 import React, { useState, useEffect } from 'react';
 import { Translate } from 'react-localize-redux';
-import PhoneInput, { isValidPhoneNumber } from 'react-phone-number-input';
 import { useSelector, useDispatch } from 'react-redux';
 import styled from 'styled-components';
 
@@ -19,7 +18,6 @@ import { selectAccountHas2fa, selectAccountId } from '../../../redux/slices/acco
 import { selectActionsPending, selectStatusSlice } from '../../../redux/slices/status';
 import { selectNearTokenFiatValueUSD } from '../../../redux/slices/tokenFiatValues';
 import { validateEmail } from '../../../utils/account';
-import isApprovedCountryCode from '../../../utils/isApprovedCountryCode';
 import AlertBanner from '../../common/AlertBanner';
 import { getNearAndFiatValue } from '../../common/balance/helpers';
 import Checkbox from '../../common/Checkbox';
@@ -90,8 +88,6 @@ export function EnableTwoFactor(props) {
     const [initiated, setInitiated] = useState(false);
     const [option, setOption] = useState('email');
     const [email, setEmail] = useState('');
-    const [phoneNumber, setPhoneNumber] = useState('');
-    const [country, setCountry] = useState('');
     const [twoFactorAmountApproved, setTwoFactorAmountApproved] = useState(false);
     const recoveryMethods = useRecoveryMethods(accountId);
     const loading = status.mainLoader;
@@ -101,20 +97,15 @@ export function EnableTwoFactor(props) {
     const multiSigMinAmountRaw = parseNearAmount(MULTISIG_MIN_AMOUNT);
 
     const method = {
-        kind: `2fa-${option}`,
-        detail: option === 'email' ? email : phoneNumber
+        kind: '2fa-email',
+        detail: email
     };
 
     useEffect(() => {
         const email = recoveryMethods.filter((method) => method.kind === 'email')[0];
-        const phone = recoveryMethods.filter((method) => method.kind === 'phone')[0];
 
         if (email) {
             setEmail(email.detail);
-        }
-
-        if (phone) {
-            setPhoneNumber(phone.detail);
         }
 
     }, [recoveryMethods]);
@@ -170,8 +161,6 @@ export function EnableTwoFactor(props) {
         switch (option) {
             case 'email':
                 return validateEmail(email);
-            case 'phone':
-                return isApprovedCountryCode(country) && isValidPhoneNumber(phoneNumber);
             default:
                 return false;
         }
@@ -209,29 +198,6 @@ export function EnableTwoFactor(props) {
                             )}
                         </Translate>
                     </TwoFactorOption>
-                    <TwoFactorOption
-                        onClick={() => setOption('phone')}
-                        option='phone'
-                        active={option}
-                    >
-                        <Translate>
-                            {({ translate }) => (
-                                <>
-                                    <PhoneInput
-                                        placeholder={translate('setupRecovery.phonePlaceholder')}
-                                        value={phoneNumber}
-                                        onChange={(value) => setPhoneNumber(value)}
-                                        onCountryChange={(option) => setCountry(option)}
-                                        tabIndex='1'
-                                        disabled={loading}
-                                    />
-                                    {!isApprovedCountryCode(country) && 
-                                        <div className='color-red'>{translate('setupRecovery.notSupportedPhone')}</div>
-                                    }
-                                </>
-                            )}
-                        </Translate>
-                    </TwoFactorOption>
                     <label>
                         <Checkbox
                             checked={twoFactorAmountApproved}
@@ -263,7 +229,6 @@ export function EnableTwoFactor(props) {
         return (
             <EnterVerificationCode
                 option={option}
-                phoneNumber={phoneNumber}
                 email={email}
                 onConfirm={handleConfirm}
                 onGoBack={handleGoBack}

--- a/packages/frontend/src/components/accounts/two_factor/TwoFactorOption.js
+++ b/packages/frontend/src/components/accounts/two_factor/TwoFactorOption.js
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import IntFlagIcon from '../../../images/int-flag-small.svg';
 import classNames from '../../../utils/classNames';
 import EmailIcon from '../../svg/EmailIcon';
-import PhoneIcon from '../../svg/PhoneIcon';
 
 const Container = styled.div`
     background-color: #F8F8F8;
@@ -152,7 +151,7 @@ const TwoFactorOption = ({
     return (
         <Container onClick={onClick} className={classNames([{active: active, inputProblem: problem}])}>
             <Header>
-                {option === 'email' ? <EmailIcon/> : <PhoneIcon/>}
+                {option === 'email' ? <EmailIcon/> : null}
                 <Title><Translate id={`twoFactor.${option}`}/></Title>
             </Header>
             {active && children}

--- a/packages/frontend/src/components/accounts/two_factor/TwoFactorOption.js
+++ b/packages/frontend/src/components/accounts/two_factor/TwoFactorOption.js
@@ -14,19 +14,7 @@ const Container = styled.div`
     max-width: 500px;
     cursor: pointer;
     position: relative;
-    margin-left: 35px;
     margin-top: 20px;
-
-    :before {
-        content: '';
-        height: 22px;
-        width: 22px;
-        border: 2px solid #E6E6E6;
-        position: absolute;
-        left: -35px;
-        top: 13px;
-        border-radius: 50%;
-    }
 
     path {
         stroke: #8dd4bd;
@@ -44,18 +32,6 @@ const Container = styled.div`
         :before {
             background-color: #0072CE;
             border-color: #0072CE;
-        }
-
-        :after {
-            content: '';
-            position: absolute;
-            transform: rotate(45deg);
-            left: -27px;
-            top: 17px;
-            height: 11px;
-            width: 6px;
-            border-bottom: 2px solid white;
-            border-right: 2px solid white;
         }
 
         .icon, path {

--- a/packages/frontend/src/components/profile/hardware_devices/ConfirmDisable.js
+++ b/packages/frontend/src/components/profile/hardware_devices/ConfirmDisable.js
@@ -16,6 +16,7 @@ const Container = styled.form`
         div {
             :nth-child(1) {
                 font-weight: 600;
+                margin-bottom: 10px;
             }
         }
 
@@ -41,13 +42,15 @@ const Container = styled.form`
     }
 `;
 
-const ConfirmDisable = ({ onConfirmDisable, onKeepEnabled, accountId, disabling, component }) => {
+const ConfirmDisable = ({ onConfirmDisable, onKeepEnabled, accountId, disabling, component, twoFactorKind }) => {
     const [username, setUsername] = useState('');
+
+    const isTwoFactorPhone = component === 'twoFactor' && twoFactorKind === '2fa-phone';
 
     return (
         <Container onSubmit={(e) => {onConfirmDisable(); e.preventDefault();}}>
             <div><Translate id={`${component}.disable.title`}/></div>
-            <div><Translate id={`${component}.disable.desc`}/></div>
+            <div><Translate id={`${component}.disable.${isTwoFactorPhone ? 'phoneDesc' : 'desc'}`}/></div>
             <Translate>
                 {({ translate }) => (
                     <input

--- a/packages/frontend/src/components/profile/two_factor/TwoFactorAuth.js
+++ b/packages/frontend/src/components/profile/two_factor/TwoFactorAuth.js
@@ -105,6 +105,7 @@ const TwoFactorAuth = ({ twoFactor, history }) => {
                     accountId={account.accountId}
                     disabling={confirmDisabling}
                     component='twoFactor'
+                    twoFactorKind={twoFactor.kind}
                 />
             }
             {!twoFactor &&

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1411,6 +1411,7 @@
         "desc": "Protect your account by requiring confirmation via SMS or email when authorizing transactions.",
         "disable": {
             "desc": "Keep in mind that transactions won't have to be confirmed with 2FA once it's disabled.",
+            "phoneDesc": "The SMS option for two-factor authentication is being deprecated, and cannot be re-enbaled.",
             "disable": "Disable 2FA",
             "keep": "No, keep 2FA",
             "title": "Are you sure you want to disable 2FA?"


### PR DESCRIPTION
This PR removes the option for enabling 2FA with SMS and it's associated code. As we will most likely expand out these options again in future the concept of "options" still remains in code.

Removing SMS leaves us with a single option making the radio options a bit redundant but we've decided to push this out as is to stop new SMS 2FA accounts ASAP. An updated UI will be addressed in a follow up PR.

<img width="481" alt="image" src="https://user-images.githubusercontent.com/11974624/156063225-53277c39-ff0f-4ba8-a966-e3b2420f4cd8.png">
