### PR TITLE
fix: Ensure NEAR token balance shows correct USD fiat value

### DIFF
--- a/packages/frontend/src/redux/crossStateSelectors/selectNEARAsTokenWithMetadata.js
+++ b/packages/frontend/src/redux/crossStateSelectors/selectNEARAsTokenWithMetadata.js
@@ -8,6 +8,6 @@ export default createSelector(
     (balanceAvailable, usd) => ({
         balance: balanceAvailable || '',
         onChainFTMetadata: { symbol: 'NEAR', decimals: 24 },
-        coingeckoMetadata: { usd },
+        fiatValueMetadata: { usd },
     })
 );


### PR DESCRIPTION
Fixing regression or missed reference introduced when adding ref-finance support for tokens other than NEAR native tokens.