### PR TITLE
WAL-177 Render pending 2FA actions in confirmation modal

### DIFF
--- a/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyInput.js
+++ b/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyInput.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 const Container = styled.div`
     max-width: 350px;
     width: 100%;
-    margin-bottom: 40px;
+    margin: 40px 0;
 
     .color-black {
         font-weight: 500;

--- a/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyInput.js
+++ b/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyInput.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 const Container = styled.div`
     max-width: 350px;
     width: 100%;
-    margin: 40px 0;
+    margin-bottom: 40px;
 
     .color-black {
         font-weight: 500;

--- a/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -22,6 +22,39 @@ const Form = styled.form`
     width: 100%;
 `;
 
+const StyledBannerContainer = styled.div`
+    &&& {
+        div:first-child {
+            margin: 0px;
+            width: 100%;
+            @media (max-width: 450px) {
+                 border-radius: 4px;
+            }
+        }
+
+        pre {
+            margin: 0px;
+        }
+    }
+`;
+
+const ActionDetailsBanner = ({ multisigRequest }) => {
+    const isAddingFullAccessKey = multisigRequest.actions.some(({ enum: type, permission }) => type === 'addKey' && !permission);
+
+    return  (
+        <StyledBannerContainer>
+            <AlertBanner theme={isAddingFullAccessKey ? 'warning' : 'light-blue'}>
+                {getTranslationsFromMultisigRequest(multisigRequest).map(({ id, data }, index, arr) => (
+                    <React.Fragment key={JSON.stringify(data)}>
+                        <Translate id={id} data={data} />
+                        {index !== arr.length - 1 && <br />}
+                    </React.Fragment>
+                ))}
+            </AlertBanner>
+        </StyledBannerContainer>
+    );
+};
+
 const TwoFactorVerifyModal = ({ open, onClose }) => {
 
     const [method, setMethod] = useState();
@@ -89,15 +122,7 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
             <h2 className='title'><Translate id='twoFactor.verify.title'/></h2>
             <p className='font-bw'><Translate id='twoFactor.verify.desc'/></p>
             <p className='color-black font-bw' style={{ marginTop: '-10px', fontWeight: '500', height: '19px'}}>{method && method.detail}</p>
-            {multisigRequest && (
-                <AlertBanner theme='alert'>
-                        <>
-                            <Translate id={id} data={data} />
-                            {index !== arr.length - 1 && <br />}
-                        </>
-                    ))}
-                </AlertBanner>
-            )}
+            {multisigRequest && <ActionDetailsBanner multisigRequest={multisigRequest} />}
             <Form onSubmit={(e) => {handleVerifyCode(); e.preventDefault();}}>
                 <TwoFactorVerifyInput
                     code={code}

