### PR TITLE
Branch for testing staking with farm validators using lockups

### DIFF
--- a/packages/frontend/src/config/environmentDefaults/testnet.js
+++ b/packages/frontend/src/config/environmentDefaults/testnet.js
@@ -17,7 +17,7 @@ export default {
     EXPLORER_URL: 'https://explorer.testnet.near.org',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
     LINKDROP_GAS: '100000000000000',
-    LOCKUP_ACCOUNT_ID_SUFFIX: 'lockup.m0',
+    LOCKUP_ACCOUNT_ID_SUFFIX: 'lockup.devnet',
     MIN_BALANCE_FOR_GAS: nearApiJs.utils.format.parseNearAmount('0.05'),
     MIN_BALANCE_TO_CREATE: nearApiJs.utils.format.parseNearAmount('0.1'),
     MOONPAY_API_KEY: 'pk_test_wQDTsWBsvUm7cPiz9XowdtNeL5xasP9',


### PR DESCRIPTION
Branch for testing staking with farm validators using lockups:

1. Create an account on the [render pull request preview](https://near-wallet-pr-2588.onrender.com/)
2. Deploy a lockup to that account using https://testnet.lockup.tech/, (change `wallet.testnet.near.org` to `near-wallet-pr-2588.onrender.com` when logging in and signing transactions)
3. Stake with one of the following validators:
      [zentriav2.factory.colorpalette.testnet](https://near-wallet-pr-2588.onrender.com/staking/zentriav2.factory.colorpalette.testnet)
[domanodes.factory.colorpalette.testnet](https://near-wallet-pr-2588.onrender.com/staking/domanodes.factory.colorpalette.testnet)