### PR TITLE
fix: fallback to string if args cannot be parsed as JSON

### DIFF
--- a/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -26,12 +26,17 @@ const Form = styled.form`
 
 const StyledBannerContainer = styled.div`
     &&& {
+        width: 100%;
+
         div:first-child {
             margin: 0px;
-            width: 100%;
             word-break: break-word;
             @media (max-width: 450px) {
                  border-radius: 4px;
+            }
+
+            > div {
+                overflow: auto;
             }
         }
 


### PR DESCRIPTION
Fixes: #2597

When the `FunctionCall` args is not JSON, display the raw base64 string, so it won't break the user workflow when the contract is `aurora`.

Please give this high priority if possible, so it won't stop the release of some important features of Ref Finance. 