### PR TITLE
WAL-160 fix(recovery): provide publicKey to security code validation endpoints

### DIFF
--- a/packages/frontend/src/components/accounts/create/implicit_account/SetupRecoveryImplicitAccount.js
+++ b/packages/frontend/src/components/accounts/create/implicit_account/SetupRecoveryImplicitAccount.js
@@ -102,6 +102,7 @@ export default ({
                     color='blue'
                     type='submit'
                     disabled={!isValidInput() || isInitializingRecoveryLink}
+                    sending={isInitializingRecoveryLink}
                     trackingId='SR Click submit button'
                     data-test-id="submitSelectedRecoveryOption"
                 >

--- a/packages/frontend/src/components/accounts/create/implicit_account/SetupRecoveryImplicitAccount.js
+++ b/packages/frontend/src/components/accounts/create/implicit_account/SetupRecoveryImplicitAccount.js
@@ -28,6 +28,7 @@ const StyledContainer = styled(Container)`
 export default ({
     onClickSecureMyAccount,
     email,
+    isInitializingRecoveryLink,
     setEmail
 }) => {
     const [recoveryOption, setRecoveryOption] = useState('phrase');
@@ -100,7 +101,7 @@ export default ({
                 <FormButton
                     color='blue'
                     type='submit'
-                    disabled={!isValidInput()}
+                    disabled={!isValidInput() || isInitializingRecoveryLink}
                     trackingId='SR Click submit button'
                     data-test-id="submitSelectedRecoveryOption"
                 >

--- a/packages/frontend/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
+++ b/packages/frontend/src/components/accounts/recovery_setup/SetupRecoveryMethod.js
@@ -214,9 +214,9 @@ class SetupRecoveryMethod extends Component {
         }
 
         try {
-            const { secretKey } = parseSeedPhrase(recoverySeedPhrase);
+            const { publicKey, secretKey } = parseSeedPhrase(recoverySeedPhrase);
             const recoveryKeyPair = KeyPair.fromString(secretKey);
-            await validateSecurityCode(accountId, method, securityCode, validateSecurityCodeEnterpriseRecaptchaToken, 'setupRecoveryMethodNewAccount');
+            await validateSecurityCode(accountId, method, securityCode, validateSecurityCodeEnterpriseRecaptchaToken, 'setupRecoveryMethodNewAccount', publicKey);
             await wallet.saveAccountKeyPair({ accountId, recoveryKeyPair });
 
             // IDENTITY VERIFIED FUNDED ACCOUNT

--- a/packages/frontend/src/routes/SetupRecoveryImplicitAccountWrapper.js
+++ b/packages/frontend/src/routes/SetupRecoveryImplicitAccountWrapper.js
@@ -20,6 +20,7 @@ export function SetupRecoveryImplicitAccountWrapper() {
     const [verifyingEmailCode, setVerifyingEmailCode] = useState(false);
     const [resendingEmailCode, setResendingEmailCode] = useState(false);
     const [seedPhrasePublicKey, setSeedPhrasePublicKey] = useState(null);
+    const [isInitializingRecoveryLink, setIsInitializingRecoveryLink] = useState(false);
 
     const handleInititalizeEmailRecoveryLink = async () => {
         const passPhrase = await wallet.initializeRecoveryMethodNewImplicitAccount({ kind: 'email', detail: email });
@@ -36,6 +37,7 @@ export function SetupRecoveryImplicitAccountWrapper() {
         return (
             <SetupRecoveryImplicitAccount
                 email={email}
+                isInitializingRecoveryLink={isInitializingRecoveryLink}
                 setEmail={(email) => setEmail(email)}
                 onClickSecureMyAccount={async ({ recoveryOption }) => {
                     if (recoveryOption === 'phrase') {
@@ -44,8 +46,10 @@ export function SetupRecoveryImplicitAccountWrapper() {
                         dispatch(redirectTo('/setup-ledger-new-account'));
                     } else if (recoveryOption === 'email') {
                         Mixpanel.track('SR Select email');
+                        setIsInitializingRecoveryLink(true);
+                        await handleInititalizeEmailRecoveryLink();
+                        setIsInitializingRecoveryLink(false);
                         setShowVerifyEmailCode(true);
-                        handleInititalizeEmailRecoveryLink();
                     }
                 }}
             />

--- a/packages/frontend/src/routes/SetupRecoveryImplicitAccountWrapper.js
+++ b/packages/frontend/src/routes/SetupRecoveryImplicitAccountWrapper.js
@@ -19,15 +19,17 @@ export function SetupRecoveryImplicitAccountWrapper() {
     const [recoveryKeyPair, setRecoveryKeyPair] = useState();
     const [verifyingEmailCode, setVerifyingEmailCode] = useState(false);
     const [resendingEmailCode, setResendingEmailCode] = useState(false);
+    const [seedPhrasePublicKey, setSeedPhrasePublicKey] = useState(null);
 
     const handleInititalizeEmailRecoveryLink = async () => {
         const passPhrase = await wallet.initializeRecoveryMethodNewImplicitAccount({ kind: 'email', detail: email });
-        const { secretKey } = parseSeedPhrase(passPhrase);
+        const { publicKey, secretKey } = parseSeedPhrase(passPhrase);
         const recoveryKeyPair = KeyPair.fromString(secretKey);
         const implicitAccountId = Buffer.from(recoveryKeyPair.publicKey.data).toString('hex');
 
         setRecoveryKeyPair(recoveryKeyPair);
         setImplicitAccountId(implicitAccountId);
+        setSeedPhrasePublicKey(publicKey);
     };
 
     if (!showVerifyEmailCode) {
@@ -60,7 +62,7 @@ export function SetupRecoveryImplicitAccountWrapper() {
                 Mixpanel.track('SR Verify email code');
                 try {
                     setVerifyingEmailCode(true);
-                    await wallet.validateSecurityCodeNewImplicitAccount(implicitAccountId, { kind: 'email', detail: email }, securityCode);
+                    await wallet.validateSecurityCodeNewImplicitAccount(implicitAccountId, { kind: 'email', detail: email }, securityCode, seedPhrasePublicKey);
                     await dispatch(saveAccount(implicitAccountId, recoveryKeyPair));
                 } catch (e) {
                     dispatch(showCustomAlert({

--- a/packages/frontend/src/utils/wallet.js
+++ b/packages/frontend/src/utils/wallet.js
@@ -730,11 +730,12 @@ class Wallet {
         return seedPhrase;
     }
 
-    async validateSecurityCodeNewImplicitAccount(implicitAccountId, method, securityCode) {
+    async validateSecurityCodeNewImplicitAccount(implicitAccountId, method, securityCode, publicKey) {
         try {
             await sendJson('POST', ACCOUNT_HELPER_URL + '/account/validateSecurityCodeForTempAccount', {
                 accountId: implicitAccountId,
                 method,
+                publicKey,
                 securityCode,
             });
         } catch (e) {
@@ -742,11 +743,12 @@ class Wallet {
         }
     }
 
-    async validateSecurityCode(accountId, method, securityCode, enterpriseRecaptchaToken, recaptchaAction) {
+    async validateSecurityCode(accountId, method, securityCode, enterpriseRecaptchaToken, recaptchaAction, publicKey) {
         const isNew = await this.checkIsNew(accountId);
         const body = {
             accountId,
             method,
+            publicKey,
             securityCode,
         };
 
@@ -779,7 +781,7 @@ class Wallet {
 
     async setupRecoveryMessage(accountId, method, securityCode, recoverySeedPhrase) {
         const { publicKey } = parseSeedPhrase(recoverySeedPhrase);
-        await this.validateSecurityCode(accountId, method, securityCode);
+        await this.validateSecurityCode(accountId, method, securityCode, undefined, undefined, publicKey);
         try {
             await this.addNewAccessKeyToAccount(accountId, publicKey);
         } catch (e) {


### PR DESCRIPTION
This PR updates calls to the recovery method endpoints responsible for validating security codes to include the public key associated with the recovery method being validated. The public key will be used to uniquely identify the recovery method document in DynamoDB and so should be provided when calling any endpoint responsible for querying or mutating recovery methods.