### PR TITLE
fix(sign): Prevent runtime error on failed sign tx

### DIFF
--- a/packages/frontend/src/redux/reducers/sign/index.js
+++ b/packages/frontend/src/redux/reducers/sign/index.js
@@ -6,7 +6,8 @@ import { parseTransactionsToSign, makeAccountActive } from '../../actions/accoun
 import { calculateGasLimit, increaseGasForFirstTransaction, handleSignTransactions, SIGN_STATUS, removeSuccessTransactions, updateSuccessHashes, checkAbleToIncreaseGas, getFirstTransactionWithFunctionCallAction, calculateGasForSuccessTransactions } from '../../slices/sign';
 
 const initialState = {
-    status: SIGN_STATUS.NEEDS_CONFIRMATION
+    status: SIGN_STATUS.NEEDS_CONFIRMATION,
+    successHashes: []
 };
 
 const deserializeTransactionsFromString = (transactionsString) => transactionsString.split(',')
@@ -20,6 +21,7 @@ const sign = handleActions({
         const allActions = transactions.flatMap((t) => t.actions);
         
         return {
+            ...initialState,
             status: SIGN_STATUS.NEEDS_CONFIRMATION,
             callbackUrl,
             meta,


### PR DESCRIPTION
When a user has 2FA enabled and gets rate limited by Twilio the sign request fails with no successful transactions, making `successHashes` `undefined`. This PR defaults `successHashes` to an empty array to prevent some of the down stream logic which assume it exists from failing:

![image](https://user-images.githubusercontent.com/11974624/160739080-ae11c922-86bd-4dff-84b3-6e824f4edf75.png)
