### PR TITLE
feat: added additional permission to LAK login display

### DIFF
--- a/packages/frontend/src/components/login/v2/ConfirmLogin.js
+++ b/packages/frontend/src/components/login/v2/ConfirmLogin.js
@@ -111,6 +111,7 @@ const LimitedAccessUI = () => (
     <>
         <PermissionItem translateId='login.v2.connectConfirm.permissions.viewAddress' />
         <PermissionItem translateId='login.v2.connectConfirm.permissions.viewBalance' />
+        <PermissionItem translateId='login.v2.connectConfirm.permissions.callMethodsOnContract' />
         <PermissionItem permitted={false} translateId='login.v2.connectConfirm.permissions.notTransferTokens' />
     </>
 );

--- a/packages/frontend/src/components/login/v2/PermissionItem.js
+++ b/packages/frontend/src/components/login/v2/PermissionItem.js
@@ -11,6 +11,7 @@ const StyledContainer = styled.div`
     > div {
         margin-right: 15px;
         width: 32px;
+        min-width: 32px;
         height: 32px;
         background-color: #F0F0F1;
         border-radius: 50%;

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -645,7 +645,8 @@
                     "notTransferTokens": "This does not allow the app to transfer tokens",
                     "transferTokens": "Transfer tokens from your account",
                     "viewAddress": "View the address of your permitted account",
-                    "viewBalance": "View the balance of your permitted account"
+                    "viewBalance": "View the balance of your permitted account",
+                    "callMethodsOnContract": "Call methods on the smart contract on behalf of your permitted account"
                 },
                 "title": "Connecting with:"
             },


### PR DESCRIPTION
This PR adresses concerns in and closes #2567 :
* Adds a new permission display regarding the ability to call methods on the contract


<img width="300" alt="image" src="https://user-images.githubusercontent.com/5849204/162056108-e44ce358-1706-4813-96c2-2def5ebae494.png">
