### PR TITLE
fix: Invalid transfer url

### DIFF
--- a/packages/frontend/src/components/sign/SignTransferInvalid.js
+++ b/packages/frontend/src/components/sign/SignTransferInvalid.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Translate } from 'react-localize-redux';
+import styled from 'styled-components';
+
+import Container from '../common/styled/Container.css';
+
+const CustomContainer = styled(Container)`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    color: #25282a;
+    text-align: center;
+
+    .title {
+        margin-top: 23px;
+
+        h2 {
+            font-weight: 900;
+            font-size: 22px;
+            color: #24272a;
+        }
+    }
+
+    && .text {
+        color: #72727a;
+        margin-top: 24px;
+    }
+`;
+
+const SignTransferInvalid = () => (
+    <CustomContainer className="small-centered">
+        <div className="title">
+            <h2>
+                <Translate id="sign.invalidTransaction.title" />
+            </h2>
+        </div>
+        <div className="text">
+            <Translate id="sign.invalidTransaction.body" />
+        </div>
+    </CustomContainer>
+);
+
+export default SignTransferInvalid;

--- a/packages/frontend/src/routes/SignWrapper.js
+++ b/packages/frontend/src/routes/SignWrapper.js
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import SignTransferAccountNotFound from '../components/sign/SignTransferAccountNotFound';
+import SignTransferInvalid from '../components/sign/SignTransferInvalid';
 import SignTransferRetry from '../components/sign/SignTransferRetry';
 import SignTransactionDetailsWrapper from '../components/sign/v2/SignTransactionDetailsWrapper';
 import SignTransactionSummaryWrapper from '../components/sign/v2/SignTransactionSummaryWrapper';
@@ -121,6 +122,13 @@ export function SignWrapper() {
             dispatch(redirectTo('/'));
         }
     };
