### PR TITLE
fix: styling in USN token box

### DIFF
--- a/packages/frontend/src/components/wallet/TokenBox.js
+++ b/packages/frontend/src/components/wallet/TokenBox.js
@@ -162,7 +162,7 @@ const TokenBox = ({ token, onClick, currentLanguage }) => {
             className='token-box'
             onClick={onClick ? () => onClick(token) : null}
             data-test-id={`token-selection-${token.contractName || 'NEAR'}`}
-            IS_USN={CREATE_USN_CONTRACT && token.onChainFTMetadata?.symbol === 'NEAR' || token.onChainFTMetadata?.symbol === 'USN'}
+            IS_USN={CREATE_USN_CONTRACT && (token.onChainFTMetadata?.symbol === 'NEAR' || token.onChainFTMetadata?.symbol === 'USN')}
         >
             <div style={{ display: 'flex', width: '100%' }}>
                 <div className='icon'>


### PR DESCRIPTION
This PR fixes alignment style specifically with USN when the feature flag is off

<img width="559" alt="image" src="https://user-images.githubusercontent.com/5849204/165841003-8af3a54d-4b96-499b-a8e2-61076a734f90.png">
