### PR TITLE
feat(indexer): indexer service

### DIFF
--- a/features/features.d.ts
+++ b/features/features.d.ts
@@ -7,5 +7,6 @@ export type Features = {
 	EXAMPLE_FLAG: boolean;
 	FARMING_VALIDATOR_APY_DISPLAY: boolean;
 	IMPORT_ACCOUNT_WITH_LINK_V2: boolean;
+	USE_INDEXER_SERVICE: boolean;
 	USN_BUTTON: boolean;
 };

--- a/features/flags.json
+++ b/features/flags.json
@@ -144,6 +144,35 @@
       "lastEditedAt": "2022-04-07T02:50:24.123Z"
     }
   },
+  "USE_INDEXER_SERVICE": {
+    "createdBy": "Andy Haynes",
+    "createdAt": "2022-05-05T21:19:46.314Z",
+    "development": {
+      "enabled": true,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2022-05-05T21:19:46.313Z"
+    },
+    "testnet": {
+      "enabled": true,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2022-05-05T22:25:53.915Z"
+    },
+    "mainnet": {
+      "enabled": false,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2022-05-05T21:19:46.314Z"
+    },
+    "mainnet_STAGING": {
+      "enabled": false,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2022-05-05T21:19:46.314Z"
+    },
+    "testnet_STAGING": {
+      "enabled": true,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2022-05-05T22:25:53.915Z"
+    }
+  },
   "USN_BUTTON": {
     "createdBy": "ignatKorokov",
     "createdAt": "2022-05-02T17:12:41.421Z",

--- a/packages/frontend/src/components/navigation/NavLinks.js
+++ b/packages/frontend/src/components/navigation/NavLinks.js
@@ -146,7 +146,8 @@ const NavLinks = () => (
             }
             target='_blank' 
             className="usn-button"
-            onClick={() => Mixpanel.track('Click Buy USN')} rel="noreferrer"
+            onClick={() => Mixpanel.track('Click Buy USN')}
+            rel="noreferrer"
             >
             <div>
                 <img src={USN_LOGO} alt='open-link'></img>

--- a/packages/frontend/src/components/navigation/NavLinks.js
+++ b/packages/frontend/src/components/navigation/NavLinks.js
@@ -4,10 +4,10 @@ import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { CREATE_USN_CONTRACT, USN_BUTTON } from '../../../../../features';
-import { IS_MAINNET } from '../../config'
+import { IS_MAINNET } from '../../config';
+import USN_LOGO from '../../images/USN-logo.png';
 import { Mixpanel } from '../../mixpanel/index';
 import HelpIcon from '../svg/HelpIcon';
-import USN_LOGO from '../../images/USN-logo.png'
 import SwapIconTwoArrows from '../svg/SwapIconTwoArrows';
 import UserIcon from '../svg/UserIcon';
 import VaultIcon from '../svg/VaultIcon';
@@ -146,7 +146,7 @@ const NavLinks = () => (
             }
             target='_blank' 
             className="usn-button"
-            onClick={() => Mixpanel.track('Click Buy USN')}
+            onClick={() => Mixpanel.track('Click Buy USN')} rel="noreferrer"
             >
             <div>
                 <img src={USN_LOGO} alt='open-link'></img>

--- a/packages/frontend/src/config/environmentDefaults/development.js
+++ b/packages/frontend/src/config/environmentDefaults/development.js
@@ -15,6 +15,7 @@ export default {
     EXPLORE_DEFI_URL: 'https://awesomenear.com/categories/defi/',
     EXPLORER_URL:'https://explorer.testnet.near.org',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
+    INDEXER_SERVICE_URL: 'https://testnet-api.kitwallet.app',
     LINKDROP_GAS: '100000000000000',
     LOCKUP_ACCOUNT_ID_SUFFIX: 'lockup.m0',
     MIN_BALANCE_FOR_GAS: nearApiJs.utils.format.parseNearAmount('0.05'),

--- a/packages/frontend/src/config/environmentDefaults/mainnet.js
+++ b/packages/frontend/src/config/environmentDefaults/mainnet.js
@@ -16,6 +16,7 @@ export default {
     EXPLORE_DEFI_URL: 'https://awesomenear.com/categories/defi/',
     EXPLORER_URL: 'https://explorer.mainnet.near.org',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
+    INDEXER_SERVICE_URL: 'https://api.kitwallet.app',
     LINKDROP_GAS: '100000000000000',
     LOCKUP_ACCOUNT_ID_SUFFIX: 'lockup.near',
     MIN_BALANCE_FOR_GAS: nearApiJs.utils.format.parseNearAmount('0.05'),

--- a/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.js
+++ b/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.js
@@ -16,6 +16,7 @@ export default {
     EXPLORE_DEFI_URL: 'https://awesomenear.com/categories/defi/',
     EXPLORER_URL: 'https://explorer.mainnet.near.org',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
+    INDEXER_SERVICE_URL: 'https://staging-api.kitwallet.app',
     LINKDROP_GAS: '100000000000000',
     LOCKUP_ACCOUNT_ID_SUFFIX: 'lockup.near',
     MIN_BALANCE_FOR_GAS: nearApiJs.utils.format.parseNearAmount('0.05'),

--- a/packages/frontend/src/config/environmentDefaults/testnet.js
+++ b/packages/frontend/src/config/environmentDefaults/testnet.js
@@ -16,6 +16,7 @@ export default {
     EXPLORE_DEFI_URL: 'https://awesomenear.com/categories/defi/',
     EXPLORER_URL: 'https://explorer.testnet.near.org',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
+    INDEXER_SERVICE_URL: 'https://testnet-api.kitwallet.app',
     LINKDROP_GAS: '100000000000000',
     LOCKUP_ACCOUNT_ID_SUFFIX: 'lockup.m0',
     MIN_BALANCE_FOR_GAS: nearApiJs.utils.format.parseNearAmount('0.05'),

--- a/packages/frontend/src/redux/actions/staking.js
+++ b/packages/frontend/src/redux/actions/staking.js
@@ -2,6 +2,7 @@ import BN from 'bn.js';
 import * as nearApiJs from 'near-api-js';
 import { createActions } from 'redux-actions';
 
+import { USE_INDEXER_SERVICE } from '../../../../../features';
 import {
     ACCOUNT_HELPER_URL,
     REACT_APP_USE_TESTINGLOCKUP,
@@ -11,6 +12,7 @@ import {
     LOCKUP_ACCOUNT_ID_SUFFIX
 } from '../../config';
 import { fungibleTokensService, FT_MINIMUM_STORAGE_BALANCE_LARGE } from '../../services/FungibleTokens';
+import { listStakingPools } from '../../services/indexer';
 import StakingFarmContracts from '../../services/StakingFarmContracts';
 import { getLockupAccountId, getLockupMinBalanceForStorage } from '../../utils/account-with-lockup';
 import { showAlert } from '../../utils/alerts';
@@ -401,7 +403,12 @@ export const { staking } = createActions({
                 const rpcValidators = [...current_validators, ...next_validators, ...current_proposals].map(({ account_id }) => account_id);
 
                 const networkId = wallet.connection.provider.connection.url.indexOf(MAINNET) > -1 ? MAINNET : TESTNET;
-                const allStakingPools = (await fetch(`${ACCOUNT_HELPER_URL}/stakingPools`).then((r) => r.json()));
+                let allStakingPools;
+                if (USE_INDEXER_SERVICE) {
+                    allStakingPools = await listStakingPools();
+                } else {
+                    allStakingPools = (await fetch(`${ACCOUNT_HELPER_URL}/stakingPools`).then((r) => r.json()));
+                }
                 const prefix = getValidatorRegExp(networkId);
                 accountIds = [...new Set([...rpcValidators, ...allStakingPools])]
                     .filter((v) => v.indexOf('nfvalidator') === -1 && v.match(prefix));

--- a/packages/frontend/src/services/FungibleTokens.js
+++ b/packages/frontend/src/services/FungibleTokens.js
@@ -1,6 +1,7 @@
 import BN from 'bn.js';
 import * as nearApiJs from 'near-api-js';
 
+import { USE_INDEXER_SERVICE } from '../../../../features';
 import { ACCOUNT_HELPER_URL, NEAR_TOKEN_ID } from '../config';
 import sendJson from '../tmp_fetch_send_json';
 import {
@@ -9,6 +10,7 @@ import {
     removeTrailingZeros,
 } from '../utils/amounts';
 import { wallet } from '../utils/wallet';
+import { listLikelyTokens } from './indexer';
 
 const {
     transactions: { functionCall },
@@ -61,10 +63,13 @@ export default class FungibleTokens {
     }
 
     static async getLikelyTokenContracts({ accountId }) {
-        return sendJson(
-            'GET',
-            `${ACCOUNT_HELPER_URL}/account/${accountId}/likelyTokens`
-        );
+        if (!USE_INDEXER_SERVICE) {
+            return sendJson(
+                'GET',
+                `${ACCOUNT_HELPER_URL}/account/${accountId}/likelyTokens`
+            );
+        }
+        return listLikelyTokens(accountId);
     }
 
     static async getStorageBalance({ contractName, accountId }) {

--- a/packages/frontend/src/services/NonFungibleTokens.js
+++ b/packages/frontend/src/services/NonFungibleTokens.js
@@ -1,8 +1,10 @@
 import * as nearAPI from 'near-api-js';
 
+import { USE_INDEXER_SERVICE } from '../../../../features';
 import { ACCOUNT_HELPER_URL } from '../config';
 import sendJson from '../tmp_fetch_send_json';
 import { wallet } from '../utils/wallet';
+import { listLikelyNfts } from './indexer';
 
 export const TOKENS_PER_PAGE = 4;
 export const NFT_TRANSFER_GAS = nearAPI.utils.format.parseNearAmount('0.00000000003');
@@ -17,7 +19,10 @@ export default class NonFungibleTokens {
     static viewFunctionAccount = wallet.getAccountBasic('dontcare')
 
     static getLikelyTokenContracts = async (accountId) => {
-        return sendJson('GET', `${ACCOUNT_HELPER_URL}/account/${accountId}/likelyNFTs`);
+        if (!USE_INDEXER_SERVICE) {
+            return sendJson('GET', `${ACCOUNT_HELPER_URL}/account/${accountId}/likelyNFTs`);
+        }
+        return listLikelyNfts(accountId);
     }
 
     static getMetadata = async (contractName) => {

--- a/packages/frontend/src/services/indexer.js
+++ b/packages/frontend/src/services/indexer.js
@@ -1,0 +1,30 @@
+import { INDEXER_SERVICE_URL } from '../config';
+import sendJson from '../tmp_fetch_send_json';
+
+export function listAccountsByPublicKey(publicKey) {
+    return fetch(`${INDEXER_SERVICE_URL}/publicKey/${publicKey}/accounts`)
+        .then((res) => res.json());
+}
+
+export function listLikelyNfts(accountId) {
+    return sendJson('GET', `${INDEXER_SERVICE_URL}/account/${accountId}/likelyNFTs`);
+}
+
+export function listLikelyTokens(accountId) {
+    return sendJson('GET', `${INDEXER_SERVICE_URL}/account/${accountId}/likelyTokens`);
+}
+
+export function listRecentTransactions(accountId) {
+    return fetch(`${INDEXER_SERVICE_URL}/account/${accountId}/activity`)
+        .then((res) => res.json());
+}
+
+export function listStakingDeposits(accountId) {
+    return fetch(`${INDEXER_SERVICE_URL}/staking-deposits/${accountId}`)
+        .then((r) => r.json());
+}
+
+export function listStakingPools() {
+    return fetch(`${INDEXER_SERVICE_URL}/stakingPools`)
+        .then((r) => r.json());
+}

--- a/packages/frontend/src/utils/explorer-api.js
+++ b/packages/frontend/src/utils/explorer-api.js
@@ -1,10 +1,17 @@
+import { USE_INDEXER_SERVICE } from '../../../../features';
 import { ACCOUNT_HELPER_URL } from '../config';
+import { listRecentTransactions } from '../services/indexer';
 import { wallet } from './wallet';
 
 export async function getTransactions({ accountId }) {
     if (!accountId) return {};
 
-    const txs = await fetch(`${ACCOUNT_HELPER_URL}/account/${accountId}/activity`).then((res) => res.json());
+    let txs;
+    if (USE_INDEXER_SERVICE) {
+        txs = await listRecentTransactions(accountId);
+    } else {
+        txs = await fetch(`${ACCOUNT_HELPER_URL}/account/${accountId}/activity`).then((res) => res.json());
+    }
 
     return txs.map((t, i) => ({
         ...t,

--- a/packages/frontend/src/utils/helper-api.js
+++ b/packages/frontend/src/utils/helper-api.js
@@ -2,13 +2,18 @@
 import * as nearApiJs from 'near-api-js';
 import { parseSeedPhrase } from 'near-seed-phrase';
 
+import { USE_INDEXER_SERVICE } from '../../../../features';
 import { ACCOUNT_HELPER_URL } from '../config';
+import { listAccountsByPublicKey } from '../services/indexer';
 
 export let controller;
 
 export async function getAccountIds(publicKey) {
     controller = new AbortController();
-    return await fetch(`${ACCOUNT_HELPER_URL}/publicKey/${publicKey}/accounts`, { signal: controller.signal }).then((res) => res.json());
+    if (!USE_INDEXER_SERVICE) {
+        return await fetch(`${ACCOUNT_HELPER_URL}/publicKey/${publicKey}/accounts`, { signal: controller.signal }).then((res) => res.json());
+    }
+    return listAccountsByPublicKey(publicKey);
 }
 
 export async function getAccountIdsBySeedPhrase(seedPhrase) {

--- a/packages/frontend/src/utils/staking.js
+++ b/packages/frontend/src/utils/staking.js
@@ -1,7 +1,9 @@
 import BN from 'bn.js';
 import * as nearApiJs from 'near-api-js';
 
+import { USE_INDEXER_SERVICE } from '../../../../features';
 import { ACCOUNT_HELPER_URL, NEAR_TOKEN_ID } from '../config';
+import { listStakingDeposits } from '../services/indexer';
 import { nearTo } from '../utils/amounts';
 import { wallet } from './wallet';
 
@@ -78,7 +80,12 @@ export async function updateStakedBalance(validatorId, account_id, contract) {
 }
 
 export async function getStakingDeposits(accountId) {
-    let stakingDeposits = await fetch(ACCOUNT_HELPER_URL + '/staking-deposits/' + accountId).then((r) => r.json());
+    let stakingDeposits;
+    if (USE_INDEXER_SERVICE) {
+        stakingDeposits = await listStakingDeposits(accountId);
+    } else {
+        stakingDeposits = await fetch(ACCOUNT_HELPER_URL + '/staking-deposits/' + accountId).then((r) => r.json());
+    }
 
     const validatorDepositMap = {};
     stakingDeposits.forEach(({ validator_id, deposit }) => {


### PR DESCRIPTION
This PR adds an indexer service responsible for calling out to the contract helper REST endpoints responsible for querying the indexer. Aside from consolidating this logic in one module, this change introduces a new set of service URLs pointed to the new backend indexer service which has been separated from the contract helper for performance and stability concerns.