### PR TITLE
fix: show NEAR symbol when flag off

### DIFF
--- a/packages/frontend/src/components/wallet/TokenBox.js
+++ b/packages/frontend/src/components/wallet/TokenBox.js
@@ -212,14 +212,14 @@ const TokenBox = ({ token, onClick, currentLanguage }) => {
                             amount={token.balance}
                             data-test-id='walletHomeNearBalance'
                             symbol={false}
-                            showSymbolNEAR={false}
+                            showSymbolNEAR={!CREATE_USN_CONTRACT}
                         />
                     </div>
                 ) : (
                     <TokenAmount
                         token={token}
                         className={token.onChainFTMetadata?.symbol  !== 'USN' && CREATE_USN_CONTRACT ? 'balance tokenAmount':'balance'}
-                        withSymbol={!CREATE_USN_CONTRACT}
+                        withSymbol={token.onChainFTMetadata?.symbol !== 'USN' || !CREATE_USN_CONTRACT}
                     />
                 )}
                 {!onClick && CREATE_USN_CONTRACT &&


### PR DESCRIPTION
Show `NEAR` and token symbols correctly depending on feature flags