### PR TITLE
style(lint): nonexistent named imports error

### DIFF
--- a/packages/frontend/.eslintrc.js
+++ b/packages/frontend/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
         'no-extra-boolean-cast':'off',
         'no-extra-semi':'off',
         'no-irregular-whitespace':'off',
+        'import/named': ['error', 'always'],
         'import/order': [
             'error',
             {
@@ -52,6 +53,9 @@ module.exports = {
             'selector': `CallExpression[callee.name='useSelector'] *[type=/FunctionExpression$/][params.0.type='ObjectPattern']`,
             'message': 'Please use a selector for any state accesses within useSelector'
         }]
+    },
+    settings: {
+        'import/ignore': ['src/config/*'],
     },
     overrides: [
         {

--- a/packages/frontend/src/redux/reducers/account/index.js
+++ b/packages/frontend/src/redux/reducers/account/index.js
@@ -2,12 +2,10 @@ import reduceReducers from 'reduce-reducers';
 import { handleActions } from 'redux-actions';
 
 import {
-    requestCode,
     getAccessKeys,
     clearCode,
     promptTwoFactor,
     refreshUrl,
-    resetAccounts,
     checkCanEnableTwoFactor,
     get2faMethod,
     getLedgerKey,
@@ -38,12 +36,6 @@ const initialState = {
 };
 
 const recoverCodeReducer = handleActions({
-    [requestCode]: (state, { error, ready }) => {
-        if (ready && !error) {
-            return { ...state, sentMessage: true };
-        }
-        return state;
-    },
     [clearCode]: (state, { error, ready }) => {
         return { ...state, sentMessage: false };
     }
@@ -126,10 +118,6 @@ const account = handleActions({
             loader: false
         };
     },
-    [resetAccounts]: (state) => ({
-        ...state,
-        loginResetAccounts: true
-    }),
     [staking.updateAccount]: (state, { ready, error, payload }) =>
         (!ready || error)
             ? state

--- a/packages/frontend/src/routes/LoginWrapper.js
+++ b/packages/frontend/src/routes/LoginWrapper.js
@@ -6,13 +6,12 @@ import { useSelector } from 'react-redux';
 import ConfirmLoginWrapper from '../components/login/v2/ConfirmLoginWrapper';
 import InvalidContractId from '../components/login/v2/InvalidContractId';
 import SelectAccountLoginWrapper from '../components/login/v2/SelectAccountLoginWrapper';
-import { EXPLORER_URL } from '../config';
+import { EXPLORER_URL, LOCKUP_ACCOUNT_ID_SUFFIX } from '../config';
 import { Mixpanel } from '../mixpanel/index';
 import {
     selectAccountLocalStorageAccountId
 } from '../redux/slices/account';
 import { isUrlNotJavascriptProtocol } from '../utils/helper-api';
-import { LOCKUP_ACCOUNT_ID_SUFFIX } from '../utils/wallet';
 
 export const LOGIN_ACCESS_TYPES = {
     FULL_ACCESS: 'fullAccess',


### PR DESCRIPTION
This PR adds a new eslint dependency and rules to verify the existence of named imports, ensuring that we no longer reference named imports not exported from the target module.