### PR TITLE
fix: Disallow switching account on onboarding/recovery pages

### DIFF
--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -179,41 +179,36 @@ class Routing extends Component {
 
         this.props.setActiveLanguage(activeLang);
         // this.addTranslationsForActiveLanguage(defaultLanguage)
-
-        const {
-            refreshAccount,
-            history,
-            handleRedirectUrl,
-            handleClearUrl,
-            handleClearAlert,
-            handleFlowLimitation,
-            router
-        } = this.props;
-
-        history.listen(async (location) => {
-            handleRedirectUrl(router.location);
-            handleClearUrl();
-            handleFlowLimitation();
-            if (!WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS.find((path) => router.location.pathname.indexOf(path) > -1)) {
-                await refreshAccount(true);
-            }
-
-            handleClearAlert();
-        });
     }
 
     componentDidMount = async () => {
         const {
             refreshAccount,
             handleRefreshUrl,
+            history,
+            handleRedirectUrl,
+            handleClearUrl,
             router,
             fetchTokenFiatValues,
+            handleClearAlert,
+            handleFlowLimitation
         } = this.props;
 
         fetchTokenFiatValues();
         this.startPollingTokenFiatValue();
         handleRefreshUrl(router);
         refreshAccount();
+
+        history.listen(async () => {
+            handleRedirectUrl(this.props.router.location);
+            handleClearUrl();
+            if (!WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS.find((path) => this.props.router.location.pathname.indexOf(path) > -1)) {
+                await refreshAccount(true);
+            }
+
+            handleClearAlert();
+            handleFlowLimitation();
+        });
     }
 
     componentDidUpdate(prevProps) {

--- a/packages/frontend/src/components/accounts/SetupSeedPhraseForm.js
+++ b/packages/frontend/src/components/accounts/SetupSeedPhraseForm.js
@@ -46,6 +46,11 @@ const CustomDiv = styled('div')`
         > button {
             width: 100%;
             margin-top: 45px;
+
+            &.link {
+                margin: 30px auto 0 auto;
+                display: inherit;
+            }
         }
     }
     #seed-phrase {
@@ -83,6 +88,7 @@ const SetupSeedPhraseForm = ({
     seedPhrase,
     refreshData,
     onClickContinue,
+    onClickCancel,
     hasSeedPhraseRecovery = false
 }) => {
 
@@ -125,6 +131,13 @@ const SetupSeedPhraseForm = ({
                 data-test-id="continueToSeedPhraseVerificationButton"
             >
                 <Translate id='button.continue' />
+            </FormButton>
+            <FormButton
+                onClick={onClickCancel}
+                className='link'
+                color='gray'
+            >
+                <Translate id='button.cancel' />
             </FormButton>
         </CustomDiv>
     );

--- a/packages/frontend/src/components/accounts/ledger/SetupLedger.js
+++ b/packages/frontend/src/components/accounts/ledger/SetupLedger.js
@@ -179,7 +179,7 @@ const SetupLedger = (props) => {
                 <Translate id={`button.${connect !== 'fail' ? 'continue' : 'retry'}`} />
             </FormButton>
             <FormButton
-                className='link red'
+                className='link gray'
                 onClick={() => props.history.goBack()}
                 trackingId='SR-Ledger Click cancel button'
             >

--- a/packages/frontend/src/components/common/styled/Container.css.js
+++ b/packages/frontend/src/components/common/styled/Container.css.js
@@ -96,7 +96,7 @@ const Container = styled.div`
             }
 
             &.link {
-                &.red {
+                &.gray {
                     margin-top: 25px !important;
                 }
             }

--- a/packages/frontend/src/redux/slices/flowLimitation/index.js
+++ b/packages/frontend/src/redux/slices/flowLimitation/index.js
@@ -22,11 +22,18 @@ const initialState = {
 const handleFlowLimitation = createAsyncThunk(
     `${SLICE_NAME}/handleFlowLimitation`,
     async (_, thunkAPI) => {
+        const { actions: { setFlowLimitation } } = flowLimitationSlice;
         const { dispatch, getState } = thunkAPI;
         const { pathname } = getState().router.location;
-        const { redirect_url } = getState().account.url;
-        const { actions: { setFlowLimitation } } = flowLimitationSlice;
 
+        if (WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS.some((url) => pathname.includes(url))) {
+            // Disallow account switching on account creation/recovery pages
+            dispatch(setFlowLimitation({ subMenu: true }));
+        } else {
+            dispatch(setFlowLimitation({ subMenu: false }));
+        }
+
+        const { redirect_url } = getState().account.url;
         const redirectUrl = redirect_url || pathname;
 
         if (redirectUrl.includes(WALLET_LOGIN_URL)) {
@@ -55,13 +62,6 @@ const handleFlowLimitation = createAsyncThunk(
                 accountData: true,
                 accountBalance: false
             }));
-        }
-
-        if (WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS.some((url) => pathname.includes(url))) {
-            // Disallow account switching on account creation/recovery pages
-            dispatch(setFlowLimitation({ subMenu: true }));
-        } else {
-            dispatch(setFlowLimitation({ subMenu: false }));
         }
     }
 );

--- a/packages/frontend/src/redux/slices/flowLimitation/index.js
+++ b/packages/frontend/src/redux/slices/flowLimitation/index.js
@@ -4,7 +4,8 @@ import assign from 'lodash.assign';
 import { 
     WALLET_INITIAL_DEPOSIT_URL,
     WALLET_LOGIN_URL,
-    WALLET_SIGN_URL
+    WALLET_SIGN_URL,
+    WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS
 } from '../../../utils/wallet';
 import { getBalance } from '../../actions/account';
 
@@ -54,6 +55,13 @@ const handleFlowLimitation = createAsyncThunk(
                 accountData: true,
                 accountBalance: false
             }));
+        }
+
+        if (WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS.some((url) => pathname.includes(url))) {
+            // Disallow account switching on account creation/recovery pages
+            dispatch(setFlowLimitation({ subMenu: true }));
+        } else {
+            dispatch(setFlowLimitation({ subMenu: false }));
         }
     }
 );

--- a/packages/frontend/src/redux/slices/flowLimitation/index.js
+++ b/packages/frontend/src/redux/slices/flowLimitation/index.js
@@ -26,12 +26,9 @@ const handleFlowLimitation = createAsyncThunk(
         const { dispatch, getState } = thunkAPI;
         const { pathname } = getState().router.location;
 
-        if (WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS.some((url) => pathname.includes(url))) {
-            // Disallow account switching on account creation/recovery pages
-            dispatch(setFlowLimitation({ subMenu: true }));
-        } else {
-            dispatch(setFlowLimitation({ subMenu: false }));
-        }
+        // Disallow account switching on account creation/recovery pages
+        const disableAccountSwitching = WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS.some((url) => pathname.includes(url));
+        dispatch(setFlowLimitation({ subMenu: disableAccountSwitching }));
 
         const { redirect_url } = getState().account.url;
         const redirectUrl = redirect_url || pathname;


### PR DESCRIPTION
Fixes:
1. Disallow switching account on onboarding/recovery pages.
2. Makes sure to pull wallet recovery methods and disable the 'continue' button for already enabled recovery methods (regression).

To test:
1. While logged in to an account, navigate to any of the onboarding or/and recovery setup pages:
```
    /create
    /set-recovery
    /setup-seed-phrase
    /recover-account
    /recover-seed-phrase
    /sign-in-ledger
    /fund-create-account
    /verify-account
    /initial-deposit
    /setup-ledger
```
3. Expect the main navigation dropdown to disable option to switch account
4. Navigate to a different page and expect option to switch account to be enabled again