### PR TITLE
Seed phrase import: enable import of zero balance account

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -10,6 +10,7 @@
     "@near-wallet/feature-flags": "^0.1.0",
     "@reduxjs/toolkit": "1.6.2",
     "@sentry/browser": "^6.4.1",
+    "bip39-light": "^1.0.7",
     "connected-react-router": "^6.6.0",
     "escape-html": "^1.0.3",
     "fetch-send-json": "0.0.2",

--- a/packages/frontend/src/components/accounts/CouldNotFindAccountModal.js
+++ b/packages/frontend/src/components/accounts/CouldNotFindAccountModal.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Translate } from 'react-localize-redux';
+import styled from 'styled-components';
+
+import FormButton from '../common/FormButton';
+import Modal from '../common/modal/Modal';
+
+const Container = styled.div`
+    &&&&& {
+        padding: 15px 0 10px 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+
+        h3 {
+            margin: 15px 0;
+        }
+
+        > button {
+            margin-top: 25px;
+            width: 100%;
+        }
+    }
+`;
+
+export default ({
+    isOpen,
+    onClickImport,
+    onClose
+ }) => {
+    return (
+        <Modal
+            id='could-not-find-account-modal'
+            isOpen={isOpen}
+            onClose={onClose}
+            modalSize='sm'
+        >
+            <Container>
+                <h3><Translate id='recoverSeedPhrase.couldNotFindAccountModal.title'/></h3>
+                <p><Translate id='recoverSeedPhrase.couldNotFindAccountModal.desc'/></p>
+                <FormButton onClick={onClickImport}><Translate id='recoverSeedPhrase.couldNotFindAccountModal.buttonImport'/></FormButton>
+                <FormButton className='link' onClick={onClose}><Translate id='button.cancel'/></FormButton>
+            </Container>
+        </Modal>
+    );
+};

--- a/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
@@ -1,10 +1,13 @@
 import { getRouter } from 'connected-react-router';
+import { KeyPair } from 'near-api-js';
+import { parseSeedPhrase } from 'near-seed-phrase';
 import { parse as parseQuery, stringify } from 'query-string';
 import React, { Component } from 'react';
 import { Translate } from 'react-localize-redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import styled from 'styled-components';
