### PR TITLE
Wallet domain banner

### DIFF
--- a/packages/frontend/src/components/accounts/RecoverAccount.js
+++ b/packages/frontend/src/components/accounts/RecoverAccount.js
@@ -109,8 +109,8 @@ const RecoverAccount = ({
     isMobile
 }) => {
     return (
-        <>
-            {IS_MAINNET && <VerifyWalletDomainBanner />}
+        <>  
+            <VerifyWalletDomainBanner />
             <StyledContainer>
                 <h1><Translate id='recoverAccount.pageTitle' /></h1>
                 <h2><Translate id='recoverAccount.pageText' /></h2>

--- a/packages/frontend/src/components/accounts/RecoverAccount.js
+++ b/packages/frontend/src/components/accounts/RecoverAccount.js
@@ -10,6 +10,7 @@ import PhraseIcon from '../../images/icon-recover-seedphrase.svg';
 import { Mixpanel } from '../../mixpanel/index';
 import FormButton from '../common/FormButton';
 import Container from '../common/styled/Container.css';
+import VerifyWalletDomainBanner from '../common/VerifyWalletDomainBanner';
 import SmartPhoneIcon from '../svg/SmartPhoneIcon';
 
 
@@ -108,53 +109,56 @@ const RecoverAccount = ({
     isMobile
 }) => {
     return (
-        <StyledContainer>
-            <h1><Translate id='recoverAccount.pageTitle'/></h1>
-            <h2><Translate id='recoverAccount.pageText'/></h2>
-            <Options>
-                <Option>
-                    <Header icon={EmailIcon}><Translate id='recoverAccount.email.title'/></Header>
-                    <P><Translate id='recoverAccount.email.desc'/> <span><Translate id='recoverAccount.email.subject'/></span></P>
-                    <P><Translate id='recoverAccount.actionRequired'/></P>
-                    <P><Translate id='recoverAccount.cannotResend'/></P>
-                </Option>
-                <Option>
-                    <Header icon={PhoneIcon}><Translate id='recoverAccount.phone.title'/></Header>
-                    <P><Translate id='recoverAccount.phone.desc'/> <span><Translate id='recoverAccount.phone.number'/></span></P>
-                    <P><Translate id='recoverAccount.actionRequired'/></P>
-                    <P><Translate id='recoverAccount.cannotResend'/></P>
-                </Option>
-                <Option>
-                    <Header icon={PhraseIcon}><Translate id='recoverAccount.phrase.title'/></Header>
-                    <P><Translate id='recoverAccount.phrase.desc'/></P>
-                    <FormButton
-                        color='seafoam-blue'
-                        linkTo={`/recover-seed-phrase${locationSearch}`}
-                        onClick={()=> Mixpanel.track('IE Click seed phrase recovery button')}
-                        data-test-id="recoverAccountWithPassphraseButton"
-                    >
-                            <Translate id='button.recoverAccount' />
-                    </FormButton>
-                </Option>
-                <Option>
-                    <Header icon={HardwareDeviceIcon}><Translate id='recoverAccount.ledger.title'/></Header>
-                    <P><Translate id='recoverAccount.ledger.desc'/></P>
-                    <FormButton
-                        color='seafoam-blue'
-                        linkTo={`/sign-in-ledger${locationSearch}`}
-                        onClick={()=> Mixpanel.track('IE Click ledger recovery button')}
-                    >
-                            <Translate id='button.signInLedger' />
-                    </FormButton>
-                </Option>
-                {!IS_MAINNET && isMobile &&
+        <>
+            {IS_MAINNET && <VerifyWalletDomainBanner />}
+            <StyledContainer>
+                <h1><Translate id='recoverAccount.pageTitle' /></h1>
+                <h2><Translate id='recoverAccount.pageText' /></h2>
+                <Options>
                     <Option>
-                        <Header className='no-background'><SmartPhoneIcon/><Translate id='mobileDeviceAccess.title'/></Header>
-                        <P><Translate id='mobileDeviceAccess.importCode.desc'/></P>
+                        <Header icon={EmailIcon}><Translate id='recoverAccount.email.title' /></Header>
+                        <P><Translate id='recoverAccount.email.desc' /> <span><Translate id='recoverAccount.email.subject' /></span></P>
+                        <P><Translate id='recoverAccount.actionRequired' /></P>
+                        <P><Translate id='recoverAccount.cannotResend' /></P>
                     </Option>
-                }
-            </Options>
-        </StyledContainer>
+                    <Option>
+                        <Header icon={PhoneIcon}><Translate id='recoverAccount.phone.title' /></Header>
+                        <P><Translate id='recoverAccount.phone.desc' /> <span><Translate id='recoverAccount.phone.number' /></span></P>
+                        <P><Translate id='recoverAccount.actionRequired' /></P>
+                        <P><Translate id='recoverAccount.cannotResend' /></P>
+                    </Option>
+                    <Option>
+                        <Header icon={PhraseIcon}><Translate id='recoverAccount.phrase.title' /></Header>
+                        <P><Translate id='recoverAccount.phrase.desc' /></P>
+                        <FormButton
+                            color='seafoam-blue'
+                            linkTo={`/recover-seed-phrase${locationSearch}`}
+                            onClick={() => Mixpanel.track('IE Click seed phrase recovery button')}
+                            data-test-id="recoverAccountWithPassphraseButton"
+                        >
+                            <Translate id='button.recoverAccount' />
+                        </FormButton>
+                    </Option>
+                    <Option>
+                        <Header icon={HardwareDeviceIcon}><Translate id='recoverAccount.ledger.title' /></Header>
+                        <P><Translate id='recoverAccount.ledger.desc' /></P>
+                        <FormButton
+                            color='seafoam-blue'
+                            linkTo={`/sign-in-ledger${locationSearch}`}
+                            onClick={() => Mixpanel.track('IE Click ledger recovery button')}
+                        >
+                            <Translate id='button.signInLedger' />
+                        </FormButton>
+                    </Option>
+                    {!IS_MAINNET && isMobile &&
+                        <Option>
+                            <Header className='no-background'><SmartPhoneIcon /><Translate id='mobileDeviceAccess.title' /></Header>
+                            <P><Translate id='mobileDeviceAccess.importCode.desc' /></P>
+                        </Option>
+                    }
+                </Options>
+            </StyledContainer>
+        </>
     );
 };
 

--- a/packages/frontend/src/components/common/VerifyWalletDomainBanner.js
+++ b/packages/frontend/src/components/common/VerifyWalletDomainBanner.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Translate } from 'react-localize-redux';
+import styled from 'styled-components';
+
+import LockIcon from '../svg/LockIcon';
+
+const StyledContainer = styled.div`
+    background-color: #fafafa;
+    border-radius: 8px;
+    margin: 0 auto;
+    text-align: center;
+    padding: 10px 20px;
+    margin: -5px 0 40px 0;
+
+    svg {
+        width: 20px;
+        margin: -1px 6px 0 0;
+    }
+
+    span {
+        color: #24272a;
+        :first-of-type {
+            color: #00C08B;
+        }
+    }
+    
+    .mobile {
+        @media (min-width: 768px) {
+            display: none;
+        }
+        > div {
+            margin-top: 8px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+    }
+
+    .desktop {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        @media (max-width: 767px) {
+            display: none;
+        }
+    }
+`;
+
+export default () => {
+    return (
+        <StyledContainer>
+            <div className='desktop'>
+                <LockIcon color='#00C08B' /><Translate id='verifyWalletDomainBanner.title' />&nbsp;<span>https://</span><span>wallet.near.org</span>
+            </div>
+            <div className='mobile'>
+                <Translate id='verifyWalletDomainBanner.title' />
+                <div>
+                    <LockIcon color='#00C08B' /><span>https://</span><span>wallet.near.org</span>
+                </div>
+            </div>
+        </StyledContainer>
+    );
+};

--- a/packages/frontend/src/components/common/VerifyWalletDomainBanner.js
+++ b/packages/frontend/src/components/common/VerifyWalletDomainBanner.js
@@ -7,11 +7,14 @@ import LockIcon from '../svg/LockIcon';
 
 const StyledContainer = styled.div`
     background-color: #fafafa;
-    border-radius: 8px;
     margin: 0 auto;
     text-align: center;
     padding: 10px 20px;
     margin: -5px 0 40px 0;
+
+    &.network-banner {
+        margin: -15px 0 40px 0;
+    }
 
     svg {
         width: 20px;
@@ -67,7 +70,7 @@ const getWalletURL = () => {
 
 export default () => {
     return (
-        <StyledContainer>
+        <StyledContainer className={(SHOW_PRERELEASE_WARNING || !IS_MAINNET) ? 'network-banner' : ''}>
             <div className='desktop'>
                 <LockIcon color='#00C08B' />
                 <Translate id='verifyWalletDomainBanner.title' />

--- a/packages/frontend/src/components/common/VerifyWalletDomainBanner.js
+++ b/packages/frontend/src/components/common/VerifyWalletDomainBanner.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Translate } from 'react-localize-redux';
 import styled from 'styled-components';
 
+import { IS_MAINNET, SHOW_PRERELEASE_WARNING } from '../../config';
 import LockIcon from '../svg/LockIcon';
 
 const StyledContainer = styled.div`
@@ -47,16 +48,37 @@ const StyledContainer = styled.div`
     }
 `;
 
+const getWalletURL = () => {
+    let networkName = '';
+
+    if (SHOW_PRERELEASE_WARNING) {
+        networkName = 'staging.';
+    }
+    if (!IS_MAINNET) {
+        networkName = 'testnet.';
+    }
+
+    return (
+        <>
+            <span>https://</span><span>wallet.{networkName}near.org</span>
+        </>
+    );
+};
+
 export default () => {
     return (
         <StyledContainer>
             <div className='desktop'>
-                <LockIcon color='#00C08B' /><Translate id='verifyWalletDomainBanner.title' />&nbsp;<span>https://</span><span>wallet.near.org</span>
+                <LockIcon color='#00C08B' />
+                <Translate id='verifyWalletDomainBanner.title' />
+                &nbsp;
+                {getWalletURL()}
             </div>
             <div className='mobile'>
                 <Translate id='verifyWalletDomainBanner.title' />
                 <div>
-                    <LockIcon color='#00C08B' /><span>https://</span><span>wallet.near.org</span>
+                    <LockIcon color='#00C08B' />
+                    {getWalletURL()}
                 </div>
             </div>
         </StyledContainer>

--- a/packages/frontend/src/components/common/VerifyWalletDomainBanner.js
+++ b/packages/frontend/src/components/common/VerifyWalletDomainBanner.js
@@ -52,7 +52,7 @@ const StyledContainer = styled.div`
     }
 `;
 
-const getWalletURLString = () => <><span>https://</span><span>{getWalletURL(false)}</span></>;
+const WalletURLString = () => <><span>https://</span><span>{getWalletURL(false)}</span></>;
 
 export default () => {
     return (
@@ -61,13 +61,13 @@ export default () => {
                 <LockIcon color='#00C08B' />
                 <Translate id='verifyWalletDomainBanner.title' />
                 &nbsp;
-                {getWalletURLString()}
+                <WalletURLString/>
             </div>
             <div className='mobile'>
                 <Translate id='verifyWalletDomainBanner.title' />
                 <div>
                     <LockIcon color='#00C08B' />
-                    {getWalletURLString()}
+                    <WalletURLString/>
                 </div>
             </div>
         </StyledContainer>

--- a/packages/frontend/src/components/common/VerifyWalletDomainBanner.js
+++ b/packages/frontend/src/components/common/VerifyWalletDomainBanner.js
@@ -3,6 +3,7 @@ import { Translate } from 'react-localize-redux';
 import styled from 'styled-components';
 
 import { IS_MAINNET, SHOW_PRERELEASE_WARNING } from '../../config';
+import getWalletURL from '../../utils/getWalletURL';
 import LockIcon from '../svg/LockIcon';
 
 const StyledContainer = styled.div`
@@ -51,22 +52,7 @@ const StyledContainer = styled.div`
     }
 `;
 
-const getWalletURL = () => {
-    let networkName = '';
-
-    if (SHOW_PRERELEASE_WARNING) {
-        networkName = 'staging.';
-    }
-    if (!IS_MAINNET) {
-        networkName = 'testnet.';
-    }
-
-    return (
-        <>
-            <span>https://</span><span>wallet.{networkName}near.org</span>
-        </>
-    );
-};
+const getWalletURLString = () => <><span>https://</span><span>{getWalletURL(false)}</span></>;
 
 export default () => {
     return (
@@ -75,13 +61,13 @@ export default () => {
                 <LockIcon color='#00C08B' />
                 <Translate id='verifyWalletDomainBanner.title' />
                 &nbsp;
-                {getWalletURL()}
+                {getWalletURLString()}
             </div>
             <div className='mobile'>
                 <Translate id='verifyWalletDomainBanner.title' />
                 <div>
                     <LockIcon color='#00C08B' />
-                    {getWalletURL()}
+                    {getWalletURLString()}
                 </div>
             </div>
         </StyledContainer>

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1526,6 +1526,9 @@
         "title": "Almost there! Verify your new account.",
         "titleNoFunding": "Almost there! Fund your new account."
     },
+    "verifyWalletDomainBanner": {
+        "title": "Please make sure you are visiting"
+    },
     "wallet": {
         "availableBalance": "Available Balance",
         "balance": "Balance",

--- a/packages/frontend/src/utils/getWalletURL.js
+++ b/packages/frontend/src/utils/getWalletURL.js
@@ -1,0 +1,14 @@
+import { IS_MAINNET, SHOW_PRERELEASE_WARNING } from '../config';
+
+export default (https = true) => {
+    let networkName = '';
+
+    if (SHOW_PRERELEASE_WARNING) {
+        networkName = 'staging.';
+    }
+    if (!IS_MAINNET) {
+        networkName = 'testnet.';
+    }
+
+    return `${https ? 'https://' : ''}wallet.${networkName}near.org`;
+};

--- a/packages/frontend/src/utils/getWalletURL.js
+++ b/packages/frontend/src/utils/getWalletURL.js
@@ -5,8 +5,7 @@ export default (https = true) => {
 
     if (SHOW_PRERELEASE_WARNING) {
         networkName = 'staging.';
-    }
-    if (!IS_MAINNET) {
+    } else if (!IS_MAINNET) {
         networkName = 'testnet.';
     }
 


### PR DESCRIPTION
Changes:

1. Show a 'verify wallet domain banner' on the main[ `/recover-account`](https://near-wallet-pr-2542.onrender.com/recover-account) route.

<img width="414" alt="Screen Shot 2022-03-23 at 4 11 04 PM" src="https://user-images.githubusercontent.com/24921205/159811299-65505a44-5a95-4c32-b147-c48551fab100.png">

<img width="1383" alt="Screen Shot 2022-03-23 at 4 10 40 PM" src="https://user-images.githubusercontent.com/24921205/159811262-511e0e79-9660-4fdd-8e5e-0df3bde87ce9.png">

