### PR TITLE
fix: key farmRewards by accountId

### DIFF
--- a/packages/frontend/src/components/staking/StakingContainer.js
+++ b/packages/frontend/src/components/staking/StakingContainer.js
@@ -214,7 +214,7 @@ export function StakingContainer({ history, match }) {
         
         validators
             .filter((validator) => validator.version === FARMING_VALIDATOR_VERSION)
-            .forEach((validator) => dispatch(getValidatorFarmData(validator, currentAccount.accountId)));
+            .forEach((validator) => dispatch(getValidatorFarmData({ validator, accountId: currentAccount.accountId })));
     }, [currentAccount.accountId, validators]);
 
     const handleAction = async (action, validator, amount) => {

--- a/packages/frontend/src/components/staking/StakingContainer.js
+++ b/packages/frontend/src/components/staking/StakingContainer.js
@@ -210,7 +210,7 @@ export function StakingContainer({ history, match }) {
     };
 
     useEffect(() => {
-        if (!accountId || !validators.length) return;
+        if (!currentAccount.accountId || !validators.length) return;
         
         validators
             .filter((validator) => validator.version === FARMING_VALIDATOR_VERSION)

--- a/packages/frontend/src/components/staking/StakingContainer.js
+++ b/packages/frontend/src/components/staking/StakingContainer.js
@@ -214,8 +214,8 @@ export function StakingContainer({ history, match }) {
         
         validators
             .filter((validator) => validator.version === FARMING_VALIDATOR_VERSION)
-            .forEach((validator) => dispatch(getValidatorFarmData(validator, accountId)));
-    }, [accountId, validators]);
+            .forEach((validator) => dispatch(getValidatorFarmData(validator, currentAccount.accountId)));
+    }, [currentAccount, validators]);
 
     const handleAction = async (action, validator, amount) => {
         let id = Mixpanel.get_distinct_id();

--- a/packages/frontend/src/components/staking/StakingContainer.js
+++ b/packages/frontend/src/components/staking/StakingContainer.js
@@ -215,7 +215,7 @@ export function StakingContainer({ history, match }) {
         validators
             .filter((validator) => validator.version === FARMING_VALIDATOR_VERSION)
             .forEach((validator) => dispatch(getValidatorFarmData(validator, currentAccount.accountId)));
-    }, [currentAccount, validators]);
+    }, [currentAccount.accountId, validators]);
 
     const handleAction = async (action, validator, amount) => {
         let id = Mixpanel.get_distinct_id();

--- a/packages/frontend/src/components/staking/components/BalanceBox.js
+++ b/packages/frontend/src/components/staking/components/BalanceBox.js
@@ -124,7 +124,7 @@ export default function BalanceBox({
                     <div className='title'>
                         {title && <Translate id={title}/>}
                         {info && <Tooltip translate={info}/>}
-                        {loading && <span className="animated-dots" style={{width: 16}}/>}
+                        {loading && <span className="animated-dots" />}
                     </div>
                 }
                 <div className='token-balance'>

--- a/packages/frontend/src/components/staking/components/BalanceBox.js
+++ b/packages/frontend/src/components/staking/components/BalanceBox.js
@@ -124,6 +124,7 @@ export default function BalanceBox({
                     <div className='title'>
                         {title && <Translate id={title}/>}
                         {info && <Tooltip translate={info}/>}
+                        {loading && <span className="animated-dots" style={{width: 16}}/>}
                     </div>
                 }
                 <div className='token-balance'>

--- a/packages/frontend/src/components/staking/components/Staking.js
+++ b/packages/frontend/src/components/staking/components/Staking.js
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 
 import selectCollectedAvailableForClaimData from '../../../redux/crossStateSelectors/selectCollectedAvailableForClaimData';
 import selectNEARAsTokenWithMetadata from '../../../redux/selectors/crossStateSelectors/selectNEARAsTokenWithMetadata';
+import { selectFarmValidatorDataIsLoading } from '../../../redux/slices/staking';
 import FormButton from '../../common/FormButton';
 import SkeletonLoading from '../../common/SkeletonLoading';
 import Tooltip from '../../common/Tooltip';
@@ -32,6 +33,7 @@ export default function Staking({
 }) {
     const NEARAsTokenWithMetadata = useSelector(selectNEARAsTokenWithMetadata);
     const collectedFarmData = useSelector(selectCollectedAvailableForClaimData);
+    const farmValidatorDataIsLoading = useSelector(selectFarmValidatorDataIsLoading);
     return (
         <>
             <h1><Translate id='staking.staking.title' /></h1>
@@ -123,6 +125,7 @@ export default function Staking({
                         }}
                         button="staking.balanceBox.farm.button"
                         hideBorder={collectedFarmData.length > 1 && i < (collectedFarmData.length - 1)}
+                        loading={farmValidatorDataIsLoading}
                 />
                 );
             })}

--- a/packages/frontend/src/components/staking/components/Validator.js
+++ b/packages/frontend/src/components/staking/components/Validator.js
@@ -147,7 +147,7 @@ export default function Validator({
         dispatch(getValidatorFarmData(validator, currentAccountId));
     }, [validator, currentAccountId]);
 
-    const farmList = validatorFarmData?.farmRewards || [];
+    const farmList = validatorFarmData?.farmRewards?.[currentAccountId] || [];
     const tokenPriceMetadata = { tokenFiatValues, tokenWhitelist };
     const hasUnwhitelistedTokens = useMemo(
         () =>

--- a/packages/frontend/src/components/staking/components/Validator.js
+++ b/packages/frontend/src/components/staking/components/Validator.js
@@ -144,7 +144,7 @@ export default function Validator({
     const validatorFarmData = validatorsFarmData[validator?.accountId] || {};
 
     useEffect(() => {
-        dispatch(getValidatorFarmData(validator, currentAccountId));
+        dispatch(getValidatorFarmData({ validator, accountId: currentAccountId }));
     }, [validator, currentAccountId]);
 
     const farmList = validatorFarmData?.farmRewards?.[currentAccountId] || [];

--- a/packages/frontend/src/redux/actions/staking.js
+++ b/packages/frontend/src/redux/actions/staking.js
@@ -574,7 +574,7 @@ export const getValidatorFarmData = (validator, accountId) => async (dispatch, g
 
     const farmData = {
         poolSummary: {...poolSummary},
-        farmRewards: farmList,
+        farmRewards: {[accountId]: farmList},
     };
     await dispatch(staking.setValidatorFarmData(validator.accountId, farmData));
 };

--- a/packages/frontend/src/redux/actions/staking.js
+++ b/packages/frontend/src/redux/actions/staking.js
@@ -551,7 +551,7 @@ export const handleUpdateCurrent = (accountId) => async (dispatch, getState) => 
     dispatch(staking.updateCurrent({ currentAccount }));
 };
 
-export const getValidatorFarmData = createAsyncThunk('staking/setValidatorFarmData', async ({ validator, accountId }, { dispatch }) => {
+export const getValidatorFarmData = createAsyncThunk('staking/getValidatorFarmData', async ({ validator, accountId }, { dispatch }) => {
     if (validator?.version !== FARMING_VALIDATOR_VERSION || !accountId) return;
 
     const poolSummary = await validator.contract.get_pool_summary();

--- a/packages/frontend/src/redux/actions/staking.js
+++ b/packages/frontend/src/redux/actions/staking.js
@@ -1,3 +1,4 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
 import BN from 'bn.js';
 import * as nearApiJs from 'near-api-js';
 import { createActions } from 'redux-actions';
@@ -436,10 +437,7 @@ export const { staking } = createActions({
                     }
                 })
             )).filter((v) => !!v);
-        },
-        SET_VALIDATOR_FARM_DATA: (validatorId, farmData) => {
-            return {validatorId, farmData};
-        },
+        }
     }
 });
 
