### PR TITLE
chore: set CLOUDFLARE_BASE_URL as default for nearorg envs

### DIFF
--- a/packages/frontend/ci/config.js
+++ b/packages/frontend/ci/config.js
@@ -8,13 +8,13 @@ const envDefaults = {
         CLOUDFLARE_BASE_URL: 'https://content.near-wallet.workers.dev',
         SENTRY_RELEASE: 'development',
     },
-    [Environments.TESTNET]: {
+    [Environments.TESTNET_NEARORG]: {
         CLOUDFLARE_BASE_URL: 'https://content.near-wallet.workers.dev',
     },
-    [Environments.MAINNET]: {
+    [Environments.MAINNET_NEARORG]: {
         CLOUDFLARE_BASE_URL: 'https://content.near-wallet.workers.dev',
     },
-    [Environments.MAINNET_STAGING]: {
+    [Environments.MAINNET_STAGING_NEARORG]: {
         CLOUDFLARE_BASE_URL: 'https://content.near-wallet.workers.dev',
     },
 };

--- a/packages/frontend/src/config/configFromEnvironment.js
+++ b/packages/frontend/src/config/configFromEnvironment.js
@@ -36,9 +36,12 @@ module.exports = {
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: parseBooleanFromShell(
         process.env.HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL
     ),
-    IS_MAINNET: [Environments.MAINNET, Environments.MAINNET_STAGING].some(
-        (env) => env === NEAR_WALLET_ENV
-    ),
+    IS_MAINNET: [
+        Environments.MAINNET,
+        Environments.MAINNET_STAGING,
+        Environments.MAINNET_STAGING_NEARORG,
+        Environments.MAINNET_NEARORG,
+    ].some((env) => env === NEAR_WALLET_ENV),
     LINKDROP_GAS: process.env.LINKDROP_GAS,
     LOCKUP_ACCOUNT_ID_SUFFIX: process.env.LOCKUP_ACCOUNT_ID_SUFFIX,
     MIN_BALANCE_FOR_GAS: process.env.REACT_APP_MIN_BALANCE_FOR_GAS,

--- a/packages/frontend/src/config/index.js
+++ b/packages/frontend/src/config/index.js
@@ -12,6 +12,9 @@ const envDefaults = {
     [Environments.TESTNET]: testnet,
     [Environments.MAINNET]: mainnet,
     [Environments.MAINNET_STAGING]: mainnet_STAGING,
+    [Environments.TESTNET_NEARORG]: testnet,
+    [Environments.MAINNET_NEARORG]: mainnet,
+    [Environments.MAINNET_STAGING_NEARORG]: mainnet_STAGING
 };
 
 module.exports = defaults(


### PR DESCRIPTION
This PR sets `CLOUDFLARE_BASE_URL` as a default value for nearorg environments. Current netlify and render instances have already been moved to `NEARORG` environments (except mainnet pending merge to `stable`) and `CLOUDFLARE_BASE_URL` was set on the UI