### PR TITLE
chore: update LOCKUP_ACCOUNT_ID_SUFFIX defaults

### DIFF
--- a/packages/frontend/src/config/environmentDefaults/development.js
+++ b/packages/frontend/src/config/environmentDefaults/development.js
@@ -16,7 +16,7 @@ export default {
     EXPLORER_URL:'https://explorer.testnet.near.org',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
     LINKDROP_GAS: '100000000000000',
-    LOCKUP_ACCOUNT_ID_SUFFIX: 'lockup.m0',
+    LOCKUP_ACCOUNT_ID_SUFFIX: 'lockup.devnet',
     MIN_BALANCE_FOR_GAS: nearApiJs.utils.format.parseNearAmount('0.05'),
     MIN_BALANCE_TO_CREATE: nearApiJs.utils.format.parseNearAmount('0.1'),
     MOONPAY_API_KEY: 'pk_test_wQDTsWBsvUm7cPiz9XowdtNeL5xasP9',

--- a/packages/frontend/src/config/environmentDefaults/testnet.js
+++ b/packages/frontend/src/config/environmentDefaults/testnet.js
@@ -17,7 +17,7 @@ export default {
     EXPLORER_URL: 'https://explorer.testnet.near.org',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
     LINKDROP_GAS: '100000000000000',
-    LOCKUP_ACCOUNT_ID_SUFFIX: 'lockup.m0',
+    LOCKUP_ACCOUNT_ID_SUFFIX: 'lockup.devnet',
     MIN_BALANCE_FOR_GAS: nearApiJs.utils.format.parseNearAmount('0.05'),
     MIN_BALANCE_TO_CREATE: nearApiJs.utils.format.parseNearAmount('0.1'),
     MOONPAY_API_KEY: 'pk_test_wQDTsWBsvUm7cPiz9XowdtNeL5xasP9',


### PR DESCRIPTION
Update `LOCKUP_ACCOUNT_ID_SUFFIX` defaults to `lockup.devnet` for testnet and development `NEAR_WALLET_ENV`s.

This will allow lockup testing using [tesnet.lockup.tech](https://testnet.lockup.tech/).