@@ -553,8 +551,7 @@ export const handleUpdateCurrent = (accountId) => async (dispatch, getState) => 
     dispatch(staking.updateCurrent({ currentAccount }));
 };
 
-export const getValidatorFarmData = (validator, accountId) => async (dispatch, getState) => {
-
+export const getValidatorFarmData = createAsyncThunk('staking/setValidatorFarmData', async ({ validator, accountId }, { dispatch }) => {
     if (validator?.version !== FARMING_VALIDATOR_VERSION || !accountId) return;
 
     const poolSummary = await validator.contract.get_pool_summary();
@@ -576,8 +573,12 @@ export const getValidatorFarmData = (validator, accountId) => async (dispatch, g
         poolSummary: {...poolSummary},
         farmRewards: {[accountId]: farmList},
     };
-    await dispatch(staking.setValidatorFarmData(validator.accountId, farmData));
-};
+
+    return {
+        validatorId: validator.accountId,
+        farmData
+    };
+});
 
 export const claimFarmRewards = (validatorId, token_id) => async (dispatch, getState) => {
     try {

--- a/packages/frontend/src/redux/crossStateSelectors/selectCollectedAvailableForClaimData.js
+++ b/packages/frontend/src/redux/crossStateSelectors/selectCollectedAvailableForClaimData.js
@@ -2,7 +2,7 @@ import BN from 'bn.js';
 import { isEmpty, some } from 'lodash';
 import { createSelector } from 'reselect';
 
-import { selectValidatorsFarmData } from '../slices/staking';
+import { selectStakingCurrentAccountAccountId, selectValidatorsFarmData } from '../slices/staking';
 import {
     selectTokensFiatValueUSD,
     selectTokenWhiteList,
@@ -18,9 +18,10 @@ const collectFarmingData = (args) => {
             contractMetadataByContractId,
             tokenFiatValues,
             tokenWhitelist,
+            accountId
         } = args;
         const filteredFarms = Object.values(validatorsFarmData)
-            .reduce((acc, {farmRewards}) => [...acc, ...farmRewards], []);
+            .reduce((acc, {farmRewards}) => [...acc, ...(farmRewards?.[accountId] || [])], []);
 
         const collectedBalance = filteredFarms.reduce((acc, farm) => ({
             ...acc,
@@ -51,18 +52,21 @@ export default createSelector(
         selectAllContractMetadata,
         selectTokensFiatValueUSD,
         selectTokenWhiteList,
+        selectStakingCurrentAccountAccountId
     ],
     (
         validatorsFarmData,
         contractMetadataByContractId,
         tokenFiatValues,
-        tokenWhitelist
+        tokenWhitelist,
+        accountId
     ) => {
         return collectFarmingData({
             validatorsFarmData,
             contractMetadataByContractId,
             tokenFiatValues,
-            tokenWhitelist
+            tokenWhitelist,
+            accountId
         });
     }
 );

--- a/packages/frontend/src/redux/reducers/staking/index.js
+++ b/packages/frontend/src/redux/reducers/staking/index.js
@@ -3,7 +3,7 @@ import { handleActions } from 'redux-actions';
 
 import { ACCOUNT_DEFAULTS } from '../../../utils/staking';
 import { clearAccountState } from '../../actions/account';
-import { staking } from '../../actions/staking';
+import { getValidatorFarmData, staking } from '../../actions/staking';
 
 // sample validator entry
 // const validator = {
@@ -77,7 +77,17 @@ const stakingHandlers = handleActions({
                 ...state,
                 allValidators: payload
             }),
-    [staking.setValidatorFarmData]: (state, { payload }) => ({
+    [getValidatorFarmData.pending]: (state, { meta: { arg: { validator } } }) => ({
+        ...state,
+        farmingValidators: {
+            ...state.farmingValidators,
+            [validator.accountId]: {
+                ...state.farmingValidators?.[validator.accountId],
+                loading: true
+            },
+        }
+    }),
+    [getValidatorFarmData.fulfilled]: (state, { payload }) => ({
         ...state,
         farmingValidators: {
             ...state.farmingValidators,
@@ -87,7 +97,18 @@ const stakingHandlers = handleActions({
                     ...state.farmingValidators?.[payload.validatorId]
                         ?.farmRewards,
                     ...payload.farmData.farmRewards,
-                }
+                },
+                loading: false
+            },
+        }
+    }),
+    [getValidatorFarmData.rejected]: (state, { meta: { arg: { validator } } }) => ({
+        ...state,
+        farmingValidators: {
+            ...state.farmingValidators,
+            [validator.accountId]: {
+                ...state.farmingValidators?.[validator.accountId],
+                loading: false
             },
         }
     }),

--- a/packages/frontend/src/redux/reducers/staking/index.js
+++ b/packages/frontend/src/redux/reducers/staking/index.js
@@ -82,7 +82,12 @@ const stakingHandlers = handleActions({
         farmingValidators: {
             ...state.farmingValidators,
             [payload.validatorId]: {
-                ...payload.farmData
+                ...payload.farmData,
+                farmRewards: {
+                    ...state.farmingValidators?.[payload.validatorId]
+                        ?.farmRewards,
+                    ...payload.farmData.farmRewards,
+                }
             },
         }
     }),

--- a/packages/frontend/src/redux/slices/staking/index.js
+++ b/packages/frontend/src/redux/slices/staking/index.js
@@ -69,3 +69,9 @@ export const selectFarmValidatorAPY = createSelector(
         return calculateAPY(farmData.poolSummary, tokenPrices);
     }
 );
+
+export const selectFarmValidatorDataIsLoading = createSelector(
+    selectValidatorsFarmData,
+    (farmingValidators) =>
+        Object.values(farmingValidators).some(({ loading }) => loading)
+);


### PR DESCRIPTION
Bug fix to correctly display accumulated farm rewards for lockup accounts as well as main account when the radio toggle is visible. Also refetch unclaimed rewards when the selected account changes to a lockup account on the staking dashboard.

This can be tested by deploying a lockup using https://testnet.lockup.tech/ on the deploy preview

cc: @askulikov 

<img src="https://user-images.githubusercontent.com/5849204/165350709-fe7037f7-08db-4f27-bc13-c08d96fa05b9.png" width="350"/>