+
 
 import { Mixpanel } from '../../mixpanel/index';
 import {
@@ -14,11 +17,14 @@ import {
     refreshAccount,
     clearAccountState
 } from '../../redux/actions/account';
-import { clearLocalAlert } from '../../redux/actions/status';
+import { clearLocalAlert, showCustomAlert, clearGlobalAlert } from '../../redux/actions/status';
 import { selectAccountSlice } from '../../redux/slices/account';
 import { selectActionsPending, selectStatusLocalAlert, selectStatusMainLoader } from '../../redux/slices/status';
+import isValidSeedPhrase from '../../utils/isValidSeedPhrase';
 import parseFundingOptions from '../../utils/parseFundingOptions';
+import { wallet } from '../../utils/wallet';
 import Container from '../common/styled/Container.css';
+import CouldNotFindAccountModal from './CouldNotFindAccountModal';
 import RecoverAccountSeedPhraseForm from './RecoverAccountSeedPhraseForm';
 
 const StyledContainer = styled(Container)`
@@ -45,7 +51,8 @@ const StyledContainer = styled(Container)`
 class RecoverAccountSeedPhrase extends Component {
     state = {
         seedPhrase: this.props.seedPhrase,
-        recoveringAccount: false
+        recoveringAccount: false,
+        showCouldNotFindAccountModal: false
     }
 
     // TODO: Use some validation framework?
@@ -72,14 +79,27 @@ class RecoverAccountSeedPhrase extends Component {
         }
 
         const { seedPhrase } = this.state;
-        const { 
+        const {
             location,
             redirectTo,
             redirectToApp,
             clearAccountState,
             recoverAccountSeedPhrase,
-            refreshAccount
+            refreshAccount,
+            showCustomAlert
         } = this.props;
+
+        try {
+            isValidSeedPhrase(seedPhrase);
+        } catch (e) {
+            showCustomAlert({
+                success: false,
+                messageCodeHeader: 'error',
+                messageCode: 'walletErrorCodes.recoverAccountSeedPhrase.errorSeedPhraseNotValid',
+                errorMessage: e.message
+            });
+            return;
+        }
 
         await Mixpanel.withTracking('IE-SP Recovery with seed phrase',
             async () => {
@@ -87,6 +107,7 @@ class RecoverAccountSeedPhrase extends Component {
                 await recoverAccountSeedPhrase(seedPhrase);
                 await refreshAccount();
             }, (e) => {
+                this.setState({ showCouldNotFindAccountModal: true });
                 throw e;
             }, () => {
                 this.setState({ recoveringAccount: false });
@@ -117,6 +138,8 @@ class RecoverAccountSeedPhrase extends Component {
             isLegit: this.isLegit && !(this.props.localAlert && this.props.localAlert.success === false)
         };
 
+        const { showCouldNotFindAccountModal, seedPhrase } = this.state;
+
         return (
             <StyledContainer className='small-centered border'>
                 <h1><Translate id='recoverSeedPhrase.pageTitle' /></h1>
@@ -127,6 +150,21 @@ class RecoverAccountSeedPhrase extends Component {
                         handleChange={this.handleChange}
                     />
                 </form>
+                {showCouldNotFindAccountModal && (
+                    <CouldNotFindAccountModal
+                        onClickImport={async () => {
+                            const { secretKey } = parseSeedPhrase(seedPhrase);
+                            const recoveryKeyPair = KeyPair.fromString(secretKey);
+                            const implicitAccountId = Buffer.from(recoveryKeyPair.publicKey.data).toString('hex');
+                            await wallet.importZeroBalanceAccount(implicitAccountId, recoveryKeyPair);
+                            this.props.refreshAccount();
+                            this.props.redirectTo('/');
+                            this.props.clearGlobalAlert();
+                        }}
+                        onClose={() => this.setState({ showCouldNotFindAccountModal: false })}
+                        isOpen={showCouldNotFindAccountModal}
+                    />
+                )}
             </StyledContainer>
         );
     }
@@ -138,7 +176,9 @@ const mapDispatchToProps = {
     redirectToApp,
     refreshAccount,
     clearLocalAlert,
-    clearAccountState
+    clearAccountState,
+    showCustomAlert,
+    clearGlobalAlert
 };
 
 const mapStateToProps = (state, { match }) => ({

--- a/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
@@ -158,10 +158,19 @@ class RecoverAccountSeedPhrase extends Component {
                             const { secretKey } = parseSeedPhrase(seedPhrase);
                             const recoveryKeyPair = KeyPair.fromString(secretKey);
                             const implicitAccountId = Buffer.from(recoveryKeyPair.publicKey.data).toString('hex');
-                            await wallet.importZeroBalanceAccount(implicitAccountId, recoveryKeyPair);
-                            this.props.refreshAccount();
-                            this.props.redirectTo('/');
-                            this.props.clearGlobalAlert();
+                            try {
+                                await wallet.importZeroBalanceAccount(implicitAccountId, recoveryKeyPair);
+                                this.props.refreshAccount();
+                                this.props.redirectTo('/');
+                                this.props.clearGlobalAlert();
+                            } catch (e) {
+                                this.props.showCustomAlert({
+                                    success: false,
+                                    messageCodeHeader: 'error',
+                                    messageCode: 'walletErrorCodes.recoverAccountSeedPhrase.errorNotAbleToImportAccount',
+                                    errorMessage: e.message
+                                });
+                            }
                         }}
                         onClose={() => this.setState({ showCouldNotFindAccountModal: false })}
                         isOpen={showCouldNotFindAccountModal}

--- a/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
@@ -107,7 +107,9 @@ class RecoverAccountSeedPhrase extends Component {
                 await recoverAccountSeedPhrase(seedPhrase);
                 await refreshAccount();
             }, (e) => {
-                this.setState({ showCouldNotFindAccountModal: true });
+                if (e.message.includes('Cannot find matching public key')) {
+                    this.setState({ showCouldNotFindAccountModal: true });
+                }
                 throw e;
             }, () => {
                 this.setState({ recoveringAccount: false });

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -897,6 +897,11 @@
         "seedPhraseInput": {
             "placeholder": "correct horse battery staple...",
             "title": "Passphrase (12 words)"
+        },
+        "couldNotFindAccountModal": {
+            "desc": "We couldn't find any <b>active account(s)</b> using the provided passphrase. This could be because the passphrase is incorrect, or because the account has no activity yet.",
+            "title": "Couldn't find account",
+            "buttonImport": "Import Anyway"
         }
     },
     "recoverWithLink": {
@@ -1702,7 +1707,8 @@
             "error": "Import of your account failed. Please try again or contact support for assistance."
         },
         "recoverAccountSeedPhrase": {
-            "errorInvalidSeedPhrase": "No accounts were found for this passphrase."
+            "errorInvalidSeedPhrase": "No accounts were found for this passphrase.",
+            "errorSeedPhraseNotValid": "The provided seed phrase is not valid. Please check your seed phrase and try again."
         },
         "recoveryMethods": {
             "lastMethod": "Cannot delete your last recovery method. Unless you have Ledger enabled, you need to keep at least one recovery method active to ensure recoverability of your account.",

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1708,7 +1708,8 @@
         },
         "recoverAccountSeedPhrase": {
             "errorInvalidSeedPhrase": "No accounts were found for this passphrase.",
-            "errorSeedPhraseNotValid": "The provided passphrase is not valid. Please check your passphrase and try again."
+            "errorSeedPhraseNotValid": "The provided passphrase is not valid. Please check your passphrase and try again.",
+            "errorNotAbleToImportAccount": "Import of your account failed. Please try again or contact support for assistance."
         },
         "recoveryMethods": {
             "lastMethod": "Cannot delete your last recovery method. Unless you have Ledger enabled, you need to keep at least one recovery method active to ensure recoverability of your account.",

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1708,7 +1708,7 @@
         },
         "recoverAccountSeedPhrase": {
             "errorInvalidSeedPhrase": "No accounts were found for this passphrase.",
-            "errorSeedPhraseNotValid": "The provided seed phrase is not valid. Please check your seed phrase and try again."
+            "errorSeedPhraseNotValid": "The provided passphrase is not valid. Please check your passphrase and try again."
         },
         "recoveryMethods": {
             "lastMethod": "Cannot delete your last recovery method. Unless you have Ledger enabled, you need to keep at least one recovery method active to ensure recoverability of your account.",

--- a/packages/frontend/src/utils/isValidSeedPhrase.js
+++ b/packages/frontend/src/utils/isValidSeedPhrase.js
@@ -1,0 +1,15 @@
+import bip39 from 'bip39-light';
+
+export default (seedPhrase) => {
+    if (seedPhrase.trim().split(/\s+/g).length < 12) {
+        throw new Error('Provided seed phrase must be at least 12 words long');
+    }
+
+    const isValidSeedPhrase = bip39.validateMnemonic(seedPhrase.trim());
+
+    if (!isValidSeedPhrase) {
+        throw new Error('Provided seed phrase is not valid according to bip39-light standard');
+    }
+
+    return isValidSeedPhrase;
+};

--- a/packages/frontend/src/utils/wallet.js
+++ b/packages/frontend/src/utils/wallet.js
@@ -477,6 +477,12 @@ class Wallet {
         setAccountConfirmed(this.accountId, false);
     }
 
+    async importZeroBalanceAccount(accountId, keyPair) {
+        await this.saveAccount(accountId, keyPair);
+        this.makeAccountActive(accountId);
+        setAccountConfirmed(this.accountId, true);
+    }
+
     async setKey(accountId, keyPair) {
         if (keyPair) {
             await this.keyStore.setKey(NETWORK_ID, accountId, keyPair);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2057,15 +2057,6 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@near-wallet/feature-flags@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@near-wallet/feature-flags/-/feature-flags-0.0.4.tgz#281a15ad66f9ba0c66bb63f81ea0b21a228071a9"
-  integrity sha512-TUu1io4U1CzvV5gGzLMGwQLFuA7Hj/RmRD1y0Ys1MdCcyErBced/cLIymQJtC5zZTYW6JlbJTQ3EmZb+HUaG4g==
-  dependencies:
-    fs-extra "^10.0.0"
-    ini "^2.0.0"
-    inquirer "^8.2.0"
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -6993,11 +6984,6 @@ ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
-
-ini@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
-  integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
 
 init-package-json@^2.0.2:
   version "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2057,6 +2057,15 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@near-wallet/feature-flags@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@near-wallet/feature-flags/-/feature-flags-0.0.4.tgz#281a15ad66f9ba0c66bb63f81ea0b21a228071a9"
+  integrity sha512-TUu1io4U1CzvV5gGzLMGwQLFuA7Hj/RmRD1y0Ys1MdCcyErBced/cLIymQJtC5zZTYW6JlbJTQ3EmZb+HUaG4g==
+  dependencies:
+    fs-extra "^10.0.0"
+    ini "^2.0.0"
+    inquirer "^8.2.0"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -6984,6 +6993,11 @@ ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
+ini@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
+  integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
 
 init-package-json@^2.0.2:
   version "2.0.3"


### PR DESCRIPTION
Referencing issues:
https://nearinc.atlassian.net/browse/WAL-193
https://nearinc.atlassian.net/browse/WAL-191

This PR enables import of a 'zero balance account' when importing an account with seed phrase on the `/recover-seed-phrase` route.

The wallet first tries to find all associated accounts using the provided seed phrase, and shows a modal with 'no accounts found' in case of no active accounts found. The user is then presented with a button to 'import anyway', which converts the seed phrase into an implicit account and imports it into the wallet.

The wallet runs a check against the provided seed phrase using [bip39-light](https://www.npmjs.com/package/bip39-light) to ensure that the provided seed phrase is valid. The wallet shows the error toast in case the provided seed phrase is:
1. Less than 12 words
2. Invalid as per bip-39-light standard
<img width="1175" alt="Screen Shot 2022-05-05 at 1 57 28 PM" src="https://user-images.githubusercontent.com/24921205/167024453-129040f1-ade8-4127-babc-210f070b1c84.png">
<img width="1101" alt="Screen Shot 2022-05-05 at 1 57 47 PM" src="https://user-images.githubusercontent.com/24921205/167024458-4f68687c-9031-4f6e-b0c6-b3ed5a46f6bf.png">
<img width="1405" alt="Screen Shot 2022-05-05 at 1 58 19 PM" src="https://user-images.githubusercontent.com/24921205/167024466-f55cb568-fbfc-4d40-8445-fa5757e1f262.png">

