### PR TITLE
WAL-215 Twilio Verify error handling

### DIFF
--- a/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -95,15 +95,15 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
     const handleResendCode = async () => {
         setResendCode('resending');
         await Mixpanel.withTracking('2FA Modal Resend code', 
-            async () => await dispatch(resendTwoFactor()),
+            async () => {
+                await dispatch(resendTwoFactor());
+                setResendCode('resent');
+                setTimeout(() => { setResendCode(); }, 3000);
+            },
             (e) => {
                 setResendCode();
                 throw e;
             },
-            () => {
-                setResendCode('resent');
-                setTimeout(() => { setResendCode(); }, 3000);
-            }
         );
     };
     

--- a/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -15,6 +15,8 @@ import Modal from '../../common/modal/Modal';
 import ModalTheme from '../ledger/ModalTheme';
 import TwoFactorVerifyInput from './TwoFactorVerifyInput';
 
+const TOO_MANY_REQUESTS_STATUS = 429;
+
 const Form = styled.form`
     display: flex;
     flex-direction: column;
@@ -101,7 +103,12 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
                 setTimeout(() => { setResendCode(); }, 3000);
             },
             (e) => {
-                setResendCode();
+                if (e.status === TOO_MANY_REQUESTS_STATUS) {
+                    onClose(false, e);
+                } else {
+                    setResendCode();
+                }
+
                 throw e;
             },
         );

--- a/packages/frontend/src/components/login/v2/ConfirmLoginWrapper.js
+++ b/packages/frontend/src/components/login/v2/ConfirmLoginWrapper.js
@@ -3,7 +3,6 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import { Mixpanel } from '../../../mixpanel/index';
 import { allowLogin } from '../../../redux/actions/account';
-import { showCustomAlert } from '../../../redux/actions/status';
 import {
     selectAccountLocalStorageAccountId,
     selectAccountUrlReferrer
@@ -33,20 +32,7 @@ export default ({
             publicKey={publicKey}
             contractId={contractId}
             onClickCancel={onClickCancel}
-            onClickConnect={async () => {
-                await Mixpanel.withTracking('LOGIN',
-                    async () => {
-                        await dispatch(allowLogin());
-                    },
-                    (e) => {
-                        dispatch(showCustomAlert({
-                            success: false,
-                            messageCodeHeader: 'error',
-                            errorMessage: e.message
-                        }));
-                    }
-                );
-            }}
+            onClickConnect={() => Mixpanel.withTracking('LOGIN', () => dispatch(allowLogin()))}
             contractIdUrl={contractIdUrl}
             successUrlIsValid={successUrlIsValid}
         />

--- a/packages/frontend/src/redux/actions/account.js
+++ b/packages/frontend/src/redux/actions/account.js
@@ -304,7 +304,7 @@ export const {
     ],
     DISABLE_MULTISIG: [
         (...args) => twoFactorMethod('disableMultisig', wallet, args),
-        () => ({})
+        () => showAlert()
     ],
     CHECK_CAN_ENABLE_TWO_FACTOR: [
         (...args) => TwoFactor.checkCanEnableTwoFactor(...args),


### PR DESCRIPTION
Twilio Verify has several different rate limits which do not exist with the current SMS delivery service. This introduces new user error states which now need to be handled. These 2FA rate limits users are likely to encounter are:
* User has sent/resent the code too many times
* User has incorrectly verified the code too many times
* A pending verification was left for an extended period and expired

This PR will surface these error messages to the user via `<GlobalAlert />` and also close the 2FA modal preventing any further rate limited verifications/resends. From here, new transactions will be blocked until the rate limit has subsided (usually ~10mins).
