### PR TITLE
feat: Add new 'import w/ link' UI

### DIFF
--- a/features/features.d.ts
+++ b/features/features.d.ts
@@ -4,4 +4,5 @@
 export type Features = {
     CREATE_IMPLICIT_ACCOUNT: boolean;
 	EXAMPLE_FLAG: boolean;
+	IMPORT_ACCOUNT_WITH_LINK_V2: boolean;
 };

--- a/features/flags.json
+++ b/features/flags.json
@@ -56,5 +56,34 @@
       "lastEditedBy": "Andy Haynes",
       "lastEditedAt": "2022-01-31T21:13:09.948Z"
     }
+  },
+  "IMPORT_ACCOUNT_WITH_LINK_V2": {
+    "createdBy": "Patrick Tajima",
+    "createdAt": "2022-03-12T01:30:32.577Z",
+    "development": {
+      "enabled": true,
+      "lastEditedBy": "Patrick Tajima",
+      "lastEditedAt": "2022-03-12T01:30:32.577Z"
+    },
+    "testnet": {
+      "enabled": false,
+      "lastEditedBy": "Patrick Tajima",
+      "lastEditedAt": "2022-03-12T01:30:32.577Z"
+    },
+    "mainnet": {
+      "enabled": false,
+      "lastEditedBy": "Patrick Tajima",
+      "lastEditedAt": "2022-03-12T01:30:32.577Z"
+    },
+    "mainnet_STAGING": {
+      "enabled": false,
+      "lastEditedBy": "Patrick Tajima",
+      "lastEditedAt": "2022-03-12T01:30:32.577Z"
+    },
+    "testnet_STAGING": {
+      "enabled": false,
+      "lastEditedBy": "Patrick Tajima",
+      "lastEditedAt": "2022-03-12T01:30:32.577Z"
+    }
   }
 }

--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -20,6 +20,7 @@ import { handleClearAlert } from '../redux/reducers/status';
 import { selectAccountSlice } from '../redux/slices/account';
 import { actions as tokenFiatValueActions } from '../redux/slices/tokenFiatValues';
 import { CreateImplicitAccountWrapper } from '../routes/CreateImplicitAccountWrapper';
+import { ImportAccountWithLinkWrapper } from '../routes/ImportAccountWithLinkWrapper';
 import { LoginWrapper } from '../routes/LoginWrapper';
 import { SetupLedgerNewAccountWrapper } from '../routes/SetupLedgerNewAccountWrapper';
 import { SetupPassphraseNewAccountWrapper } from '../routes/SetupPassphraseNewAccountWrapper';