+
+    // potentially malicious callback URL found
+    if (!isValidCallbackUrl) {
+        return (
+            <SignTransferInvalid />
+        );
+    }
 
     if (currentDisplay === DISPLAY.INSUFFICIENT_NETWORK_FEE) {
         return (

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1149,7 +1149,7 @@
     },
     "sign": {
         "accountNotFound": {
-            "body": "<a href=\"${signCallbackUrl}\">${signCallbackUrl}</a> is requesting authorization from a NEAR account that cannot be found: <b>${signTransactionSignerId}</b><br/><br/>To approve any transactions, you’ll first need to import the account.",
+            "body": "${signCallbackUrl} is requesting authorization from a NEAR account that cannot be found: <b>${signTransactionSignerId}</b><br/><br/>To approve any transactions, you’ll first need to import the account.",
             "title": "Account Not Found"
         },
         "ActionWarrning": {

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -346,9 +346,9 @@
             },
             "verifyPassphrase": {
                 "desc": "Enter an existing passphrase below to secure your new account.",
+                "passPhrasePlaceholder": "bubble word sun join impact exist ramp skull title hollow symbol very",
                 "tite": "Verify Your Passphrase",
-                "yourPassphrase": "Your Passphrase",
-                "passPhrasePlaceholder": "bubble word sun join impact exist ramp skull title hollow symbol very"
+                "yourPassphrase": "Your Passphrase"
             }
         },
         "step": "Step ${step}/${total}",
@@ -1180,6 +1180,10 @@
         "hereAreSomeDetails": "Here are some details that will help you.",
         "insufficientFunds": "Insufficient Funds",
         "insufficientFundsDesc": "You do not have enough available NEAR to complete this transaction.",
+        "invalidTransaction": {
+            "body": "The request is invalid and cannot be signed.",
+            "title": "Invalid Transaction"
+        },
         "isRequesting": {
             "authorization": "is requesting authorization",
             "transferOf": "is requesting the transfer of"

--- a/packages/frontend/src/translations/pt.global.json
+++ b/packages/frontend/src/translations/pt.global.json
@@ -1106,7 +1106,7 @@
     },
     "sign": {
         "accountNotFound": {
-            "body": "<a href=\"${signCallbackUrl}\">${signCallbackUrl}</a> is requesting authorization from a NEAR account that cannot be found: <b>${signTransactionSignerId}</b><br/><br/>To approve any transactions, you’ll first need to import the account.",
+            "body": "${signCallbackUrl} is requesting authorization from a NEAR account that cannot be found: <b>${signTransactionSignerId}</b><br/><br/>To approve any transactions, you’ll first need to import the account.",
             "title": "Account Not Found"
         },
         "ActionWarrning": {

--- a/packages/frontend/src/translations/pt.global.json
+++ b/packages/frontend/src/translations/pt.global.json
@@ -1130,6 +1130,10 @@
         },
         "hereAreSomeDetails": "Aqui estão alguns detalhes que ajudarão você.",
         "insufficientFunds": "Fundos insuficientes",
+        "invalidTransaction": {
+            "body": "The request is invalid and cannot be signed.",
+            "title": "Invalid Transaction"
+        },
         "isRequesting": {
             "authorization": "está solicitando autorização",
             "transferOf": "está solicitando a transferência de"

--- a/packages/frontend/src/translations/ru.global.json
+++ b/packages/frontend/src/translations/ru.global.json
@@ -974,7 +974,7 @@
     },
     "sign": {
         "accountNotFound": {
-            "body": "<a href=\"${signCallbackUrl}\">${signCallbackUrl}</a> is requesting authorization from a NEAR account that cannot be found: <b>${signTransactionSignerId}</b><br/><br/>To approve any transactions, you’ll first need to import the account.",
+            "body": "${signCallbackUrl} is requesting authorization from a NEAR account that cannot be found: <b>${signTransactionSignerId}</b><br/><br/>To approve any transactions, you’ll first need to import the account.",
             "title": "Account Not Found"
         },
         "ActionWarrning": {

--- a/packages/frontend/src/translations/ru.global.json
+++ b/packages/frontend/src/translations/ru.global.json
@@ -997,6 +997,10 @@
         },
         "hereAreSomeDetails": "Вот некоторые детали, которые помогут вам.",
         "insufficientFunds": "Недостаточно средств",
+        "invalidTransaction": {
+            "body": "The request is invalid and cannot be signed.",
+            "title": "Invalid Transaction"
+        },
         "isRequesting": {
             "authorization": "запрашивает разрешение",
             "transferOf": "запрашивает перевод"

--- a/packages/frontend/src/translations/vi.global.json
+++ b/packages/frontend/src/translations/vi.global.json
@@ -1036,7 +1036,7 @@
     },
     "sign": {
         "accountNotFound": {
-            "body": "<a href=\"${signCallbackUrl}\">${signCallbackUrl}</a> is requesting authorization from a NEAR account that cannot be found: <b>${signTransactionSignerId}</b><br/><br/>To approve any transactions, you’ll first need to import the account.",
+            "body": "${signCallbackUrl} is requesting authorization from a NEAR account that cannot be found: <b>${signTransactionSignerId}</b><br/><br/>To approve any transactions, you’ll first need to import the account.",
             "title": "Account Not Found"
         },
         "ActionWarrning": {

--- a/packages/frontend/src/translations/vi.global.json
+++ b/packages/frontend/src/translations/vi.global.json
@@ -1060,6 +1060,10 @@
         },
         "hereAreSomeDetails": "Dưới đây là một số chi tiết sẽ hỗ trợ bạn.",
         "insufficientFunds": "Không đủ tiền",
+        "invalidTransaction": {
+            "body": "The request is invalid and cannot be signed.",
+            "title": "Invalid Transaction"
+        },
         "isRequesting": {
             "authorization": "đang yêu cầu ủy quyền",
             "transferOf": "đang yêu cầu chuyển"

--- a/packages/frontend/src/translations/zh-hans.global.json
+++ b/packages/frontend/src/translations/zh-hans.global.json
@@ -1158,6 +1158,10 @@
         "hereAreSomeDetails": "这里是能够帮助你的一些信息。",
         "insufficientFunds": "资产不足",
         "insufficientFundsDesc": "你没有足够的可用 NEAR 完成该操作。",
+        "invalidTransaction": {
+            "body": "The request is invalid and cannot be signed.",
+            "title": "Invalid Transaction"
+        },
         "isRequesting": {
             "authorization": "正在请求授权",
             "transferOf": "正在请求转账"

--- a/packages/frontend/src/translations/zh-hans.global.json
+++ b/packages/frontend/src/translations/zh-hans.global.json
@@ -1127,7 +1127,7 @@
     },
     "sign": {
         "accountNotFound": {
-            "body": "<a href=\"${signCallbackUrl}\">${signCallbackUrl}</a> is requesting authorization from a NEAR account that cannot be found: <b>${signTransactionSignerId}</b><br/><br/>To approve any transactions, you’ll first need to import the account.",
+            "body": "${signCallbackUrl} is requesting authorization from a NEAR account that cannot be found: <b>${signTransactionSignerId}</b><br/><br/>To approve any transactions, you’ll first need to import the account.",
             "title": "Account Not Found"
         },
         "ActionWarrning": {

--- a/packages/frontend/src/translations/zh-hant.global.json
+++ b/packages/frontend/src/translations/zh-hant.global.json
@@ -1158,6 +1158,10 @@
         "hereAreSomeDetails": "這裏是能夠幫助你的一些信息。",
         "insufficientFunds": "資產不足",
         "insufficientFundsDesc": "你沒有足夠的可用 NEAR 完成該操作。",
+        "invalidTransaction": {
+            "body": "The request is invalid and cannot be signed.",
+            "title": "Invalid Transaction"
+        },
         "isRequesting": {
             "authorization": "正在請求授權",
             "transferOf": "正在請求轉賬"

--- a/packages/frontend/src/translations/zh-hant.global.json
+++ b/packages/frontend/src/translations/zh-hant.global.json
@@ -1127,7 +1127,7 @@
     },
     "sign": {
         "accountNotFound": {
-            "body": "<a href=\"${signCallbackUrl}\">${signCallbackUrl}</a> is requesting authorization from a NEAR account that cannot be found: <b>${signTransactionSignerId}</b><br/><br/>To approve any transactions, you’ll first need to import the account.",
+            "body": "${signCallbackUrl} is requesting authorization from a NEAR account that cannot be found: <b>${signTransactionSignerId}</b><br/><br/>To approve any transactions, you’ll first need to import the account.",
             "title": "Account Not Found"
         },
         "ActionWarrning": {


### PR DESCRIPTION
This PR applies the fix from `stable` in which callback URLs used in signing transactions are considered invalid when they contain JavaScript code.