### PR TITLE
fix(nft): restore data URI scheme rendering for NFTs

### DIFF
--- a/packages/frontend/src/services/NonFungibleTokens.js
+++ b/packages/frontend/src/services/NonFungibleTokens.js
@@ -93,24 +93,26 @@ export default class NonFungibleTokens {
             .map((token) => this.mapTokenMediaUrl(token, base_uri));
     }
 
-    static mapTokenMediaUrl = ({ metadata, ...token }, base_uri) => {
-        const { media } = metadata;
-        let mediaUrl;
-        if (media && !media.includes('://')) {
-            if (base_uri) {
-                mediaUrl = `${base_uri}/${media}`;
-            } else {
-                mediaUrl = `https://cloudflare-ipfs.com/ipfs/${media}`;
-            }
-        } else {
-            mediaUrl = media;
+    static buildMediaUrl = (media, base_uri) => {
+        // return the provided media string if it is empty or already in a URI format
+        if (!media || media.includes('://') || media.startsWith('data:image')) {
+            return media;
         }
 
+        if (base_uri) {
+            return `${base_uri}/${media}`;
+        }
+
+        return `https://cloudflare-ipfs.com/ipfs/${media}`;
+    }
+
+    static mapTokenMediaUrl = ({ metadata, ...token }, base_uri) => {
+        const { media } = metadata;
         return {
             ...token,
             metadata: {
                 ...metadata,
-                mediaUrl
+                mediaUrl: this.buildMediaUrl(media, base_uri),
             }
         };
     }

--- a/packages/frontend/src/services/NonFungibleTokens.js
+++ b/packages/frontend/src/services/NonFungibleTokens.js
@@ -11,7 +11,7 @@ export const NFT_TRANSFER_DEPOSIT = 1; // 1 yocto Near
 
 const functionCall = nearAPI.transactions.functionCall;
 
-// Methods for interacting witn NEP171 tokens (https://nomicon.io/Standards/NonFungibleToken/README.html)
+// Methods for interacting with NEP171 tokens (https://nomicon.io/Standards/NonFungibleToken/README.html)
 export default class NonFungibleTokens {
     // View functions are not signed, so do not require a real account!
     static viewFunctionAccount = wallet.getAccountBasic('dontcare')


### PR DESCRIPTION
This PR adds a `buildMediaUrl` method to the NFT class to simplify the logic around extracting URI data from NFT metadata. In particular it restores the logic responsible for rendering `data:image` URIs.

Closes #2534 