### PR TITLE
fix: fiat selector and text align

### DIFF
--- a/packages/frontend/src/components/wallet/TokenBox.js
+++ b/packages/frontend/src/components/wallet/TokenBox.js
@@ -162,7 +162,7 @@ const TokenBox = ({ token, onClick, currentLanguage }) => {
             className='token-box'
             onClick={onClick ? () => onClick(token) : null}
             data-test-id={`token-selection-${token.contractName || 'NEAR'}`}
-            IS_USN={CREATE_USN_CONTRACT}
+            IS_USN={CREATE_USN_CONTRACT && token.onChainFTMetadata?.symbol === 'NEAR' || token.onChainFTMetadata?.symbol === 'USN'}
         >
             <div style={{ display: 'flex', width: '100%' }}>
                 <div className='icon'>

--- a/packages/frontend/src/hooks/fungibleTokensIncludingNEAR.js
+++ b/packages/frontend/src/hooks/fungibleTokensIncludingNEAR.js
@@ -15,7 +15,7 @@ export const useFungibleTokensIncludingNEAR = function () {
     const fungibleTokenPrices = useSelector(selectTokensFiatValueUSD);
     const fungibleTokensWithPrices = fungibleTokens.map((ft) => ({
         ...ft,
-        fiatValueMetadata: ft.fiatValueMetadata || {...fungibleTokenPrices[ft.contractName]}
+        fiatValueMetadata: ft.fiatValueMetadata?.usd ? ft.fiatValueMetadata : {...fungibleTokenPrices[ft.contractName]}
     }));
 
     return [NEARAsTokenWithMetadata, ...fungibleTokensWithPrices];


### PR DESCRIPTION
- Fix the fallback logic on the fiat value selector to only fallback when fiat data actually exists
- Fix the conditional text alignment on the token list component