@@ -471,7 +472,7 @@ class Routing extends Component {
                             <Route
                                 exact
                                 path='/recover-with-link/:accountId/:seedPhrase'
-                                component={RecoverWithLinkWithRouter}
+                                component={ImportAccountWithLinkWrapper}
                             />
                             <Route
                                 exact

--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { Redirect, Switch } from 'react-router-dom';
 import styled, { ThemeProvider } from 'styled-components';
 
-import { CREATE_IMPLICIT_ACCOUNT } from '../../../../features';
+import { CREATE_IMPLICIT_ACCOUNT, IMPORT_ACCOUNT_WITH_LINK_V2 } from '../../../../features';
 import TwoFactorVerifyModal from '../components/accounts/two_factor/TwoFactorVerifyModal';
 import { IS_MAINNET, PUBLIC_URL, SHOW_PRERELEASE_WARNING, DISABLE_CREATE_ACCOUNT } from '../config';
 import ExampleFlag from '../ExampleFlag';
@@ -59,6 +59,7 @@ import { SignInLedger } from './accounts/ledger/SignInLedger';
 import { LinkdropLandingWithRouter } from './accounts/LinkdropLanding';
 import { RecoverAccountSeedPhraseWithRouter } from './accounts/RecoverAccountSeedPhrase';
 import { RecoverAccountWrapper } from './accounts/RecoverAccountWrapper';
+import { RecoverWithLinkWithRouter } from './accounts/RecoverWithLink';
 import { SetupRecoveryMethodWithRouter } from './accounts/recovery_setup/SetupRecoveryMethod';
 import { SetupImplicitWithRouter } from './accounts/SetupImplicit';
 import { SetupSeedPhraseWithRouter } from './accounts/SetupSeedPhrase';
@@ -471,7 +472,7 @@ class Routing extends Component {
                             <Route
                                 exact
                                 path='/recover-with-link/:accountId/:seedPhrase'
-                                component={ImportAccountWithLinkWrapper}
+                                component={IMPORT_ACCOUNT_WITH_LINK_V2 ? ImportAccountWithLinkWrapper : RecoverWithLinkWithRouter}
                             />
                             <Route
                                 exact

--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -59,7 +59,6 @@ import { SignInLedger } from './accounts/ledger/SignInLedger';
 import { LinkdropLandingWithRouter } from './accounts/LinkdropLanding';
 import { RecoverAccountSeedPhraseWithRouter } from './accounts/RecoverAccountSeedPhrase';
 import { RecoverAccountWrapper } from './accounts/RecoverAccountWrapper';
-import { RecoverWithLinkWithRouter } from './accounts/RecoverWithLink';
 import { SetupRecoveryMethodWithRouter } from './accounts/recovery_setup/SetupRecoveryMethod';
 import { SetupImplicitWithRouter } from './accounts/SetupImplicit';
 import { SetupSeedPhraseWithRouter } from './accounts/SetupSeedPhrase';

--- a/packages/frontend/src/components/accounts/import/ImportAccountWithLink.js
+++ b/packages/frontend/src/components/accounts/import/ImportAccountWithLink.js
@@ -1,0 +1,169 @@
+import React from 'react';
+import { Translate } from 'react-localize-redux';
+import styled from 'styled-components';
+
+import ClickToCopy from '../../common/ClickToCopy';
+import FormButton from '../../common/FormButton';
+import Container from '../../common/styled/Container.css';
+import UserIcon from '../../svg/UserIcon';
+
+const StyledContainer = styled(Container)`
+    &&& {
+        text-align: center;
+
+        h2 {
+            button {
+                font-weight: normal;
+            }
+        }
+        
+        .copy {
+            display: inline;
+
+            button {
+                cursor: copy;
+            }
+        }
+
+        .counter {
+            font-size: 12px;
+            color: #A2A2A8;
+            text-align: left;
+        }
+
+        .accounts-wrapper {
+            margin-top: 20px;
+        }
+    
+        .accounts {
+            margin: 0 -40px -20px -40px;
+            border-top: 1px solid #F0F0F1;
+
+            @media (max-width: 767px) {
+                margin: 0 -14px -20px -14px;
+            }
+        }
+    
+        .account {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            color: #24272A;
+            border-bottom: 1px solid #F0F0F1;
+            padding: 20px 40px;
+
+            @media (max-width: 767px) {
+                padding: 20px 14px;
+            }
+
+            :last-child {
+                border-bottom: 0;
+                margin-bottom: -40px;
+            }
+
+            svg {
+                margin-right: 10px;
+            }
+    
+            button {
+                margin: 0;
+                padding: 8px 24px;
+                height: auto;
+                white-space: nowrap;
+                width: auto;
+            }
+    
+            > div {
+                display: flex;
+                align-items: center;
+                overflow: hidden;
+                width: 100%;
+
+                 > div {
+                    text-overflow: ellipsis;
+                    overflow: hidden;
+                    max-width: 70%;
+                    white-space: nowrap;
+                 }
+            }
+        }
+    }
+`;
+
+export default ({
+    accountsBySeedPhrase,
+    onClickAccount,
+    importingAccount
+}) => {
+
+    const numberOfAccountsFound = accountsBySeedPhrase.length;
+
+    const getAccountsStatus = () => {
+        if (numberOfAccountsFound === 1 && accountsBySeedPhrase[0].imported === true) {
+            return <h2><Translate id='importAccountWithLink.alreadyImported' /></h2>;
+        }
+
+        if (numberOfAccountsFound !== 1) {
+            return <h2><Translate id='importAccountWithLink.foundAccounts' data={{ count: numberOfAccountsFound }} /></h2>;
+        }
+
+        return <h2><Translate id='importAccountWithLink.foundAccount' /></h2>;
+    };
+
+    return (
+        <StyledContainer className='small-centered border'>
+            <h3><Translate id='importAccountWithLink.importAccount' /></h3>
+
+            {getAccountsStatus()}
+
+            <h2>
+                <Translate id='importAccountWithLink.preferedBrowser' />&nbsp;
+                <ClickToCopy copy={window.location.href} className='copy'>
+                    <FormButton className='link underline'>
+                        <Translate id='importAccountWithLink.copyUrl' />
+                    </FormButton>
+                </ClickToCopy>&nbsp;
+                <Translate id='importAccountWithLink.continue' />
+            </h2>
+            <div className='counter'>
+                {numberOfAccountsFound !== 1
+                    ? <Translate id='importAccountWithLink.accountsFound' data={{ count: numberOfAccountsFound }} />
+                    : <Translate id='importAccountWithLink.accountFound' />
+                }
+            </div>
+            {
+                numberOfAccountsFound > 0 && (
+                    <div className='accounts-wrapper'>
+                        <div className='accounts'>
+                            {accountsBySeedPhrase.map((account) => (
+                                <div className='account' key={account.accountId}>
+                                    <div>
+                                        <UserIcon background={true} />
+                                        <div>{account.accountId}</div>
+                                    </div>
+                                    <FormButton
+                                        color={accountsBySeedPhrase.some((account) => account.imported) && !account.imported ? 'gray-blue' : 'blue'}
+                                        disabled={!!importingAccount}
+                                        sending={importingAccount === account.accountId}
+                                        sendingString='importing'
+                                        onClick={() => {
+                                            onClickAccount({
+                                                accountId: account.accountId,
+                                                action: account.imported ? 'select' : 'import'
+                                            });
+                                        }}
+                                    >
+                                        {account.imported
+                                            ? <Translate id='importAccountWithLink.goToAccount' />
+                                            : <Translate id='importAccountWithLink.import' />
+                                        }
+                                    </FormButton>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                )
+            }
+        </StyledContainer>
+    );
+};

--- a/packages/frontend/src/components/accounts/import/ImportAccountWithLink.js
+++ b/packages/frontend/src/components/accounts/import/ImportAccountWithLink.js
@@ -99,7 +99,7 @@ export default ({
     const numberOfAccountsFound = accountsBySeedPhrase.length;
 
     const getAccountsStatus = () => {
-        if (numberOfAccountsFound === 1 && accountsBySeedPhrase[0].imported === true) {
+        if (numberOfAccountsFound === 1 && accountsBySeedPhrase[0].imported) {
             return <h2><Translate id='importAccountWithLink.alreadyImported' /></h2>;
         }
 
@@ -119,7 +119,7 @@ export default ({
             <h2>
                 <Translate id='importAccountWithLink.preferedBrowser' />&nbsp;
                 <ClickToCopy copy={window.location.href} className='copy'>
-                    <FormButton className='link underline'>
+                    <FormButton className='link underline' trackingId='IE with link Click copy url button'>
                         <Translate id='importAccountWithLink.copyUrl' />
                     </FormButton>
                 </ClickToCopy>&nbsp;

--- a/packages/frontend/src/routes/ImportAccountWithLinkWrapper.js
+++ b/packages/frontend/src/routes/ImportAccountWithLinkWrapper.js
@@ -22,7 +22,7 @@ export function ImportAccountWithLinkWrapper() {
     const activeAccountId = useSelector(selectAccountId);
     const availableAccounts = useSelector(selectAvailableAccounts);
     const [accountIdsBySeedPhrase, setAccountIdsBySeedPhrase] = useState([]);
-    const [importingAccount, setImportingAccount] = useState(false);
+    const [importingAccount, setImportingAccount] = useState(null);
 
     useEffect(() => {
         const handleGetAccountsBySeedPhrase = async () => {
@@ -32,14 +32,10 @@ export function ImportAccountWithLinkWrapper() {
         handleGetAccountsBySeedPhrase();
     }, []);
 
-    let accountsBySeedPhrase = [];
-
-    for (let accountId of accountIdsBySeedPhrase) {
-        let account = {};
-        account.accountId = accountId;
-        account.imported = availableAccounts.includes(accountId);
-        accountsBySeedPhrase.push(account);
-    }
+    const accountsBySeedPhrase = accountIdsBySeedPhrase.map((accountId) => ({
+        accountId,
+        imported: availableAccounts.includes(accountId),
+    }));
 
     return (
         <ImportAccountWithLink
@@ -73,7 +69,7 @@ export function ImportAccountWithLinkWrapper() {
                     if (accountId !== activeAccountId) {
                         await dispatch(switchAccount({ accountId }));
                     }
-                    await dispatch(redirectTo('/'));
+                    dispatch(redirectTo('/'));
                 }
             }}
         />

--- a/packages/frontend/src/routes/ImportAccountWithLinkWrapper.js
+++ b/packages/frontend/src/routes/ImportAccountWithLinkWrapper.js
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useParams } from 'react-router-dom';
+
+import ImportAccountWithLink from '../components/accounts/import/ImportAccountWithLink';
+import { Mixpanel } from '../mixpanel/index';
+import {
+    switchAccount,
+    redirectTo,
+    recoverAccountSeedPhrase,
+    refreshAccount,
+    clearAccountState
+} from '../redux/actions/account';
+import { showCustomAlert } from '../redux/actions/status';
+import { selectAccountId } from '../redux/slices/account';
+import { selectAvailableAccounts } from '../redux/slices/availableAccounts';
+import { getAccountIdsBySeedPhrase } from '../utils/helper-api';
+
+export function ImportAccountWithLinkWrapper() {
+    const dispatch = useDispatch();
+    const { seedPhrase } = useParams();
+    const activeAccountId = useSelector(selectAccountId);
+    const availableAccounts = useSelector(selectAvailableAccounts);
+    const [accountIdsBySeedPhrase, setAccountIdsBySeedPhrase] = useState([]);
+    const [importingAccount, setImportingAccount] = useState(false);
+
+    useEffect(() => {
+        const handleGetAccountsBySeedPhrase = async () => {
+            const accountIdsBySeedPhrase = await getAccountIdsBySeedPhrase(seedPhrase);
+            setAccountIdsBySeedPhrase(accountIdsBySeedPhrase);
+        };
+        handleGetAccountsBySeedPhrase();
+    }, []);
+
+    let accountsBySeedPhrase = [];
+
+    for (let accountId of accountIdsBySeedPhrase) {
+        let account = {};
+        account.accountId = accountId;
+        account.imported = availableAccounts.includes(accountId);
+        accountsBySeedPhrase.push(account);
+    }
+
+    return (
+        <ImportAccountWithLink
+            accountsBySeedPhrase={accountsBySeedPhrase}
+            importingAccount={importingAccount}
+            onClickAccount={async ({ accountId, action }) => {
+                if (action === 'import') {
+                    await Mixpanel.withTracking('IE Recover with link',
+                        async () => {
+                            const shouldCreateFullAccessKey = false;
+                            setImportingAccount(accountId);
+                            await dispatch(recoverAccountSeedPhrase(seedPhrase, accountId, shouldCreateFullAccessKey));
+                            dispatch(refreshAccount());
+                            dispatch(redirectTo('/'));
+                            dispatch(clearAccountState());
+                        },
+                        (e) => {
+                            dispatch(showCustomAlert({
+                                success: false,
+                                messageCodeHeader: 'error',
+                                messageCode: 'walletErrorCodes.recoverAccountLink.error',
+                                errorMessage: e.message
+                            }));
+                            throw e;
+                        },
+                        () => {
+                            setImportingAccount(false);
+                        }
+                    );
+                } else if (action === 'select') {
+                    if (accountId !== activeAccountId) {
+                        await dispatch(switchAccount({ accountId }));
+                    }
+                    await dispatch(redirectTo('/'));
+                }
+            }}
+        />
+    );
+};

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -844,6 +844,20 @@
         "snackbarCopySuccess": "Recover URL copied",
         "title": "Restore Account"
     },
+    "importAccountWithLink": {
+        "accountFound": "1 Account Found",
+        "accountsFound": "${count} Accounts Found",
+        "accountImported": "Account Imported",
+        "alreadyImported": "The account secured by this link has been imported.",
+        "copyUrl": "copy the URL",
+        "continue": "and continue this process in your browser of choice.",
+        "foundAccount": "We found <b>1 account</b> secured by this link.",
+        "foundAccounts": "We found <b>${count} accounts</b> secured by this link.",
+        "import": "Import",
+        "importAccount": "Import Your Account",
+        "preferedBrowser": "If this isn't your preferred browser,",
+        "goToAccount": "Go to Account"
+    },
     "recoveryMgmt": {
         "disableInputPlaceholder": "Enter your account ID to confirm",
         "disableNo": "No, keep",
@@ -975,6 +989,7 @@
         "switchAccounthNotAllowed": "This app doesn't allow account changes"
     },
     "sending": "Sending",
+    "importing": "Importing",
     "sendMoney": {
         "account": {
             "title": "Send to"
@@ -1554,6 +1569,9 @@
         },
         "recoverAccountSeedPhrase": {
             "errorInvalidSeedPhrase": "No accounts were found for this passphrase."
+        },
+        "recoverAccountLink": {
+            "error": "Import of your account failed. Please try again or contact support for assistance."
         },
         "recoveryMethods": {
             "lastMethod": "Cannot delete your last recovery method. Unless you have Ledger enabled, you need to keep at least one recovery method active to ensure recoverability of your account.",

--- a/packages/frontend/src/translations/pt.global.json
+++ b/packages/frontend/src/translations/pt.global.json
@@ -795,6 +795,20 @@
         "snackbarCopySuccess": "URL de Recuperação copiada",
         "title": "Restaurar conta"
     },
+    "importAccountWithLink": {
+        "accountFound": "1 Account Found",
+        "accountsFound": "${count} Accounts Found",
+        "accountImported": "Account Imported",
+        "alreadyImported": "The account secured by this link has been imported.",
+        "copyUrl": "copy the URL",
+        "continue": "and continue this process in your browser of choice.",
+        "foundAccount": "We found <b>1 account</b> secured by this link.",
+        "foundAccounts": "We found <b>${count} accounts</b> secured by this link.",
+        "import": "Import",
+        "importAccount": "Import Your Account",
+        "preferedBrowser": "If this isn't your preferred browser,",
+        "goToAccount": "Go to Account"
+    },
     "recoveryMgmt": {
         "disableInputPlaceholder": "Insira o ID da sua conta para confirmar",
         "disableNo": "Não, manter",

--- a/packages/frontend/src/translations/ru.global.json
+++ b/packages/frontend/src/translations/ru.global.json
@@ -676,6 +676,20 @@
         "snackbarCopySuccess": "Ссылка для восстанавления скопирована",
         "title": "Восстановление Учетной Записи"
     },
+    "importAccountWithLink": {
+        "accountFound": "1 Account Found",
+        "accountsFound": "${count} Accounts Found",
+        "accountImported": "Account Imported",
+        "alreadyImported": "The account secured by this link has been imported.",
+        "copyUrl": "copy the URL",
+        "continue": "and continue this process in your browser of choice.",
+        "foundAccount": "We found <b>1 account</b> secured by this link.",
+        "foundAccounts": "We found <b>${count} accounts</b> secured by this link.",
+        "import": "Import",
+        "importAccount": "Import Your Account",
+        "preferedBrowser": "If this isn't your preferred browser,",
+        "goToAccount": "Go to Account"
+    },
     "recoveryMgmt": {
         "disableInputPlaceholder": "Введите свое имя пользователя для подтверждения",
         "disableNo": "Нет, продолжить",

--- a/packages/frontend/src/translations/tr.global.json
+++ b/packages/frontend/src/translations/tr.global.json
@@ -783,6 +783,20 @@
         "snackbarCopySuccess": "Kopyalanan URL'yi kurtar",
         "title": "Hesabı Geri Yükle"
     },
+    "importAccountWithLink": {
+        "accountFound": "1 Account Found",
+        "accountsFound": "${count} Accounts Found",
+        "accountImported": "Account Imported",
+        "alreadyImported": "The account secured by this link has been imported.",
+        "copyUrl": "copy the URL",
+        "continue": "and continue this process in your browser of choice.",
+        "foundAccount": "We found <b>1 account</b> secured by this link.",
+        "foundAccounts": "We found <b>${count} accounts</b> secured by this link.",
+        "import": "Import",
+        "importAccount": "Import Your Account",
+        "preferedBrowser": "If this isn't your preferred browser,",
+        "goToAccount": "Go to Account"
+    },
     "recoveryMgmt": {
         "disableInputPlaceholder": "Onaylamak için hesap kimliğinizi girin",
         "disableNo": "Hayır, Devam",

--- a/packages/frontend/src/translations/vi.global.json
+++ b/packages/frontend/src/translations/vi.global.json
@@ -739,6 +739,20 @@
         "snackbarCopySuccess": "Đã sao chép URL khôi phục",
         "title": "Khôi phục tài khoản"
     },
+    "importAccountWithLink": {
+        "accountFound": "1 Account Found",
+        "accountsFound": "${count} Accounts Found",
+        "accountImported": "Account Imported",
+        "alreadyImported": "The account secured by this link has been imported.",
+        "copyUrl": "copy the URL",
+        "continue": "and continue this process in your browser of choice.",
+        "foundAccount": "We found <b>1 account</b> secured by this link.",
+        "foundAccounts": "We found <b>${count} accounts</b> secured by this link.",
+        "import": "Import",
+        "importAccount": "Import Your Account",
+        "preferedBrowser": "If this isn't your preferred browser,",
+        "goToAccount": "Go to Account"
+    },
     "recoveryMgmt": {
         "disableInputPlaceholder": "Nhập ID tài khoản của bạn để xác nhận",
         "disableNo": "Không, giữ lại",

--- a/packages/frontend/src/translations/zh-hans.global.json
+++ b/packages/frontend/src/translations/zh-hans.global.json
@@ -814,6 +814,20 @@
         "snackbarCopySuccess": "恢复链接已复制",
         "title": "恢复账户"
     },
+    "importAccountWithLink": {
+        "accountFound": "1 Account Found",
+        "accountsFound": "${count} Accounts Found",
+        "accountImported": "Account Imported",
+        "alreadyImported": "The account secured by this link has been imported.",
+        "copyUrl": "copy the URL",
+        "continue": "and continue this process in your browser of choice.",
+        "foundAccount": "We found <b>1 account</b> secured by this link.",
+        "foundAccounts": "We found <b>${count} accounts</b> secured by this link.",
+        "import": "Import",
+        "importAccount": "Import Your Account",
+        "preferedBrowser": "If this isn't your preferred browser,",
+        "goToAccount": "Go to Account"
+    },
     "recoveryMgmt": {
         "disableInputPlaceholder": "请输入用户名确认",
         "disableNo": "不，保留。",

--- a/packages/frontend/src/translations/zh-hant.global.json
+++ b/packages/frontend/src/translations/zh-hant.global.json
@@ -814,6 +814,20 @@
         "snackbarCopySuccess": "恢復鏈接已複製",
         "title": "恢復賬戶"
     },
+    "importAccountWithLink": {
+        "accountFound": "1 Account Found",
+        "accountsFound": "${count} Accounts Found",
+        "accountImported": "Account Imported",
+        "alreadyImported": "The account secured by this link has been imported.",
+        "copyUrl": "copy the URL",
+        "continue": "and continue this process in your browser of choice.",
+        "foundAccount": "We found <b>1 account</b> secured by this link.",
+        "foundAccounts": "We found <b>${count} accounts</b> secured by this link.",
+        "import": "Import",
+        "importAccount": "Import Your Account",
+        "preferedBrowser": "If this isn't your preferred browser,",
+        "goToAccount": "Go to Account"
+    },
     "recoveryMgmt": {
         "disableInputPlaceholder": "請輸入用戶名確認",
         "disableNo": "不，保留。",

--- a/packages/frontend/src/utils/helper-api.js
+++ b/packages/frontend/src/utils/helper-api.js
@@ -15,8 +15,7 @@ export async function getAccountIdsBySeedPhrase(seedPhrase) {
     const { secretKey } = parseSeedPhrase(seedPhrase);
     const keyPair = nearApiJs.KeyPair.fromString(secretKey);
     const publicKey = keyPair.publicKey.toString();
-    const accountIdsByPublickKey = await getAccountIds(publicKey);
-    return accountIdsByPublickKey;
+    return getAccountIds(publicKey);
 }
 
 export function isUrlNotJavascriptProtocol(url) {

--- a/packages/frontend/src/utils/helper-api.js
+++ b/packages/frontend/src/utils/helper-api.js
@@ -1,4 +1,7 @@
 
+import * as nearApiJs from 'near-api-js';
+import { parseSeedPhrase } from 'near-seed-phrase';
+
 import { ACCOUNT_HELPER_URL } from '../config';
 
 export let controller;
@@ -6,6 +9,14 @@ export let controller;
 export async function getAccountIds(publicKey) {
     controller = new AbortController();
     return await fetch(`${ACCOUNT_HELPER_URL}/publicKey/${publicKey}/accounts`, { signal: controller.signal }).then((res) => res.json());
+}
+
+export async function getAccountIdsBySeedPhrase(seedPhrase) {
+    const { secretKey } = parseSeedPhrase(seedPhrase);
+    const keyPair = nearApiJs.KeyPair.fromString(secretKey);
+    const publicKey = keyPair.publicKey.toString();
+    const accountIdsByPublickKey = await getAccountIds(publicKey);
+    return accountIdsByPublickKey;
 }
 
 export function isUrlNotJavascriptProtocol(url) {

--- a/packages/frontend/src/utils/wallet.js
+++ b/packages/frontend/src/utils/wallet.js
@@ -5,6 +5,7 @@ import { KeyType } from 'near-api-js/lib/utils/key_pair';
 import { generateSeedPhrase, parseSeedPhrase } from 'near-seed-phrase';
 
 import { store } from '..';
+import { IMPORT_ACCOUNT_WITH_LINK_V2 } from '../../../../features';
 import * as Config from '../config';
 import {
     makeAccountActive,
@@ -848,10 +849,13 @@ class Wallet {
             accountIds = [accountId];
         }
 
-        if (!accountId) {
-            // Import implicit account only if no accountId is specified
+        if (!IMPORT_ACCOUNT_WITH_LINK_V2) {
             accountIds.push(implicitAccountId);
         }
+
+        // TODO: getAccountIds returns all accounts including any implicit account.
+        // Once 'IMPORT_ACCOUNT_WITH_LINK_V2' feature is on shipped:
+        // Remove automatically adding implicitAccountId into array and then removing the duplicates.
 
         // remove duplicate and non-existing accounts
         const accountsSet = new Set(accountIds);

--- a/packages/frontend/src/utils/wallet.js
+++ b/packages/frontend/src/utils/wallet.js
@@ -848,7 +848,10 @@ class Wallet {
             accountIds = [accountId];
         }
 
-        accountIds.push(implicitAccountId);
+        if (!accountId) {
+            // Import implicit account only if no accountId is specified
+            accountIds.push(implicitAccountId);
+        }
 
         // remove duplicate and non-existing accounts
         const accountsSet = new Set(accountIds);

--- a/packages/frontend/src/utils/wallet.js
+++ b/packages/frontend/src/utils/wallet.js
@@ -854,7 +854,7 @@ class Wallet {
         }
 
         // TODO: getAccountIds returns all accounts including any implicit account.
-        // Once 'IMPORT_ACCOUNT_WITH_LINK_V2' feature is on shipped:
+        // Once 'IMPORT_ACCOUNT_WITH_LINK_V2' feature is shipped:
         // Remove automatically adding implicitAccountId into array and then removing the duplicates.
 
         // remove duplicate and non-existing accounts


### PR DESCRIPTION
https://nearinc.atlassian.net/browse/WAL-168

-------

~~Testnet account with a named and implicit account: [testing-pr-2521.testnet](https://near-wallet-pr-2521.onrender.com/recover-with-link/testing-pr-2521.testnet/mobile%20element%20anxiety%20giraffe%20beef%20brand%20pistol%20steak%20cook%20dad%20spatial%20found)~~

~~https://near-wallet-pr-2521.onrender.com/recover-with-link/testing-pr-2521.testnet/mobile%20element%20anxiety%20giraffe%20beef%20brand%20pistol%20steak%20cook%20dad%20spatial%20found~~

~~Testnet account with only a named account: [testing-pr-2521-1.testnet](https://near-wallet-pr-2521.onrender.com/recover-with-link/testing-pr-2521-1.testnet/loyal%20inhale%20milk%20neither%20eyebrow%20plate%20dinner%20super%20project%20hurt%20adjust%20game)~~

~~https://near-wallet-pr-2521.onrender.com/recover-with-link/testing-pr-2521-1.testnet/loyal%20inhale%20milk%20neither%20eyebrow%20plate%20dinner%20super%20project%20hurt%20adjust%20game~~

Above testing links are only valid when `IMPORT_ACCOUNT_WITH_LINK_V2` is enabled in a `testnet` environment. Currently only enabled in a `development` environment.

<img width="681" alt="Screen Shot 2022-03-10 at 5 09 42 PM" src="https://user-images.githubusercontent.com/24921205/157782377-ced6dfea-3048-492c-abe8-f6e263e2e630.png">