--- a/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -91,10 +91,9 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
             <p className='color-black font-bw' style={{ marginTop: '-10px', fontWeight: '500', height: '19px'}}>{method && method.detail}</p>
             {multisigRequest && (
                 <AlertBanner theme='alert'>
-                    {getTranslationsFromMultisigRequest(multisigRequest).map(({ id, data }) => (
                         <>
                             <Translate id={id} data={data} />
-                            <br />
+                            {index !== arr.length - 1 && <br />}
                         </>
                     ))}
                 </AlertBanner>

--- a/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -180,7 +180,7 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
             <p className='font-bw'><Translate id='twoFactor.verify.desc'/></p>
             <p className='color-black font-bw' style={{ marginTop: '-10px', fontWeight: '500', height: '19px'}}>{method && method.detail}</p>
             {multisigRequest && (
-                <AlertBanner theme="alert">
+                <AlertBanner theme='alert'>
                     {getTranslationsFromMultisigRequest(multisigRequest).map(({ id, data }) => (
                         <>
                             <Translate id={id} data={data} />

--- a/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -39,7 +39,7 @@ const StyledBannerContainer = styled.div`
 `;
 
 const ActionDetailsBanner = ({ multisigRequest }) => {
-    const isAddingFullAccessKey = multisigRequest.actions.some(({ enum: type, permission }) => type === 'addKey' && !permission);
+    const isAddingFullAccessKey = multisigRequest.actions.some(({ enum: type, [type]: action }) => type === 'addKey' && !action.accessKey.permission);
 
     return  (
         <StyledBannerContainer>

--- a/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -27,6 +27,7 @@ const StyledBannerContainer = styled.div`
         div:first-child {
             margin: 0px;
             width: 100%;
+            word-break: break-word;
             @media (max-width: 450px) {
                  border-radius: 4px;
             }

--- a/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -1,5 +1,3 @@
-import BN from 'bn.js';
-import { utils } from 'near-api-js';
 import React, { useEffect, useState } from 'react';
 import { Translate } from 'react-localize-redux';
 import { useDispatch, useSelector } from 'react-redux';
@@ -9,6 +7,7 @@ import { Mixpanel } from '../../../mixpanel/index';
 import { resendTwoFactor, get2faMethod, getMultisigRequest } from '../../../redux/actions/account';
 import { selectAccountSlice, selectAccountMultisigRequest } from '../../../redux/slices/account';
 import { selectActionsPending, selectStatusSlice } from '../../../redux/slices/status';
+import getTranslationsFromMultisigRequest from '../../../utils/getTranslationsFromMultisigRequest';
 import { WalletError } from '../../../utils/walletError';
 import AlertBanner from '../../common/AlertBanner';
 import FormButton from '../../common/FormButton';
@@ -16,101 +15,12 @@ import Modal from '../../common/modal/Modal';
 import ModalTheme from '../ledger/ModalTheme';
 import TwoFactorVerifyInput from './TwoFactorVerifyInput';
 
-const {
-    format: {
-        formatNearAmount
-    },
-    key_pair: {
-        PublicKey,
-        KeyType
-    },
-} = utils;
-
 const Form = styled.form`
     display: flex;
     flex-direction: column;
     align-items: center;
     width: 100%;
 `;
-
-const formatNear = (amount) => {
-    try {
-        return formatNearAmount(amount, 4);
-    } catch {
-        // Near amount may be stored as hex rather than decimal
-        return formatNearAmount(new BN(amount, 16).toString(), 4);
-    }
-};
-
-const getTranslationsFromMultisigRequest = ({ actions, receiverId, accountId }) => {
-    const fullAccessKeyAction = actions.find(({ enum: type, permission }) => type === 'addKey' && !permission);
-    if (fullAccessKeyAction) {
-        const publicKey = new PublicKey({
-            keyType: KeyType.ED25519,
-            data: fullAccessKeyAction.addKey.publicKey.data
-        });
-        return [
-            {
-                id: 'twoFactor.action.addKey.full',
-                data: {
-                    accountId,
-                    publicKey: publicKey.toString(),
-                }
-            }
-        ];
-    }
-
-    return actions
-        .map(({ enum: actionType, [actionType]: action }) => {
-            switch (actionType) {
-                case 'addKey':
-                    return {
-                        id: 'twoFactor.action.addKey.limited',
-                        data: {
-                            receiverId,
-                            methodNames: action.permission.functionCall.methodNames.join(', '),
-                            allowance: formatNearAmount(action.permission.functionCall.allowance, 4),
-                            publicKey: new PublicKey({ keyType: KeyType.ED25519, data: action.publicKey.data }).toString(),
-                        }
-                    };
-                case 'deleteKey':
-                    return {
-                        id: 'twoFactor.action.deleteKey',
-                        data: {
-                            publicKey: new PublicKey({ keyType: KeyType.ED25519, data: action.publicKey.data }).toString(),
-                        }
-                    };
-                case 'functionCall':
-                    return {
-                        id: 'twoFactor.action.functionCall',
-                        data: {
-                            receiverId,
-                            methodName: action.methodName,
-                            deposit: formatNear(action.deposit, 4),
-                            args: Buffer.from(action.args).toString(),
-                        }
-                    };
-                case 'transfer':
-                    return {
-                        id: 'twoFactor.action.transfer',
-                        data:{
-                            receiverId,
-                            deposit: formatNearAmount(action.deposit, 4),
-                        }
-                    };
-                case 'stake':
-                    return {
-                        id: 'twoFactor.action.stake',
-                        data: {
-                            receiverId,
-                            deposit: formatNearAmount(action.deposit, 4),
-                        }
-                    };
-                default:
-                    return {};
-            }
-        });
-};
 
 const TwoFactorVerifyModal = ({ open, onClose }) => {
 

--- a/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -39,7 +39,7 @@ const StyledBannerContainer = styled.div`
 `;
 
 const ActionDetailsBanner = ({ multisigRequest }) => {
-    const isAddingFullAccessKey = multisigRequest.actions.some(({ enum: type, [type]: action }) => type === 'addKey' && !action.accessKey.permission);
+    const isAddingFullAccessKey = multisigRequest.actions.some(({ type, permission }) => type === 'AddKey' && !permission);
 
     return  (
         <StyledBannerContainer>

--- a/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -1,17 +1,30 @@
+import BN from 'bn.js';
+import { utils } from 'near-api-js';
 import React, { useEffect, useState } from 'react';
 import { Translate } from 'react-localize-redux';
 import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 
 import { Mixpanel } from '../../../mixpanel/index';
-import { resendTwoFactor, get2faMethod } from '../../../redux/actions/account';
-import { selectAccountSlice } from '../../../redux/slices/account';
+import { resendTwoFactor, get2faMethod, getMultisigRequest } from '../../../redux/actions/account';
+import { selectAccountSlice, selectAccountMultisigRequest } from '../../../redux/slices/account';
 import { selectActionsPending, selectStatusSlice } from '../../../redux/slices/status';
 import { WalletError } from '../../../utils/walletError';
+import AlertBanner from '../../common/AlertBanner';
 import FormButton from '../../common/FormButton';
 import Modal from '../../common/modal/Modal';
 import ModalTheme from '../ledger/ModalTheme';
 import TwoFactorVerifyInput from './TwoFactorVerifyInput';
+
+const {
+    format: {
+        formatNearAmount
+    },
+    key_pair: {
+        PublicKey,
+        KeyType
+    },
+} = utils;
 
 const Form = styled.form`
     display: flex;
@@ -20,6 +33,85 @@ const Form = styled.form`
     width: 100%;
 `;
 
+const formatNear = (amount) => {
+    try {
+        return formatNearAmount(amount, 4);
+    } catch {
+        // Near amount may be stored as hex rather than decimal
+        return formatNearAmount(new BN(amount, 16).toString(), 4);
+    }
+};
+
+const getTranslationsFromMultisigRequest = ({ actions, receiverId, accountId }) => {
+    const fullAccessKeyAction = actions.find(({ enum: type, permission }) => type === 'addKey' && !permission);
+    if (fullAccessKeyAction) {
+        const publicKey = new PublicKey({
+            keyType: KeyType.ED25519,
+            data: fullAccessKeyAction.addKey.publicKey.data
+        });
+        return [
+            {
+                id: 'twoFactor.action.addKey.full',
+                data: {
+                    accountId,
+                    publicKey: publicKey.toString(),
+                }
+            }
+        ];
+    }
+
+    return actions
+        .map(({ enum: actionType, [actionType]: action }) => {
+            switch (actionType) {
+                case 'addKey':
+                    return {
+                        id: 'twoFactor.action.addKey.limited',
+                        data: {
+                            receiverId,
+                            methodNames: action.permission.functionCall.methodNames.join(', '),
+                            allowance: formatNearAmount(action.permission.functionCall.allowance, 4),
+                            publicKey: new PublicKey({ keyType: KeyType.ED25519, data: action.publicKey.data }).toString(),
+                        }
+                    };
+                case 'deleteKey':
+                    return {
+                        id: 'twoFactor.action.deleteKey',
+                        data: {
+                            publicKey: new PublicKey({ keyType: KeyType.ED25519, data: action.publicKey.data }).toString(),
+                        }
+                    };
+                case 'functionCall':
+                    return {
+                        id: 'twoFactor.action.functionCall',
+                        data: {
+                            receiverId,
+                            methodName: action.methodName,
+                            deposit: formatNear(action.deposit, 4),
+                            args: Buffer.from(action.args).toString(),
+                        }
+                    };
+                case 'transfer':
+                    return {
+                        id: 'twoFactor.action.transfer',
+                        data:{
+                            receiverId,
+                            deposit: formatNearAmount(action.deposit, 4),
+                        }
+                    };
+                case 'stake':
+                    return {
+                        id: 'twoFactor.action.stake',
+                        data: {
+                            receiverId,
+                            deposit: formatNearAmount(action.deposit, 4),
+                        }
+                    };
+                default:
+                    return {};
+            }
+        });
+};
+
 const TwoFactorVerifyModal = ({ open, onClose }) => {
 
     const [method, setMethod] = useState();
@@ -27,6 +119,7 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
     const [resendCode, setResendCode] = useState();
     const dispatch = useDispatch();
     const account = useSelector(selectAccountSlice);
+    const multisigRequest = useSelector(selectAccountMultisigRequest);
     const status = useSelector(selectStatusSlice);
     const loading = useSelector((state) => selectActionsPending(state, { types: ['VERIFY_TWO_FACTOR'] }));
 
@@ -39,6 +132,7 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
 
         if (isMounted) {
             handleGetTwoFactor();
+            dispatch(getMultisigRequest());
         }
         
         return () => { isMounted = false; };
@@ -85,6 +179,16 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
             <h2 className='title'><Translate id='twoFactor.verify.title'/></h2>
             <p className='font-bw'><Translate id='twoFactor.verify.desc'/></p>
             <p className='color-black font-bw' style={{ marginTop: '-10px', fontWeight: '500', height: '19px'}}>{method && method.detail}</p>
+            {multisigRequest && (
+                <AlertBanner theme="alert">
+                    {getTranslationsFromMultisigRequest(multisigRequest).map(({ id, data }) => (
+                        <>
+                            <Translate id={id} data={data} />
+                            <br />
+                        </>
+                    ))}
+                </AlertBanner>
+            )}
             <Form onSubmit={(e) => {handleVerifyCode(); e.preventDefault();}}>
                 <TwoFactorVerifyInput
                     code={code}

--- a/packages/frontend/src/components/common/AlertBanner.js
+++ b/packages/frontend/src/components/common/AlertBanner.js
@@ -104,7 +104,7 @@ export default function AlertBanner({ title, button, linkTo, data, theme }) {
                 : <AlertTriangleIcon/>
             }      
             <div>
-                <SafeTranslate id={title} data={{ data: data }}/>
+                {title && <SafeTranslate id={title} data={{ data: data }}/>}
                 {linkTo ? 
                     <>
                         {linkTo.includes('http') ? (

--- a/packages/frontend/src/components/common/AlertBanner.js
+++ b/packages/frontend/src/components/common/AlertBanner.js
@@ -96,7 +96,7 @@ const Container = styled.div`
     }
 `;
 
-export default function AlertBanner({ title, button, linkTo, data, theme }) {
+export default function AlertBanner({ title, button, linkTo, data, theme, children }) {
     return (
         <Container className={classNames(['alert-banner', theme])}>
             {theme !== 'warning'
@@ -115,6 +115,7 @@ export default function AlertBanner({ title, button, linkTo, data, theme }) {
                     </>
                     : null
                 }
+                {children}
             </div>
         </Container>
     );

--- a/packages/frontend/src/components/common/balance/helpers.js
+++ b/packages/frontend/src/components/common/balance/helpers.js
@@ -1,17 +1,17 @@
 import BN from 'bn.js';
 import { utils } from 'near-api-js';
 
-const FRAC_DIGITS = 5;
-export const YOCTO_NEAR_THRESHOLD = new BN('10', 10).pow(new BN(utils.format.NEAR_NOMINATION_EXP - FRAC_DIGITS + 1, 10));
+const NEAR_FRACTIONAL_DIGITS = 5;
+export const YOCTO_NEAR_THRESHOLD = new BN('10', 10).pow(new BN(utils.format.NEAR_NOMINATION_EXP - NEAR_FRACTIONAL_DIGITS + 1, 10));
 
 export const formatNearAmount = (amount) => {
     amount = amount.toString();
     if (amount === '0') {
         return amount;
     }
-    let formattedAmount = utils.format.formatNearAmount(amount, FRAC_DIGITS);
+    let formattedAmount = utils.format.formatNearAmount(amount, NEAR_FRACTIONAL_DIGITS);
     if (formattedAmount === '0') {
-        return `< ${!FRAC_DIGITS ? '0' : `0.${'0'.repeat((FRAC_DIGITS || 1) - 1)}1`}`;
+        return `< ${!NEAR_FRACTIONAL_DIGITS ? '0' : `0.${'0'.repeat((NEAR_FRACTIONAL_DIGITS || 1) - 1)}1`}`;
     }
     return formattedAmount;
 };

--- a/packages/frontend/src/redux/actions/account.js
+++ b/packages/frontend/src/redux/actions/account.js
@@ -253,7 +253,8 @@ export const {
     checkNewAccount,
     saveAccount,
     checkAccountAvailable,
-    clearCode
+    clearCode,
+    getMultisigRequest,
 } = createActions({
     INITIALIZE_RECOVERY_METHOD: [
         wallet.initializeRecoveryMethod.bind(wallet),
@@ -312,6 +313,10 @@ export const {
     GET_2FA_METHOD: [
         (...args) => twoFactorMethod('get2faMethod', wallet, args),
         () => ({})
+    ],
+    GET_MULTISIG_REQUEST: [
+        () => new TwoFactor(wallet, wallet.accountId).getMultisigRequest(),
+        () => ({}),
     ],
     GET_LEDGER_KEY: [
         wallet.getLedgerKey.bind(wallet),

--- a/packages/frontend/src/redux/reducers/account/index.js
+++ b/packages/frontend/src/redux/reducers/account/index.js
@@ -13,7 +13,8 @@ import {
     makeAccountActive,
     setLocalStorage,
     getAccountBalance,
-    setAccountBalance
+    setAccountBalance,
+    getMultisigRequest,
 } from '../../actions/account';
 import {
     staking
@@ -28,7 +29,8 @@ const initialState = {
     canEnableTwoFactor: null,
     twoFactor: null,
     ledgerKey: null,
-    accountsBalance: undefined
+    accountsBalance: undefined,
+    multisigRequest: null,
 };
 
 const recoverCodeReducer = handleActions({
@@ -63,6 +65,13 @@ const twoFactor = handleActions({
     [get2faMethod]: (state, { payload }) => ({
         ...state,
         twoFactor: payload
+    })
+}, initialState);
+
+const multisigRequest = handleActions({
+    [getMultisigRequest]: (state, { payload }) => ({
+        ...state,
+        multisigRequest: payload,
     })
 }, initialState);
 
@@ -195,5 +204,6 @@ export default reduceReducers(
     canEnableTwoFactor,
     twoFactor,
     twoFactorPrompt,
-    ledgerKey
+    ledgerKey,
+    multisigRequest,
 );

--- a/packages/frontend/src/redux/slices/account/index.js
+++ b/packages/frontend/src/redux/slices/account/index.js
@@ -24,6 +24,8 @@ export const selectAccountLedgerKey = createSelector(selectAccountSlice, (accoun
 
 export const selectAccountGlobalAlertPreventClear = createSelector(selectAccountSlice, (account) => account.globalAlertPreventClear);
 
+export const selectAccountMultisigRequest = createSelector(selectAccountSlice, (account) => account.multisigRequest);
+
 // balance - state
 export const selectBalance = createSelector(selectAccountSlice, (account) => account.balance || {});
 

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1473,7 +1473,7 @@
         "action": {
             "addKey": {
                 "limited": "Adding key ${publicKey} limited to call ${methodNames} on ${receiverId} and spend up to ${allowance} NEAR on gas",
-                "full": "WARNING: Entering the code below will authorize full access to your NEAR account: ${accountId}. If you did not initiate this action, please DO NOT continue.<br /><br />This should only be done if you are adding a new seed phrase to your account. In all other cases, this is very dangerous.<br /><br /> The public key you are adding is: ${publicKey} ",
+                "full": "WARNING: Entering the code below will authorize full access to your NEAR account: ${accountId}. If you did not initiate this action, please DO NOT continue.<br /><br />This should only be done if you are adding a new full access key to your account. In all other cases, this is very dangerous.<br /><br /> The public key you are adding is: ${publicKey} ",
             },
             "deleteKey": "Deleting key ${publicKey}",
             "functionCall": "Calling method: ${methodName} in contract: ${receiverId} with amount ${deposit} NEAR and with args: <pre>${args}</pre>",

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1477,7 +1477,7 @@
             },
             "deleteKey": "Deleting key ${publicKey}",
             "functionCall": "Calling method: ${methodName} in contract: ${receiverId} with amount ${deposit} NEAR and with args ${args}",
-            "stake": "Staking: ${deposit} NEAR to validator: ${receiverId}",
+            "stake": "Staking: ${amount} NEAR to validator: ${receiverId}",
             "transfer": "Transferring: ${deposit} NEAR to ${receiverId}"
         }
     },

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1469,6 +1469,16 @@
             "resending": "Sending...",
             "resent": "Code sent!",
             "title": "Enter Two-Factor Verification Code"
+        },
+        "action": {
+            "addKey": {
+                "limited": "Adding key ${publicKey} limited to call ${methodNames} on ${receiverId} and spend up to ${allowance} on gas",
+                "full": "WARNING: Entering the code below will authorize full access to your NEAR account: ${accountId}. If you did not initiate this action, please DO NOT continue.<br /><br />This should only be done if you are adding a new seed phrase to your account. In all other cases, this is very dangerous.<br /><br /> The public key you are adding is: ${publicKey} ",
+            },
+            "deleteKey": "Deleting key ${publicKey}",
+            "functionCall": "Calling method: ${methodName} in contract: ${receiverId} with amount ${deposit} and with args ${args}",
+            "stake": "Staking: ${deposit} to validator: ${receiverId}",
+            "transfer": "Transferring: ${deposit}Ⓝ to ${receiverId}"
         }
     },
     "unlockedAvailTransfer": "This NEAR is unlocked, and can be transferred out of your lockup contract.",

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1476,7 +1476,7 @@
                 "full": "WARNING: Entering the code below will authorize full access to your NEAR account: ${accountId}. If you did not initiate this action, please DO NOT continue.<br /><br />This should only be done if you are adding a new seed phrase to your account. In all other cases, this is very dangerous.<br /><br /> The public key you are adding is: ${publicKey} ",
             },
             "deleteKey": "Deleting key ${publicKey}",
-            "functionCall": "Calling method: ${methodName} in contract: ${receiverId} with amount ${deposit} NEAR and with args ${args}",
+            "functionCall": "Calling method: ${methodName} in contract: ${receiverId} with amount ${deposit} NEAR and with args: <pre>${args}</pre>",
             "stake": "Staking: ${amount} NEAR to validator: ${receiverId}",
             "transfer": "Transferring: ${deposit} NEAR to ${receiverId}"
         }

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1472,13 +1472,13 @@
         },
         "action": {
             "addKey": {
-                "limited": "Adding key ${publicKey} limited to call ${methodNames} on ${receiverId} and spend up to ${allowance} on gas",
+                "limited": "Adding key ${publicKey} limited to call ${methodNames} on ${receiverId} and spend up to ${allowance} NEAR on gas",
                 "full": "WARNING: Entering the code below will authorize full access to your NEAR account: ${accountId}. If you did not initiate this action, please DO NOT continue.<br /><br />This should only be done if you are adding a new seed phrase to your account. In all other cases, this is very dangerous.<br /><br /> The public key you are adding is: ${publicKey} ",
             },
             "deleteKey": "Deleting key ${publicKey}",
-            "functionCall": "Calling method: ${methodName} in contract: ${receiverId} with amount ${deposit} and with args ${args}",
-            "stake": "Staking: ${deposit} to validator: ${receiverId}",
-            "transfer": "Transferring: ${deposit}Ⓝ to ${receiverId}"
+            "functionCall": "Calling method: ${methodName} in contract: ${receiverId} with amount ${deposit} NEAR and with args ${args}",
+            "stake": "Staking: ${deposit} NEAR to validator: ${receiverId}",
+            "transfer": "Transferring: ${deposit} NEAR to ${receiverId}"
         }
     },
     "unlockedAvailTransfer": "This NEAR is unlocked, and can be transferred out of your lockup contract.",

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1478,7 +1478,7 @@
             "deleteKey": "Deleting key ${publicKey}",
             "functionCall": "Calling method: ${methodName} in contract: ${receiverId} with amount ${deposit} NEAR and with args: <pre>${args}</pre>",
             "stake": "Staking: ${amount} NEAR to validator: ${receiverId}",
-            "transfer": "Transferring: ${deposit} NEAR to ${receiverId}"
+            "transfer": "Transferring: ${amount} NEAR to ${receiverId}"
         }
     },
     "unlockedAvailTransfer": "This NEAR is unlocked, and can be transferred out of your lockup contract.",

--- a/packages/frontend/src/utils/getTranslationsFromMultisigRequest.js
+++ b/packages/frontend/src/utils/getTranslationsFromMultisigRequest.js
@@ -1,8 +1,4 @@
-import { formatNearAmount } from 'near-api-js/lib/utils/format';
-
-const NEAR_FRACTIONAL_DIGITS = 4;
-
-const formatNear = (amount) => formatNearAmount(amount, NEAR_FRACTIONAL_DIGITS);
+import { formatNearAmount } from '../components/common/balance/helpers';
 
 const parseAndFormatArguments = (encodedArgs) => {
     const argsBuffer = Buffer.from(encodedArgs, 'base64');
@@ -10,8 +6,8 @@ const parseAndFormatArguments = (encodedArgs) => {
 
     const parsedArgs = {
         ...args,
-        ...(args.amount && { amount: formatNear(args.amount) }),
-        ...(args.deposit && { deposit: formatNear(args.deposit )}),
+        ...(args.amount && { amount: formatNearAmount(args.amount) }),
+        ...(args.deposit && { deposit: formatNearAmount(args.deposit )}),
     };
 
     return JSON.stringify(parsedArgs, null, 2);
@@ -40,7 +36,7 @@ export default function getTranslationsFromMultisigRequest({ actions, receiver_i
                         data: {
                             receiverId: receiver_id,
                             methodNames: action.permission.method_names.join(', '),
-                            allowance: formatNear(action.permission.allowance),
+                            allowance: formatNearAmount(action.permission.allowance),
                             publicKey: action.public_key,
                         }
                     };
@@ -57,7 +53,7 @@ export default function getTranslationsFromMultisigRequest({ actions, receiver_i
                         data: {
                             receiverId: receiver_id,
                             methodName: action.method_name,
-                            deposit: formatNear(action.deposit),
+                            deposit: formatNearAmount(action.deposit),
                             args: parseAndFormatArguments(action.args),
                         }
                     };
@@ -66,7 +62,7 @@ export default function getTranslationsFromMultisigRequest({ actions, receiver_i
                         id: 'twoFactor.action.transfer',
                         data:{
                             receiverId: receiver_id,
-                            amount: formatNear(action.amount),
+                            amount: formatNearAmount(action.amount),
                         }
                     };
                 default:

--- a/packages/frontend/src/utils/getTranslationsFromMultisigRequest.js
+++ b/packages/frontend/src/utils/getTranslationsFromMultisigRequest.js
@@ -22,6 +22,18 @@ const formatNear = (amount) => {
 
 const rawPublicKeyToString = ({ keyType, data }) => new PublicKey({ keyType, data }).toString();
 
+const parseAndFormatArguments = (argsBuffer) => {
+    const args = JSON.parse(Buffer.from(argsBuffer).toString());
+
+    const parsedArgs = {
+        ...args,
+        ...(args.amount && { amount: formatNear(args.amount) }),
+        ...(args.deposit && { deposit: formatNear(args.deposit )}),
+    };
+
+    return JSON.stringify(parsedArgs, null, 2);
+};
+
 export default function getTranslationsFromMultisigRequest({ actions, receiverId, accountId }) {
     const fullAccessKeyAction = actions.find(({ enum: type, permission }) => type === 'addKey' && !permission);
     if (fullAccessKeyAction) {
@@ -63,7 +75,7 @@ export default function getTranslationsFromMultisigRequest({ actions, receiverId
                             receiverId,
                             methodName: action.methodName,
                             deposit: formatNear(action.deposit),
-                            args: JSON.stringify(JSON.parse(Buffer.from(action.args).toString()), null, 2),
+                            args: parseAndFormatArguments(action.args),
                         }
                     };
                 case 'transfer':

--- a/packages/frontend/src/utils/getTranslationsFromMultisigRequest.js
+++ b/packages/frontend/src/utils/getTranslationsFromMultisigRequest.js
@@ -66,7 +66,7 @@ export default function getTranslationsFromMultisigRequest({ actions, receiverId
                             receiverId,
                             methodName: action.methodName,
                             deposit: formatNear(action.deposit),
-                            args: Buffer.from(action.args).toString(),
+                            args: JSON.stringify(JSON.parse(Buffer.from(action.args).toString()), null, 2),
                         }
                     };
                 case 'transfer':

--- a/packages/frontend/src/utils/getTranslationsFromMultisigRequest.js
+++ b/packages/frontend/src/utils/getTranslationsFromMultisigRequest.js
@@ -1,0 +1,92 @@
+import BN from 'bn.js';
+import { utils } from 'near-api-js';
+
+const {
+    format: {
+        formatNearAmount
+    },
+    key_pair: {
+        PublicKey,
+        KeyType
+    },
+} = utils;
+
+
+const formatNear = (amount) => {
+    try {
+        return formatNearAmount(amount, 4);
+    } catch {
+        // Near amount may be stored as hex rather than decimal
+        return formatNearAmount(new BN(amount, 16).toString(), 4);
+    }
+};
+
+export default function getTranslationsFromMultisigRequest({ actions, receiverId, accountId }) {
+    const fullAccessKeyAction = actions.find(({ enum: type, permission }) => type === 'addKey' && !permission);
+    if (fullAccessKeyAction) {
+        const publicKey = new PublicKey({
+            keyType: KeyType.ED25519,
+            data: fullAccessKeyAction.addKey.publicKey.data
+        });
+        return [
+            {
+                id: 'twoFactor.action.addKey.full',
+                data: {
+                    accountId,
+                    publicKey: publicKey.toString(),
+                }
+            }
+        ];
+    }
+
+    return actions
+        .map(({ enum: actionType, [actionType]: action }) => {
+            switch (actionType) {
+                case 'addKey':
+                    return {
+                        id: 'twoFactor.action.addKey.limited',
+                        data: {
+                            receiverId,
+                            methodNames: action.permission.functionCall.methodNames.join(', '),
+                            allowance: formatNear(action.permission.functionCall.allowance),
+                            publicKey: new PublicKey({ keyType: KeyType.ED25519, data: action.publicKey.data }).toString(),
+                        }
+                    };
+                case 'deleteKey':
+                    return {
+                        id: 'twoFactor.action.deleteKey',
+                        data: {
+                            publicKey: new PublicKey({ keyType: KeyType.ED25519, data: action.publicKey.data }).toString(),
+                        }
+                    };
+                case 'functionCall':
+                    return {
+                        id: 'twoFactor.action.functionCall',
+                        data: {
+                            receiverId,
+                            methodName: action.methodName,
+                            deposit: formatNear(action.deposit),
+                            args: Buffer.from(action.args).toString(),
+                        }
+                    };
+                case 'transfer':
+                    return {
+                        id: 'twoFactor.action.transfer',
+                        data:{
+                            receiverId,
+                            deposit: formatNear(action.deposit),
+                        }
+                    };
+                case 'stake':
+                    return {
+                        id: 'twoFactor.action.stake',
+                        data: {
+                            receiverId,
+                            amount: formatNear(action.amount),
+                        }
+                    };
+                default:
+                    return {};
+            }
+        });
+};

--- a/packages/frontend/src/utils/getTranslationsFromMultisigRequest.js
+++ b/packages/frontend/src/utils/getTranslationsFromMultisigRequest.js
@@ -35,7 +35,7 @@ const parseAndFormatArguments = (argsBuffer) => {
 };
 
 export default function getTranslationsFromMultisigRequest({ actions, receiverId, accountId }) {
-    const fullAccessKeyAction = actions.find(({ enum: type, permission }) => type === 'addKey' && !permission);
+    const fullAccessKeyAction = actions.find(({ enum: type, [type]: action }) => type === 'addKey' && !action.accessKey.permission);
     if (fullAccessKeyAction) {
         return [
             {
@@ -49,15 +49,15 @@ export default function getTranslationsFromMultisigRequest({ actions, receiverId
     }
 
     return actions
-        .map(({ enum: actionType, [actionType]: action }) => {
-            switch (actionType) {
+        .map(({ enum: type, [type]: action }) => {
+            switch (type) {
                 case 'addKey':
                     return {
                         id: 'twoFactor.action.addKey.limited',
                         data: {
                             receiverId,
-                            methodNames: action.permission.functionCall.methodNames.join(', '),
-                            allowance: formatNear(action.permission.functionCall.allowance),
+                            methodNames: action.accessKey.permission.functionCall.methodNames.join(', '),
+                            allowance: formatNear(action.accessKey.permission.functionCall.allowance),
                             publicKey: rawPublicKeyToString(action.publicKey),
                         }
                     };

--- a/packages/frontend/src/utils/getTranslationsFromMultisigRequest.js
+++ b/packages/frontend/src/utils/getTranslationsFromMultisigRequest.js
@@ -7,7 +7,6 @@ const {
     },
     key_pair: {
         PublicKey,
-        KeyType
     },
 } = utils;
 
@@ -21,19 +20,17 @@ const formatNear = (amount) => {
     }
 };
 
+const rawPublicKeyToString = ({ keyType, data }) => new PublicKey({ keyType, data }).toString();
+
 export default function getTranslationsFromMultisigRequest({ actions, receiverId, accountId }) {
     const fullAccessKeyAction = actions.find(({ enum: type, permission }) => type === 'addKey' && !permission);
     if (fullAccessKeyAction) {
-        const publicKey = new PublicKey({
-            keyType: KeyType.ED25519,
-            data: fullAccessKeyAction.addKey.publicKey.data
-        });
         return [
             {
                 id: 'twoFactor.action.addKey.full',
                 data: {
                     accountId,
-                    publicKey: publicKey.toString(),
+                    publicKey: rawPublicKeyToString(fullAccessKeyAction.addKey.publicKey)
                 }
             }
         ];
@@ -49,14 +46,14 @@ export default function getTranslationsFromMultisigRequest({ actions, receiverId
                             receiverId,
                             methodNames: action.permission.functionCall.methodNames.join(', '),
                             allowance: formatNear(action.permission.functionCall.allowance),
-                            publicKey: new PublicKey({ keyType: KeyType.ED25519, data: action.publicKey.data }).toString(),
+                            publicKey: rawPublicKeyToString(action.publicKey),
                         }
                     };
                 case 'deleteKey':
                     return {
                         id: 'twoFactor.action.deleteKey',
                         data: {
-                            publicKey: new PublicKey({ keyType: KeyType.ED25519, data: action.publicKey.data }).toString(),
+                            publicKey: rawPublicKeyToString((action.publicKey)),
                         }
                     };
                 case 'functionCall':

--- a/packages/frontend/src/utils/getTranslationsFromMultisigRequest.js
+++ b/packages/frontend/src/utils/getTranslationsFromMultisigRequest.js
@@ -77,14 +77,6 @@ export default function getTranslationsFromMultisigRequest({ actions, receiverId
                             deposit: formatNear(action.deposit),
                         }
                     };
-                case 'stake':
-                    return {
-                        id: 'twoFactor.action.stake',
-                        data: {
-                            receiverId,
-                            amount: formatNear(action.amount),
-                        }
-                    };
                 default:
                     return {};
             }

--- a/packages/frontend/src/utils/twoFactor.js
+++ b/packages/frontend/src/utils/twoFactor.js
@@ -49,16 +49,11 @@ export class TwoFactor extends Account2FA {
     }
 
     async getMultisigRequest() {
-        const request = this.getRequest();
-        const { receiver_id } = await this.viewFunction(
-            this.accountId,
-            'get_request',
-            { request_id: request.requestId }
-        );
-
+        const { requestId, accountId } = this.getRequest();
         return {
-            ...request,
-            receiverId: receiver_id,
+            ...await this.viewFunction(this.accountId, 'get_request', { request_id: requestId }),
+            request_id: requestId,
+            account_id: accountId,
         };
     }
 

--- a/packages/frontend/src/utils/twoFactor.js
+++ b/packages/frontend/src/utils/twoFactor.js
@@ -48,6 +48,20 @@ export class TwoFactor extends Account2FA {
         });
     }
 
+    async getMultisigRequest() {
+        const request = this.getRequest();
+        const { receiver_id } = await this.viewFunction(
+            this.accountId,
+            'get_request',
+            { request_id: request.requestId }
+        );
+
+        return {
+            ...request,
+            receiverId: receiver_id,
+        };
+    }
+
     async deployMultisig() {
         const contractBytes = new Uint8Array(await (await fetch('/multisig.wasm')).arrayBuffer());
         await super.deployMultisig(contractBytes);


### PR DESCRIPTION
With the migration to Twilio Verify 2FA SMS messages will no longer show the transaction details. This PR adds UI to the 2FA verification modal to render the same details which would be present in the SMS.

This is essentially a 1:1 replacement of the existing messaging _except_ for setting up SMS 2FA. I've left that out as we have disabled that flow.

![158480330-ac9cad39-93b0-4a9e-b6b6-8f61c639e772](https://user-images.githubusercontent.com/11974624/158480545-9b870ab1-ee84-46c8-92ad-796beeab5442.png)
![158478845-8dd09ae8-6be8-45fd-80da-a432a89bc5f2](https://user-images.githubusercontent.com/11974624/158480550-b6aa6a22-be65-4bb3-a9b4-9ebf36fb34b8.png)
![158478597-d0cfa5df-f71f-4141-8c8c-23b4bb807611](https://user-images.githubusercontent.com/11974624/158480556-aa1a5d2c-f11d-4ab5-8343-c05ae23fe536.png)

