### PR TITLE
feat: added video to show up on the NFT detail screen

### DIFF
--- a/packages/frontend/src/components/nft/NFTDetail.js
+++ b/packages/frontend/src/components/nft/NFTDetail.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Translate } from 'react-localize-redux';
 import styled from 'styled-components';
 
+import FailedToLoad from '../../images/failed_to_load.svg';
 import UserIconGrey from '../../images/UserIconGrey';
 import { NFT_TRANSFER_DEPOSIT, NFT_TRANSFER_GAS } from '../../services/NonFungibleTokens';
 import BackArrowButton from '../common/BackArrowButton';
@@ -15,7 +16,7 @@ const StyledContainer = styled(Container)`
         max-width: 429px;
         position: relative;
 
-        img {
+        video,img {
             width: 100%;
             max-width: 429px;
             margin-bottom: 83px;
@@ -110,6 +111,7 @@ const UserIcon = styled.div`
 export function NFTDetail({ nft, accountId, nearBalance, ownerId, history }) {
     const [transferNftDetail, setTransferNftDetail] = useState();
     const hasSufficientBalance = nearBalance >= NFT_TRANSFER_DEPOSIT + NFT_TRANSFER_GAS;
+    const isVideo = !!nft.metadata.mediaUrl && nft.metadata.mediaUrl.match(/\.webm$/i);
 
     return (
         <StyledContainer className='medium centered'>
@@ -122,7 +124,22 @@ export function NFTDetail({ nft, accountId, nearBalance, ownerId, history }) {
                 >
                 </BackArrowButton>
 
-                <img src={nft.metadata.mediaUrl} alt='NFT'/>
+                {isVideo && (
+                    <video muted={true} loop controls>
+                        <source
+                            src={nft.metadata.mediaUrl}
+                            type="video/webm"
+                            onError={(e) => {
+                                e.target.onerror = null;
+                                e.target.parentElement.setAttribute(
+                                    'poster',
+                                    FailedToLoad
+                                );
+                            }}
+                        />
+                    </video>
+                )}
+                {!isVideo && <img src={nft.metadata.mediaUrl} alt='NFT'/>}
                 <h1 className="title">{nft.metadata.title}</h1>
                 <p className="desc">{nft.metadata.description}</p>
 

--- a/packages/frontend/src/components/nft/NFTDetail.js
+++ b/packages/frontend/src/components/nft/NFTDetail.js
@@ -2,13 +2,13 @@ import React, { useState } from 'react';
 import { Translate } from 'react-localize-redux';
 import styled from 'styled-components';
 
-import FailedToLoad from '../../images/failed_to_load.svg';
 import UserIconGrey from '../../images/UserIconGrey';
 import { NFT_TRANSFER_DEPOSIT, NFT_TRANSFER_GAS } from '../../services/NonFungibleTokens';
 import BackArrowButton from '../common/BackArrowButton';
 import FormButton from '../common/FormButton';
 import Container from '../common/styled/Container.css';
 import SendIcon from '../svg/SendIcon';
+import { NFTMedia } from './NFTMedia';
 import NFTTransferModal from './NFTTransferModal';
 
 const StyledContainer = styled(Container)`
@@ -111,8 +111,7 @@ const UserIcon = styled.div`
 export function NFTDetail({ nft, accountId, nearBalance, ownerId, history }) {
     const [transferNftDetail, setTransferNftDetail] = useState();
     const hasSufficientBalance = nearBalance >= NFT_TRANSFER_DEPOSIT + NFT_TRANSFER_GAS;
-    const isVideo = !!nft.metadata.mediaUrl && nft.metadata.mediaUrl.match(/\.webm$/i);
-
+    
     return (
         <StyledContainer className='medium centered'>
           {
@@ -124,22 +123,8 @@ export function NFTDetail({ nft, accountId, nearBalance, ownerId, history }) {
                 >
                 </BackArrowButton>
 
-                {isVideo && (
-                    <video muted={true} loop controls>
-                        <source
-                            src={nft.metadata.mediaUrl}
-                            type="video/webm"
-                            onError={(e) => {
-                                e.target.onerror = null;
-                                e.target.parentElement.setAttribute(
-                                    'poster',
-                                    FailedToLoad
-                                );
-                            }}
-                        />
-                    </video>
-                )}
-                {!isVideo && <img src={nft.metadata.mediaUrl} alt='NFT'/>}
+                <NFTMedia mediaUrl={nft.metadata.mediaUrl}/>
+
                 <h1 className="title">{nft.metadata.title}</h1>
                 <p className="desc">{nft.metadata.description}</p>
 

--- a/packages/frontend/src/components/nft/NFTMedia.js
+++ b/packages/frontend/src/components/nft/NFTMedia.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import FailedToLoad from '../../images/failed_to_load.svg';
+
+export function NFTMedia({ mediaUrl, autoPlay = false }) {
+    const isVideo = !!mediaUrl && mediaUrl.match(/\.webm$/i);
+
+    return (
+        <>
+            {isVideo ? (
+                <video muted={true} loop controls autoPlay={autoPlay}>
+                    <source
+                        src={mediaUrl}
+                        type="video/webm"
+                        onError={(e) => {
+                            e.target.onerror = null;
+                            e.target.parentElement.setAttribute(
+                                'poster',
+                                FailedToLoad
+                            );
+                        }}
+                    />
+                </video>
+            ) : (
+                <img
+                    alt="NFT"
+                    src={mediaUrl}
+                    onError={(e) => {
+                        e.target.onerror = null;
+                        e.target.src = FailedToLoad;
+                    }}
+                />
+            )}
+        </>
+    );
+}

--- a/packages/frontend/src/components/wallet/NFTBox.js
+++ b/packages/frontend/src/components/wallet/NFTBox.js
@@ -3,12 +3,11 @@ import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 
 import { EXPLORER_URL } from '../../config';
-import FailedToLoad from '../../images/failed_to_load.svg';
 import { redirectTo } from '../../redux/actions/account';
 import isDataURL from '../../utils/isDataURL';
+import {NFTMedia} from '../nft/NFTMedia';
 import DefaultTokenIcon from '../svg/DefaultTokenIcon';
 import LoadMoreButtonWrapper from './LoadMoreButtonWrapper';
-
 const StyledContainer = styled.div`
     display: flex;
     justify-content: flex-start;
@@ -153,28 +152,10 @@ const NFTBox = ({ tokenDetails }) => {
                 ownedTokensMetadata &&
                 <div className='tokens'>
                     {ownedTokensMetadata.map(({ token_id, metadata: { mediaUrl, title } }, index) => {
-                        const videoProps = index === 0 ? { autoPlay: true } : {};
-                        const isVideo = !!mediaUrl && mediaUrl.match(/\.webm$/i);
                         return (
                             <div className='nft' key={token_id}
                                 onClick={() => dispatch(redirectTo(`/nft-detail/${contractName}/${token_id}`))}>
-                                {isVideo && (
-                                    <video muted={true} loop controls { ...videoProps }>
-                                        <source src={mediaUrl} type="video/webm" onError={(e) => {
-                                            e.target.onerror = null;
-                                            e.target.parentElement.setAttribute('poster', FailedToLoad);
-                                        }}/>
-                                    </video>
-                                )}
-                                {!isVideo && (
-                                    <img src={mediaUrl}
-                                         alt='NFT'
-                                         onError={(e) => {
-                                             e.target.onerror = null;
-                                             e.target.src = FailedToLoad;
-                                         }}
-                                    />
-                                )}
+                                    <NFTMedia mediaUrl={mediaUrl} autoPlay={ index === 0}/>
                                 <b className='title'>{title}</b>
                             </div>
                         );


### PR DESCRIPTION
Users are unable to see their video NFTs on the NFT-detail screen when they click their NFTs. Video NFTs are not supported. 

### What Changed? 
- Users are able to video and regular image NFTs in the NFT details tab. 

| Before   |      After      |
|----------|:-------------:|
| ![Before](https://user-images.githubusercontent.com/25015977/160926699-acbc309d-043d-4b83-97b2-da5d4d3ff2e7.gif) | ![After](https://user-images.githubusercontent.com/25015977/160926716-119cf1a5-bc9d-4942-a285-ae183da9086d.gif) |

## Image NFTs show up as normal 

| Collectible Screen   |      NFT Detail Screen      |
|----------|:-------------:|
| <img width="648" alt="image" src="https://user-images.githubusercontent.com/25015977/160928198-04692767-f6ed-41be-9649-6648ed2b8b7b.png"> | <img width="625" alt="image" src="https://user-images.githubusercontent.com/25015977/160928237-5ea64709-dbdf-412d-bc13-1b31f4b723ea.png">|


