### PR TITLE
fix: passing data from WalletError to actionStatus state

### DIFF
--- a/packages/frontend/src/redux/reducers/status/index.js
+++ b/packages/frontend/src/redux/reducers/status/index.js
@@ -73,6 +73,7 @@ const alertReducer = (state, { error, ready, payload, meta, type }) => {
                 errorMessage: (error && payload?.message) || (type === 'SHOW_CUSTOM_ALERT' && payload.errorMessage) || undefined,
                 data: {
                     ...meta?.data,
+                    ...payload?.data,
                     ...payload
                 }
             }


### PR DESCRIPTION
It one-line fix, but a few hours of tinkering and checking.

I analyzed several possible solutions. We cannot use `alert.data.data` (like is mentioned in the issue description) because it will interfere with other usages of global alerts that are proper. We cannot change `walletError` implementation because it's also used in two other cases, and it seems reasonable as it is. The only proper solution is to destructure `payload.data` into `data` prop in `actionStatus`. It's solving the problem properly.

Generally, we are planning to slowly get rid of global alerts in favor of custom error UI implemented in all functionalities. So basically every UI will have its own way to show error information.