### PR TITLE
Refactor tokens reducer into two reducers

### DIFF
--- a/packages/frontend/src/components/staking/components/Validator.js
+++ b/packages/frontend/src/components/staking/components/Validator.js
@@ -12,7 +12,7 @@ import selectNEARAsTokenWithMetadata from '../../../redux/selectors/crossStateSe
 import { selectValidatorsFarmData, selectFarmValidatorAPY, selectStakingCurrentAccountAccountId } from '../../../redux/slices/staking';
 import { selectActionsPending } from '../../../redux/slices/status';
 import { selectTokensFiatValueUSD, selectTokenWhiteList } from '../../../redux/slices/tokenFiatValues';
-import { selectAllContractMetadata } from '../../../redux/slices/tokens';
+import { selectContractsMetadata } from '../../../redux/slices/tokensMetadata';
 import StakingFarmContracts from '../../../services/StakingFarmContracts';
 import { FARMING_VALIDATOR_VERSION } from '../../../utils/constants';
 import FormButton from '../../common/FormButton';
@@ -78,7 +78,7 @@ export default function Validator({
     
     const NEARAsTokenWithMetadata = useSelector(selectNEARAsTokenWithMetadata);
 
-    const contractMetadataByContractId = useSelector(selectAllContractMetadata);
+    const contractMetadataByContractId = useSelector(selectContractsMetadata);
     const tokenFiatValues = useSelector(selectTokensFiatValueUSD);
     const tokenWhitelist = useSelector(selectTokenWhiteList);
     const currentAccountId = useSelector(selectStakingCurrentAccountAccountId);

--- a/packages/frontend/src/redux/createReducers/combinedMainReducers.js
+++ b/packages/frontend/src/redux/createReducers/combinedMainReducers.js
@@ -16,7 +16,6 @@ import nftSlice from '../slices/nft';
 import recoveryMethodsSlice from '../slices/recoveryMethods';
 import swapSlice from '../slices/swap';
 import tokenFiatValuesSlice from '../slices/tokenFiatValues';
-import tokensMetadataSlice from '../slices/tokensMetadata';
 import transactionsSlice from '../slices/transactions';
 
 export default (history) => ({
@@ -24,7 +23,6 @@ export default (history) => ({
     localize: localizeReducer,
     router: connectRouter(history),
     [tokenFiatValuesSlice.name]: tokenFiatValuesSlice.reducer,
-    [tokensMetadataSlice.name]: tokensMetadataSlice.reducer,
     // account reducers
     allAccounts,
     account,

--- a/packages/frontend/src/redux/createReducers/combinedMainReducers.js
+++ b/packages/frontend/src/redux/createReducers/combinedMainReducers.js
@@ -16,17 +16,22 @@ import nftSlice from '../slices/nft';
 import recoveryMethodsSlice from '../slices/recoveryMethods';
 import swapSlice from '../slices/swap';
 import tokenFiatValuesSlice from '../slices/tokenFiatValues';
+import tokensMetadataSlice from '../slices/tokensMetadata';
 import transactionsSlice from '../slices/transactions';
 
 export default (history) => ({
+    // shared reducers
     localize: localizeReducer,
+    router: connectRouter(history),
+    [tokenFiatValuesSlice.name]: tokenFiatValuesSlice.reducer,
+    [tokensMetadataSlice.name]: tokensMetadataSlice.reducer,
+    // account reducers
     allAccounts,
     account,
     sign,
     staking,
     status,
     [nftSlice.name]: nftSlice.reducer,
-    [tokenFiatValuesSlice.name]: tokenFiatValuesSlice.reducer,
     [linkdropSlice.name]: linkdropSlice.reducer,
     [transactionsSlice.name]: transactionsSlice.reducer,
     [flowLimitationSlice.name]: flowLimitationSlice.reducer,
@@ -35,6 +40,5 @@ export default (history) => ({
     [availableAccountsSlice.name]: availableAccountsSlice.reducer,
     [ledgerSlice.name]: ledgerSlice.reducer,
     [multiplierSlice.name]: multiplierSlice.reducer,
-    [swapSlice.name]: swapSlice.reducer,
-    router: connectRouter(history)
+    [swapSlice.name]: swapSlice.reducer
 });

--- a/packages/frontend/src/redux/createReducers/combinedSharedReducers.js
+++ b/packages/frontend/src/redux/createReducers/combinedSharedReducers.js
@@ -1,7 +1,9 @@
 import { combineReducers } from 'redux';
 
+import tokensMetadataSlice from '../slices/tokensMetadata';
 
 export default {
     shared: combineReducers({
+        [tokensMetadataSlice.name]: tokensMetadataSlice.reducer,
     })
 };

--- a/packages/frontend/src/redux/createReducers/combinedSharedReducers.js
+++ b/packages/frontend/src/redux/createReducers/combinedSharedReducers.js
@@ -1,0 +1,7 @@
+import { combineReducers } from 'redux';
+
+
+export default {
+    shared: combineReducers({
+    })
+};

--- a/packages/frontend/src/redux/createReducers/index.js
+++ b/packages/frontend/src/redux/createReducers/index.js
@@ -1,9 +1,11 @@
 import { combineReducers } from 'redux';
 
 import combinedMainReducers from './combinedMainReducers';
+import combinedSharedReducers from './combinedSharedReducers';
 import setupAccountReducer from './setupAccountReducer';
 
 export default (history) => combineReducers({
     ...combinedMainReducers(history),
+    ...combinedSharedReducers,
     ...setupAccountReducer()
 });

--- a/packages/frontend/src/redux/crossStateSelectors/selectCollectedAvailableForClaimData.js
+++ b/packages/frontend/src/redux/crossStateSelectors/selectCollectedAvailableForClaimData.js
@@ -7,7 +7,7 @@ import {
     selectTokensFiatValueUSD,
     selectTokenWhiteList,
 } from '../slices/tokenFiatValues';
-import { selectAllContractMetadata } from '../slices/tokens';
+import { selectContractsMetadata } from '../slices/tokensMetadata';
 
 const collectFarmingData = (args) => {
     try {
@@ -49,7 +49,7 @@ const collectFarmingData = (args) => {
 export default createSelector(
     [
         selectValidatorsFarmData,
-        selectAllContractMetadata,
+        selectContractsMetadata,
         selectTokensFiatValueUSD,
         selectTokenWhiteList,
         selectStakingCurrentAccountAccountId

--- a/packages/frontend/src/redux/selectors/topLevel.js
+++ b/packages/frontend/src/redux/selectors/topLevel.js
@@ -8,6 +8,8 @@ export const createParameterSelector = (selector) => (_, params) => selector(par
 
 const selectAccounts = (state) => state.accounts || {};
 
+const selectShared = (state) => state.shared || {};
+
 const selectAccountState = createSelector(
     [selectAccounts, selectActiveAccountId],
     (accounts, activeAccountId) => accounts[activeAccountId] || {}
@@ -16,4 +18,9 @@ const selectAccountState = createSelector(
 export const selectSliceByAccountId = (sliceName, initialState) => createSelector(
     selectAccountState, 
     (accountState) => accountState[sliceName] || initialState
+);
+
+export const selectSliceFromShared = (sliceName, initialState) => createSelector(
+    selectShared, 
+    (shared) => shared[sliceName] || initialState
 );

--- a/packages/frontend/src/redux/slices/tokensMetadata/index.js
+++ b/packages/frontend/src/redux/slices/tokensMetadata/index.js
@@ -3,7 +3,7 @@ import set from 'lodash.set';
 import { createSelector } from 'reselect';
 
 import FungibleTokens from '../../../services/FungibleTokens';
-import createParameterSelector from '../../selectors/mainSelectors/createParameterSelector';
+import { createParameterSelector } from '../../selectors/topLevel';
 
 const SLICE_NAME = 'tokensMetadata';
 
@@ -32,17 +32,12 @@ export const tokensMetadataSlice = createSlice({
 
 export default tokensMetadataSlice;
 
-export const actions = {
-    ...tokensMetadataSlice.actions
-};
-export const reducer = tokensMetadataSlice.reducer;
-
 // Top level selectors
 const selectTokensMetadataSlice = (state) => state[SLICE_NAME] || initialState;
 
 const getContractNameParam = createParameterSelector((params) => params.contractName);
 
-export const selectContractsMetadata = createSelector(selectTokensMetadataSlice, ({ byContractName }) => byContractName || {});
+export const selectContractsMetadata = createSelector(selectTokensMetadataSlice, ({ byContractName }) => byContractName);
 
 export const selectOneContractMetadata = createSelector(
     [selectContractsMetadata, getContractNameParam],

--- a/packages/frontend/src/redux/slices/tokensMetadata/index.js
+++ b/packages/frontend/src/redux/slices/tokensMetadata/index.js
@@ -3,7 +3,7 @@ import set from 'lodash.set';
 import { createSelector } from 'reselect';
 
 import FungibleTokens from '../../../services/FungibleTokens';
-import { createParameterSelector } from '../../selectors/topLevel';
+import { createParameterSelector, selectSliceFromShared } from '../../selectors/topLevel';
 
 const SLICE_NAME = 'tokensMetadata';
 
@@ -33,7 +33,7 @@ export const tokensMetadataSlice = createSlice({
 export default tokensMetadataSlice;
 
 // Top level selectors
-const selectTokensMetadataSlice = (state) => state.shared[SLICE_NAME] || initialState;
+const selectTokensMetadataSlice = selectSliceFromShared(SLICE_NAME, initialState);
 
 const getContractNameParam = createParameterSelector((params) => params.contractName);
 

--- a/packages/frontend/src/redux/slices/tokensMetadata/index.js
+++ b/packages/frontend/src/redux/slices/tokensMetadata/index.js
@@ -1,5 +1,9 @@
 import { createSlice } from '@reduxjs/toolkit';
 import set from 'lodash.set';
+import { createSelector } from 'reselect';
+
+import createParameterSelector from '../../selectors/mainSelectors/createParameterSelector';
+
 const SLICE_NAME = 'tokensMetadata';
 
 const initialState = {
@@ -15,3 +19,22 @@ export const tokensMetadataSlice = createSlice({
         }
     }
 });
+
+export default tokensMetadataSlice;
+
+export const actions = {
+    ...tokensMetadataSlice.actions
+};
+export const reducer = tokensMetadataSlice.reducer;
+
+// Top level selectors
+const selectTokensMetadataSlice = (state) => state[SLICE_NAME] || initialState;
+
+const getContractNameParam = createParameterSelector((params) => params.contractName);
+
+export const selectContractsMetadata = createSelector(selectTokensMetadataSlice, ({ byContractName }) => byContractName || {});
+
+export const selectOneContractMetadata = createSelector(
+    [selectContractsMetadata, getContractNameParam],
+    (metadataByContractName, contractName) => metadataByContractName[contractName]
+);

--- a/packages/frontend/src/redux/slices/tokensMetadata/index.js
+++ b/packages/frontend/src/redux/slices/tokensMetadata/index.js
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 import set from 'lodash.set';
 import { createSelector } from 'reselect';
 
+import FungibleTokens from '../../../services/FungibleTokens';
 import createParameterSelector from '../../selectors/mainSelectors/createParameterSelector';
 
 const SLICE_NAME = 'tokensMetadata';
@@ -9,6 +10,15 @@ const SLICE_NAME = 'tokensMetadata';
 const initialState = {
     byContractName: {}
 };
+
+export async function getCachedContractMetadataOrFetch(contractName, state) {
+    let contractMetadata = selectOneContractMetadata(state, { contractName });
+    if (contractMetadata) {
+        return contractMetadata;
+    }
+    return FungibleTokens.getMetadata({ contractName });
+}
+
 export const tokensMetadataSlice = createSlice({
     name: SLICE_NAME,
     initialState,

--- a/packages/frontend/src/redux/slices/tokensMetadata/index.js
+++ b/packages/frontend/src/redux/slices/tokensMetadata/index.js
@@ -33,7 +33,7 @@ export const tokensMetadataSlice = createSlice({
 export default tokensMetadataSlice;
 
 // Top level selectors
-const selectTokensMetadataSlice = (state) => state[SLICE_NAME] || initialState;
+const selectTokensMetadataSlice = (state) => state.shared[SLICE_NAME] || initialState;
 
 const getContractNameParam = createParameterSelector((params) => params.contractName);
 

--- a/packages/frontend/src/redux/slices/tokensMetadata/index.js
+++ b/packages/frontend/src/redux/slices/tokensMetadata/index.js
@@ -1,0 +1,13 @@
+import { createSlice } from '@reduxjs/toolkit';
+const SLICE_NAME = 'tokensMetadata';
+
+const initialState = {
+    byContractName: {}
+};
+
+export const tokensMetadataSlice = createSlice({
+    name: SLICE_NAME,
+    initialState,
+    reducers: {
+    }
+});

--- a/packages/frontend/src/redux/slices/tokensMetadata/index.js
+++ b/packages/frontend/src/redux/slices/tokensMetadata/index.js
@@ -1,13 +1,17 @@
 import { createSlice } from '@reduxjs/toolkit';
+import set from 'lodash.set';
 const SLICE_NAME = 'tokensMetadata';
 
 const initialState = {
     byContractName: {}
 };
-
 export const tokensMetadataSlice = createSlice({
     name: SLICE_NAME,
     initialState,
     reducers: {
+        setContractMetadata(state, { payload }) {
+            const { metadata, contractName } = payload;
+            set(state, ['byContractName', contractName], metadata);
+        }
     }
 });


### PR DESCRIPTION
The idea is to have two separate reducers:
1. `tokens` - that will be a part of account reducers
2. `tokensMetadata` - that will be shared between accounts.