### PR TITLE
Wal 277 withdrawing lockup funds issue

### DIFF
--- a/packages/frontend/src/redux/crossStateSelectors/selectCollectedAvailableForClaimData.js
+++ b/packages/frontend/src/redux/crossStateSelectors/selectCollectedAvailableForClaimData.js
@@ -71,7 +71,7 @@ const selectCollectedAvailableForClaimData = createSelector(
     }
 );
 
-export const selectCollectedAvailableForClaimDataForAccountId = createSelector(
+export const selectCollectedAvailableForClaimDataByAccountId = createSelector(
     [
         selectValidatorsFarmData,
         selectAllContractMetadata,

--- a/packages/frontend/src/redux/crossStateSelectors/selectCollectedAvailableForClaimData.js
+++ b/packages/frontend/src/redux/crossStateSelectors/selectCollectedAvailableForClaimData.js
@@ -46,7 +46,7 @@ const collectFarmingData = (args) => {
     }
 };
 
-export default createSelector(
+const selectCollectedAvailableForClaimData = createSelector(
     [
         selectValidatorsFarmData,
         selectAllContractMetadata,
@@ -70,3 +70,36 @@ export default createSelector(
         });
     }
 );
+
+export const selectCollectedAvailableForClaimDataForAccountId = createSelector(
+    [
+        selectValidatorsFarmData,
+        selectAllContractMetadata,
+        selectTokensFiatValueUSD,
+        selectTokenWhiteList,
+        (state, accountId) => accountId
+    ],
+    (
+        validatorsFarmData,
+        contractMetadataByContractId,
+        tokenFiatValues,
+        tokenWhitelist,
+        accountId
+    ) => {
+        return collectFarmingData({
+            validatorsFarmData,
+            contractMetadataByContractId,
+            tokenFiatValues,
+            tokenWhitelist,
+            accountId
+        });
+    }
+);
+
+export const selectHasAvailableForClaimForAccountId = createSelector(
+    [selectCollectedAvailableForClaimDataForAccountId],
+    (farmData) =>
+        farmData.filter((tokenData) => +tokenData.balance > 0).length > 0
+);
+
+export default selectCollectedAvailableForClaimData

--- a/packages/frontend/src/redux/crossStateSelectors/selectCollectedAvailableForClaimData.js
+++ b/packages/frontend/src/redux/crossStateSelectors/selectCollectedAvailableForClaimData.js
@@ -102,4 +102,4 @@ export const selectHasAvailableForClaimForAccountId = createSelector(
         farmData.filter((tokenData) => +tokenData.balance > 0).length > 0
 );
 
-export default selectCollectedAvailableForClaimData
+export default selectCollectedAvailableForClaimData;

--- a/packages/frontend/src/redux/crossStateSelectors/selectCollectedAvailableForClaimData.js
+++ b/packages/frontend/src/redux/crossStateSelectors/selectCollectedAvailableForClaimData.js
@@ -97,7 +97,7 @@ export const selectCollectedAvailableForClaimDataByAccountId = createSelector(
 );
 
 export const selectHasAvailableForClaimForAccountId = createSelector(
-    [selectCollectedAvailableForClaimDataForAccountId],
+    [selectCollectedAvailableForClaimDataByAccountId],
     (farmData) =>
         farmData.filter((tokenData) => +tokenData.balance > 0).length > 0
 );

--- a/packages/frontend/src/services/StakingFarmContracts.js
+++ b/packages/frontend/src/services/StakingFarmContracts.js
@@ -1,10 +1,10 @@
 import { Account, Connection } from 'near-api-js';
 
-import { FARMING_VALIDATOR_VERSION, getValidationVersion, MAINNET, TESTNET } from '../utils/constants';
 import {
     NETWORK_ID,
     NODE_URL
 } from '../config';
+import { FARMING_VALIDATOR_VERSION, getValidationVersion, MAINNET, TESTNET } from '../utils/constants';
 
 // Staking Farm Contract
 // https://github.com/referencedev/staking-farm/
@@ -14,12 +14,12 @@ export default class StakingFarmContracts {
         Connection.fromConfig({
             networkId: NETWORK_ID,
             provider: {
-                type: "JsonRpcProvider",
-                args: { url: NODE_URL + "/" },
+                type: 'JsonRpcProvider',
+                args: { url: NODE_URL + '/' },
             },
             signer: {}
         }),
-        "dontcare"
+        'dontcare'
     );
 
     static getFarms({ contractName, from_index, limit }) {

--- a/packages/frontend/src/services/StakingFarmContracts.js
+++ b/packages/frontend/src/services/StakingFarmContracts.js
@@ -1,12 +1,26 @@
+import { Account, Connection } from 'near-api-js';
+
+import { FARMING_VALIDATOR_VERSION, getValidationVersion, MAINNET, TESTNET } from '../utils/constants';
 import {
-    wallet
-} from '../utils/wallet';
+    NETWORK_ID,
+    NODE_URL
+} from '../config';
 
 // Staking Farm Contract
 // https://github.com/referencedev/staking-farm/
 export default class StakingFarmContracts {
     // View functions are not signed, so do not require a real account!
-    static viewFunctionAccount = wallet.getAccountBasic('dontcare');
+    static viewFunctionAccount = new Account(
+        Connection.fromConfig({
+            networkId: NETWORK_ID,
+            provider: {
+                type: "JsonRpcProvider",
+                args: { url: NODE_URL + "/" },
+            },
+            signer: {}
+        }),
+        "dontcare"
+    );
 
     static getFarms({ contractName, from_index, limit }) {
         return this.viewFunctionAccount.viewFunction(
@@ -46,4 +60,34 @@ export default class StakingFarmContracts {
             )
         );
     }
+
+    static isFarmingValidator(accountId) {
+        return (
+            getValidationVersion(
+                NODE_URL.indexOf(MAINNET) > -1 ? MAINNET : TESTNET,
+                accountId
+            ) === FARMING_VALIDATOR_VERSION
+        );
+    }
+
+    static hasUnclaimedRewards = async ({
+        contractName,
+        account_id,
+        from_index,
+        limit,
+    }) => {
+        return (
+            StakingFarmContracts.isFarmingValidator(contractName) &&
+            (await StakingFarmContracts.getFarmListWithUnclaimedRewards({
+                contractName,
+                account_id,
+                from_index,
+                limit,
+            }).then(
+                (farmListWithBalance) =>
+                    farmListWithBalance.filter(({ balance }) => +balance > 0)
+                        .length > 0
+            ))
+        );
+    };
 }

--- a/packages/frontend/src/services/StakingFarmContracts.js
+++ b/packages/frontend/src/services/StakingFarmContracts.js
@@ -78,12 +78,12 @@ export default class StakingFarmContracts {
     }) => {
         return (
             StakingFarmContracts.isFarmingValidator(contractName) &&
-            (await StakingFarmContracts.getFarmListWithUnclaimedRewards({
+            StakingFarmContracts.getFarmListWithUnclaimedRewards({
                 contractName,
                 account_id,
                 from_index,
                 limit,
-            }).then(
+            }.then(
                 (farmListWithBalance) =>
                     farmListWithBalance.filter(({ balance }) => +balance > 0)
                         .length > 0

--- a/packages/frontend/src/services/StakingFarmContracts.js
+++ b/packages/frontend/src/services/StakingFarmContracts.js
@@ -70,7 +70,7 @@ export default class StakingFarmContracts {
         );
     }
 
-    static hasUnclaimedRewards = async ({
+    static hasUnclaimedRewards = ({
         contractName,
         account_id,
         from_index = 0,

--- a/packages/frontend/src/services/StakingFarmContracts.js
+++ b/packages/frontend/src/services/StakingFarmContracts.js
@@ -73,8 +73,8 @@ export default class StakingFarmContracts {
     static hasUnclaimedRewards = async ({
         contractName,
         account_id,
-        from_index,
-        limit,
+        from_index = 0,
+        limit = 300,
     }) => {
         return (
             StakingFarmContracts.isFarmingValidator(contractName) &&

--- a/packages/frontend/src/utils/account-with-lockup.js
+++ b/packages/frontend/src/utils/account-with-lockup.js
@@ -275,7 +275,7 @@ async function getAccountBalance(limitedAccountData = false) {
         let totalBalance = new BN(lockupBalance.total);
         let stakedBalanceLockup = new BN(0);
         const stakingPoolLockupAccountId = await this.wrappedAccount.viewFunction(lockupAccountId, 'get_staking_pool_account_id');
-        let hasUnclaimedTokenBalance = stakingPoolLockupAccountId && await StakingFarmContracts.hasUnclaimedRewards({
+        const hasUnclaimedTokenBalance = stakingPoolLockupAccountId && await StakingFarmContracts.hasUnclaimedRewards({
             contractName: stakingPoolLockupAccountId,
             account_id: lockupAccountId,
             from_index: 0,

--- a/packages/frontend/src/utils/account-with-lockup.js
+++ b/packages/frontend/src/utils/account-with-lockup.js
@@ -13,6 +13,7 @@ import {
     REACT_APP_USE_TESTINGLOCKUP,
 } from '../config';
 import { listStakingDeposits } from '../services/indexer';
+import StakingFarmContracts from '../services/StakingFarmContracts';
 import { WalletError } from './walletError';
 
 // TODO: Should gas allowance be dynamically calculated
@@ -124,7 +125,15 @@ export async function transferAllFromLockup(missingAmount) {
     const lockedBalance = new BN(await this.wrappedAccount.viewFunction(lockupAccountId, 'get_locked_amount'));
     if (lockedBalance.eq(new BN(0))) {
         const stakingPoolBalance = await this.wrappedAccount.viewFunction(lockupAccountId, 'get_known_deposited_balance');
-        if (!new BN(stakingPoolBalance).eq(new BN(0))) {
+        const hasUnclaimedTokenRewards =
+            poolAccountId &&
+            (await StakingFarmContracts.hasUnclaimedRewards({
+                contractName: poolAccountId,
+                account_id: lockupAccountId,
+                from_index: 0,
+                limit: 300,
+            }));
+        if (!new BN(stakingPoolBalance).eq(new BN(0)) || hasUnclaimedTokenRewards) {
             throw new WalletError('Staking pool balance detected.', 'lockup.transferAllWithStakingPoolBalance');
         }
 
@@ -266,6 +275,12 @@ async function getAccountBalance(limitedAccountData = false) {
         let totalBalance = new BN(lockupBalance.total);
         let stakedBalanceLockup = new BN(0);
         const stakingPoolLockupAccountId = await this.wrappedAccount.viewFunction(lockupAccountId, 'get_staking_pool_account_id');
+        let hasUnclaimedTokenBalance = stakingPoolLockupAccountId && await StakingFarmContracts.hasUnclaimedRewards({
+            contractName: stakingPoolLockupAccountId,
+            account_id: lockupAccountId,
+            from_index: 0,
+            limit: 300,
+        });
         if (stakingPoolLockupAccountId) {
             stakedBalanceLockup = new BN(await this.wrappedAccount.viewFunction(stakingPoolLockupAccountId,
                 'get_account_total_balance', { account_id: lockupAccountId }));
@@ -275,7 +290,7 @@ async function getAccountBalance(limitedAccountData = false) {
         const ownersBalance = totalBalance.sub(lockedAmount);
 
         // if acc is deletable (nothing locked && nothing stake) you can transfer the whole amount ohterwise get_liquid_owners_balance
-        const isAccDeletable = lockedAmount.isZero() && stakedBalanceLockup.isZero();
+        const isAccDeletable = lockedAmount.isZero() && stakedBalanceLockup.isZero() && !hasUnclaimedTokenBalance;
         const MIN_BALANCE_FOR_STORAGE = getLockupMinBalanceForStorage(lockupContractCodeHash);
         const liquidOwnersBalanceTransfersEnabled = isAccDeletable
             ? new BN(lockupBalance.total)

--- a/packages/frontend/src/utils/account-with-lockup.js
+++ b/packages/frontend/src/utils/account-with-lockup.js
@@ -129,9 +129,7 @@ export async function transferAllFromLockup(missingAmount) {
             poolAccountId &&
             (await StakingFarmContracts.hasUnclaimedRewards({
                 contractName: poolAccountId,
-                account_id: lockupAccountId,
-                from_index: 0,
-                limit: 300,
+                account_id: lockupAccountId
             }));
         if (!new BN(stakingPoolBalance).eq(new BN(0)) || hasUnclaimedTokenRewards) {
             throw new WalletError('Staking pool balance detected.', 'lockup.transferAllWithStakingPoolBalance');
@@ -277,9 +275,7 @@ async function getAccountBalance(limitedAccountData = false) {
         const stakingPoolLockupAccountId = await this.wrappedAccount.viewFunction(lockupAccountId, 'get_staking_pool_account_id');
         const hasUnclaimedTokenBalance = stakingPoolLockupAccountId && await StakingFarmContracts.hasUnclaimedRewards({
             contractName: stakingPoolLockupAccountId,
-            account_id: lockupAccountId,
-            from_index: 0,
-            limit: 300,
+            account_id: lockupAccountId
         });
         if (stakingPoolLockupAccountId) {
             stakedBalanceLockup = new BN(await this.wrappedAccount.viewFunction(stakingPoolLockupAccountId,


### PR DESCRIPTION
This PR adds an additional condition in `isAccDeletable` for lockup accounts to check for unclaimed token rewards. `isAccDeletable` will affect whether the "Available to transfer" for the lockup includes the storage amount (3.5 / 35 Ⓝ) and whether we delete the lockup when withdrawing from it.