### PR TITLE
fix: Fix button margin on ledger pages

### DIFF
--- a/packages/frontend/src/components/common/styled/Container.css.js
+++ b/packages/frontend/src/components/common/styled/Container.css.js
@@ -89,26 +89,19 @@ const Container = styled.div`
             margin: 20px 0;
         }
 
-        button {
-
-            &.link {
+        &&& {
+            button {
                 margin-top: 25px;
-            }
-
-            &.link {
-                &.gray {
-                    margin-top: 25px !important;
+    
+                &.blue {
+                    width: 100%;
                 }
-            }
-
-            &.blue {
-                width: 100% !important;
-            }
-
-            &.remove-all-keys {
-                min-height: 56px;
-                height: auto;
-                line-height: 140%;
+    
+                &.remove-all-keys {
+                    min-height: 56px;
+                    height: auto;
+                    line-height: 140%;
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes lack of spacing between buttons in the ledger sign in page

<img width="596" alt="Screen Shot 2022-04-15 at 1 23 08 PM" src="https://user-images.githubusercontent.com/24921205/163628604-b17132c1-0f0f-4ee4-bd7d-fda902529b09.png">

<img width="620" alt="Screen Shot 2022-04-15 at 1 24 24 PM" src="https://user-images.githubusercontent.com/24921205/163628693-5ed328de-fe16-49a4-b543-7a166488e731.png">

