### PR TITLE
fix(env): more descriptive environment error

### DIFF
--- a/packages/feature-flags/src/index.js
+++ b/packages/feature-flags/src/index.js
@@ -4,7 +4,10 @@ function initFeatureFlags({ flagState, currentEnvironment, environments }) {
     }
 
     if (!Object.values(environments).includes(currentEnvironment)) {
-        throw Error(`invalid environment: "${currentEnvironment}"`);
+        throw Error(`
+invalid environment "${currentEnvironment}", the NEAR_WALLET_ENV environment variable must be set to one of:
+${Object.values(environments).join(', ')}
+        `);
     }
 
     return new Proxy(flagState, {


### PR DESCRIPTION
This PR expands the "no environment set" error message to provide more context and enumerate the set of valid environments (values for `NEAR_WALLET_ENV` env var).

Closes #2564 