### PR TITLE
fix: support ipfs:// base_uri

### DIFF
--- a/packages/frontend/src/services/NonFungibleTokens.js
+++ b/packages/frontend/src/services/NonFungibleTokens.js
@@ -99,7 +99,7 @@ export default class NonFungibleTokens {
             return media;
         }
 
-        if (base_uri) {
+        if (base_uri && base_uri != 'ipfs://') {
             return `${base_uri}/${media}`;
         }
 


### PR DESCRIPTION
I don't really understand, is it useful or not.
I think base_uri may be equal to ipfs:// 