### PR TITLE
Fix sign in with ledger errors

### DIFF
--- a/packages/frontend/src/components/accounts/ledger/LedgerHdPaths.js
+++ b/packages/frontend/src/components/accounts/ledger/LedgerHdPaths.js
@@ -120,10 +120,11 @@ export default function LedgerHdPaths({
         if (dropdownOpen) {
             if (e.keyCode === 38) {
                 increment();
+                e.preventDefault();
             } else if (e.keyCode === 40) {
                 decrement();
+                e.preventDefault();
             }
-            e.preventDefault();
         }
     });
 

--- a/packages/frontend/src/components/accounts/ledger/LedgerHdPaths.js
+++ b/packages/frontend/src/components/accounts/ledger/LedgerHdPaths.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Translate } from 'react-localize-redux';
 import styled from 'styled-components';
 
@@ -109,7 +109,12 @@ const Container = styled.div`
     }
 `;
 
-export default function LedgerHdPaths({ onSetPath, path, onConfirmHdPath }) {
+export default function LedgerHdPaths({ 
+    confirmedPath,
+    setConfirmedPath
+}) {
+    const [path, setPath] = useState(confirmedPath);
+
     onKeyDown((e) => {
         const dropdownOpen = document.getElementById('hd-paths-dropdown').classList.contains('open');
         if (dropdownOpen) {
@@ -123,13 +128,17 @@ export default function LedgerHdPaths({ onSetPath, path, onConfirmHdPath }) {
     });
 
     const increment = () => {
-        onSetPath(path + 1);
+        setPath(path + 1);
     };
 
     const decrement = () => {
         if (path > 0) {
-            onSetPath(path - 1);
+            setPath(path - 1);
         }
+    };
+
+    const handleConfirmHdPath = () => {
+        setConfirmedPath(path);
     };
 
     const dropDownContent = () => {
@@ -152,7 +161,7 @@ export default function LedgerHdPaths({ onSetPath, path, onConfirmHdPath }) {
                         </div>
                     </div>
                 </div>
-                <FormButton className='hd-paths-dropdown-toggle' onClick={onConfirmHdPath}>
+                <FormButton className='hd-paths-dropdown-toggle' onClick={handleConfirmHdPath}>
                     <Translate id='signInLedger.advanced.setPath'/>
                 </FormButton>
             </div>

--- a/packages/frontend/src/components/accounts/ledger/SignInLedgerViews/Authorize.js
+++ b/packages/frontend/src/components/accounts/ledger/SignInLedgerViews/Authorize.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Translate } from 'react-localize-redux';
 
-import { Mixpanel } from '../../../../mixpanel/index';
 import FormButton from '../../../common/FormButton';
 import LocalAlertBox from '../../../common/LocalAlertBox';
 import LedgerImageCircle from '../../../svg/LedgerImageCircle';
@@ -9,8 +8,7 @@ import LedgerHdPaths from '../LedgerHdPaths';
 
 const Authorize = ({
     status,
-    path,
-    setPath,
+    confirmedPath,
     setConfirmedPath,
     handleSignIn,
     signingIn,
@@ -24,12 +22,8 @@ const Authorize = ({
             <br /><br />
             <LocalAlertBox localAlert={status.localAlert} />
             <LedgerHdPaths
-                path={path}
-                onSetPath={(path) => setPath(path)}
-                onConfirmHdPath={() => {
-                    setConfirmedPath(path);
-                    Mixpanel.track('IE-Ledger Sign in set custom HD path');
-                }}
+                confirmedPath={confirmedPath}
+                setConfirmedPath={setConfirmedPath}
             />
             <div className='buttons-bottom-buttons'>
                 <FormButton

--- a/packages/frontend/src/components/accounts/ledger/SignInLedgerViews/Authorize.js
+++ b/packages/frontend/src/components/accounts/ledger/SignInLedgerViews/Authorize.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Translate } from 'react-localize-redux';
 
+import { Mixpanel } from '../../../../mixpanel/index';
 import FormButton from '../../../common/FormButton';
 import LedgerImageCircle from '../../../svg/LedgerImageCircle';
 import LedgerHdPaths from '../LedgerHdPaths';
@@ -20,7 +21,10 @@ const Authorize = ({
             <br /><br />
             <LedgerHdPaths
                 confirmedPath={confirmedPath}
-                setConfirmedPath={setConfirmedPath}
+                setConfirmedPath={(path) => {
+                    setConfirmedPath(path);
+                    Mixpanel.track('IE-Ledger Sign in set custom HD path');
+                }}
             />
             <div className='buttons-bottom-buttons'>
                 <FormButton

--- a/packages/frontend/src/components/accounts/ledger/SignInLedgerViews/Authorize.js
+++ b/packages/frontend/src/components/accounts/ledger/SignInLedgerViews/Authorize.js
@@ -2,12 +2,10 @@ import React from 'react';
 import { Translate } from 'react-localize-redux';
 
 import FormButton from '../../../common/FormButton';
-import LocalAlertBox from '../../../common/LocalAlertBox';
 import LedgerImageCircle from '../../../svg/LedgerImageCircle';
 import LedgerHdPaths from '../LedgerHdPaths';
 
 const Authorize = ({
-    status,
     confirmedPath,
     setConfirmedPath,
     handleSignIn,
@@ -20,7 +18,6 @@ const Authorize = ({
             <h1><Translate id='signInLedger.header' /></h1>
             <Translate id='signInLedger.one' />
             <br /><br />
-            <LocalAlertBox localAlert={status.localAlert} />
             <LedgerHdPaths
                 confirmedPath={confirmedPath}
                 setConfirmedPath={setConfirmedPath}

--- a/packages/frontend/src/components/accounts/ledger/SignInLedgerViews/EnterAccountId.js
+++ b/packages/frontend/src/components/accounts/ledger/SignInLedgerViews/EnterAccountId.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import { Translate } from 'react-localize-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
+import { clearLocalAlert } from '../../../../redux/actions/status';
+import { selectStatusSlice } from '../../../../redux/slices/status';
 import AccountFormAccountId from '../../../accounts/AccountFormAccountId';
 import FormButton from '../../../common/FormButton';
 import LedgerImageCircle from '../../../svg/LedgerImageCircle';
@@ -9,13 +12,15 @@ const EnterAccountId = ({
     handleAdditionalAccountId, 
     handleChange, 
     checkAccountAvailable, 
-    localAlert, 
     mainLoader, 
-    clearLocalAlert, 
     stateAccountId, 
     loader,
     clearSignInWithLedgerModalState
 }) => {
+    const dispatch = useDispatch();
+
+    const status = useSelector(selectStatusSlice);
+
     return (
         <>
             <LedgerImageCircle />
@@ -26,15 +31,15 @@ const EnterAccountId = ({
                 mainLoader={mainLoader}
                 handleChange={handleChange}
                 checkAvailability={checkAccountAvailable}
-                localAlert={localAlert}
+                localAlert={status.localAlert}
                 autoFocus={true}
-                clearLocalAlert={clearLocalAlert}
+                clearLocalAlert={() => dispatch(clearLocalAlert())}
                 stateAccountId={stateAccountId}
             />
             <div className='buttons-bottom-buttons'>
                 <FormButton
                     onClick={handleAdditionalAccountId}
-                    disabled={mainLoader || !localAlert?.success}
+                    disabled={mainLoader || !status?.localAlert?.success}
                     sending={loader}
                 >
                     <Translate id='button.confirm'/>

--- a/packages/frontend/src/components/accounts/ledger/SignInLedgerWrapper.js
+++ b/packages/frontend/src/components/accounts/ledger/SignInLedgerWrapper.js
@@ -10,10 +10,9 @@ import {
     checkAccountAvailable,
     clearAccountState
 } from '../../../redux/actions/account';
-import { clearLocalAlert } from '../../../redux/actions/status';
 import { selectAccountSlice } from '../../../redux/slices/account';
 import { actions as ledgerActions, LEDGER_MODAL_STATUS, selectLedgerSignInWithLedger, selectLedgerSignInWithLedgerStatus, selectLedgerTxSigned } from '../../../redux/slices/ledger';
-import { selectStatusMainLoader, selectStatusSlice } from '../../../redux/slices/status';
+import { selectStatusMainLoader } from '../../../redux/slices/status';
 import parseFundingOptions from '../../../utils/parseFundingOptions';
 import Container from '../../common/styled/Container.css';
 import Authorize from './SignInLedgerViews/Authorize';
@@ -44,7 +43,6 @@ export function SignInLedgerWrapper(props) {
     const ledgerHdPath = `44'/397'/0'/0'/${confirmedPath}'`;
 
     const account = useSelector(selectAccountSlice);
-    const status = useSelector(selectStatusSlice);
     const signInWithLedgerState = useSelector(selectLedgerSignInWithLedger);
     const txSigned = useSelector(selectLedgerTxSigned);
     const signInWithLedgerStatus = useSelector(selectLedgerSignInWithLedgerStatus);
@@ -125,7 +123,6 @@ export function SignInLedgerWrapper(props) {
     const LedgerView = () => {
         if (!signInWithLedgerStatus) {
             return <Authorize
-                status={status}
                 confirmedPath={confirmedPath}
                 setConfirmedPath={setConfirmedPath}
                 handleSignIn={handleSignIn}
@@ -144,10 +141,8 @@ export function SignInLedgerWrapper(props) {
                 handleAdditionalAccountId={handleAdditionalAccountId}
                 accountId={accountId}
                 handleChange={handleChange}
-                localAlert={status.localAlert}
                 checkAccountAvailable={(accountId) => dispatch(checkAccountAvailable(accountId))}
                 mainLoader={mainLoader}
-                clearLocalAlert={() => dispatch(clearLocalAlert())}
                 stateAccountId={account.accountId}
                 loader={loader}
                 clearSignInWithLedgerModalState={() => dispatch(clearSignInWithLedgerModalState())}

--- a/packages/frontend/src/components/accounts/ledger/SignInLedgerWrapper.js
+++ b/packages/frontend/src/components/accounts/ledger/SignInLedgerWrapper.js
@@ -11,7 +11,7 @@ import {
     clearAccountState
 } from '../../../redux/actions/account';
 import { selectAccountSlice } from '../../../redux/slices/account';
-import { actions as ledgerActions, LEDGER_MODAL_STATUS, selectLedgerSignInWithLedger, selectLedgerSignInWithLedgerStatus, selectLedgerTxSigned } from '../../../redux/slices/ledger';
+import { actions as ledgerActions, LEDGER_HD_PATH_PREFIX, LEDGER_MODAL_STATUS, selectLedgerSignInWithLedger, selectLedgerSignInWithLedgerStatus, selectLedgerTxSigned } from '../../../redux/slices/ledger';
 import { selectStatusMainLoader } from '../../../redux/slices/status';
 import parseFundingOptions from '../../../utils/parseFundingOptions';
 import Container from '../../common/styled/Container.css';
@@ -40,7 +40,7 @@ export function SignInLedgerWrapper(props) {
     const [accountId, setAccountId] = useState('');
     const [loader, setLoader] = useState(false);
     const [confirmedPath, setConfirmedPath] = useState(1);
-    const ledgerHdPath = `44'/397'/0'/0'/${confirmedPath}'`;
+    const ledgerHdPath = `${LEDGER_HD_PATH_PREFIX}${confirmedPath}'`;
 
     const account = useSelector(selectAccountSlice);
     const signInWithLedgerState = useSelector(selectLedgerSignInWithLedger);

--- a/packages/frontend/src/components/accounts/ledger/SignInLedgerWrapper.js
+++ b/packages/frontend/src/components/accounts/ledger/SignInLedgerWrapper.js
@@ -120,51 +120,46 @@ export function SignInLedgerWrapper(props) {
         dispatch(redirectTo('/recover-account'));
     };
 
-    const LedgerView = () => {
-        if (!signInWithLedgerStatus) {
-            return <Authorize
-                confirmedPath={confirmedPath}
-                setConfirmedPath={setConfirmedPath}
-                handleSignIn={handleSignIn}
-                signingIn={!!signInWithLedgerStatus}
-                handleCancel={handleCancelAuthorize}
-            />;
-        }
-        if (signInWithLedgerStatus === LEDGER_MODAL_STATUS.CONFIRM_PUBLIC_KEY) {
-            return <SignIn
-                txSigned={txSigned}
-                handleCancel={handleCancelSignIn}
-            />;
-        }
-        if (signInWithLedgerStatus === LEDGER_MODAL_STATUS.ENTER_ACCOUNTID) {
-            return <EnterAccountId
-                handleAdditionalAccountId={handleAdditionalAccountId}
-                accountId={accountId}
-                handleChange={handleChange}
-                checkAccountAvailable={(accountId) => dispatch(checkAccountAvailable(accountId))}
-                mainLoader={mainLoader}
-                stateAccountId={account.accountId}
-                loader={loader}
-                clearSignInWithLedgerModalState={() => dispatch(clearSignInWithLedgerModalState())}
-            />;
-        }
-        if (signInWithLedgerStatus === LEDGER_MODAL_STATUS.CONFIRM_ACCOUNTS || signInWithLedgerStatus === LEDGER_MODAL_STATUS.SUCCESS) {
-            return <ImportAccounts
-                accountsApproved={accountsApproved}
-                totalAccounts={totalAccounts}
-                ledgerAccounts={ledgerAccounts}
-                accountsError={accountsError}
-                accountsRejected={accountsRejected}
-                signInWithLedgerStatus={signInWithLedgerStatus}
-                handleContinue={handleContinue}
-            />;
-        }
-        return null;
-    };
-
     return (
         <Container className='small-centered border ledger-theme'>
-            <LedgerView />
+            {!signInWithLedgerStatus &&
+                <Authorize
+                    confirmedPath={confirmedPath}
+                    setConfirmedPath={setConfirmedPath}
+                    handleSignIn={handleSignIn}
+                    signingIn={!!signInWithLedgerStatus}
+                    handleCancel={handleCancelAuthorize}
+                />
+            }
+            {signInWithLedgerStatus === LEDGER_MODAL_STATUS.CONFIRM_PUBLIC_KEY &&
+                <SignIn
+                    txSigned={txSigned}
+                    handleCancel={handleCancelSignIn}
+                />
+            }
+            {signInWithLedgerStatus === LEDGER_MODAL_STATUS.ENTER_ACCOUNTID && 
+                <EnterAccountId
+                    handleAdditionalAccountId={handleAdditionalAccountId}
+                    accountId={accountId}
+                    handleChange={handleChange}
+                    checkAccountAvailable={(accountId) => dispatch(checkAccountAvailable(accountId))}
+                    mainLoader={mainLoader}
+                    stateAccountId={account.accountId}
+                    loader={loader}
+                    clearSignInWithLedgerModalState={() => dispatch(clearSignInWithLedgerModalState())}
+                />
+            }
+            {(signInWithLedgerStatus === LEDGER_MODAL_STATUS.CONFIRM_ACCOUNTS || signInWithLedgerStatus === LEDGER_MODAL_STATUS.SUCCESS) &&
+                <ImportAccounts
+                    accountsApproved={accountsApproved}
+                    totalAccounts={totalAccounts}
+                    ledgerAccounts={ledgerAccounts}
+                    accountsError={accountsError}
+                    accountsRejected={accountsRejected}
+                    signInWithLedgerStatus={signInWithLedgerStatus}
+                    handleContinue={handleContinue}
+                />
+            }
         </Container>
     );
 }

--- a/packages/frontend/src/components/accounts/ledger/SignInLedgerWrapper.js
+++ b/packages/frontend/src/components/accounts/ledger/SignInLedgerWrapper.js
@@ -140,7 +140,6 @@ export function SignInLedgerWrapper(props) {
             {signInWithLedgerStatus === LEDGER_MODAL_STATUS.ENTER_ACCOUNTID && 
                 <EnterAccountId
                     handleAdditionalAccountId={handleAdditionalAccountId}
-                    accountId={accountId}
                     handleChange={handleChange}
                     checkAccountAvailable={(accountId) => dispatch(checkAccountAvailable(accountId))}
                     mainLoader={mainLoader}

--- a/packages/frontend/src/components/accounts/ledger/SignInLedgerWrapper.js
+++ b/packages/frontend/src/components/accounts/ledger/SignInLedgerWrapper.js
@@ -40,9 +40,8 @@ export function SignInLedgerWrapper(props) {
 
     const [accountId, setAccountId] = useState('');
     const [loader, setLoader] = useState(false);
-    const [path, setPath] = useState(1);
-    const [confirmedPath, setConfirmedPath] = useState(null);
-    const ledgerHdPath = confirmedPath ? `44'/397'/0'/0'/${confirmedPath}'` : null;
+    const [confirmedPath, setConfirmedPath] = useState(1);
+    const ledgerHdPath = `44'/397'/0'/0'/${confirmedPath}'`;
 
     const account = useSelector(selectAccountSlice);
     const status = useSelector(selectStatusSlice);
@@ -127,8 +126,7 @@ export function SignInLedgerWrapper(props) {
         if (!signInWithLedgerStatus) {
             return <Authorize
                 status={status}
-                path={path}
-                setPath={setPath}
+                confirmedPath={confirmedPath}
                 setConfirmedPath={setConfirmedPath}
                 handleSignIn={handleSignIn}
                 signingIn={!!signInWithLedgerStatus}

--- a/packages/frontend/src/redux/slices/ledger/index.js
+++ b/packages/frontend/src/redux/slices/ledger/index.js
@@ -15,6 +15,8 @@ import refreshAccountOwner from '../../sharedThunks/refreshAccountOwner';
 
 const SLICE_NAME = 'ledger';
 
+export const LEDGER_HD_PATH_PREFIX = '44\'/397\'/0\'/0\'/';
+
 export const LEDGER_MODAL_STATUS = {
     CONFIRM_PUBLIC_KEY: 'confirm-public-key',
     CONFIRM_ACCOUNTS: 'confirm-accounts',

--- a/packages/frontend/src/redux/slices/ledger/index.js
+++ b/packages/frontend/src/redux/slices/ledger/index.js
@@ -105,9 +105,7 @@ const signInWithLedgerAddAndSaveAccounts = createAsyncThunk(
     async ({ path, accountIds }, { dispatch, getState }) => {
         for (let accountId of accountIds) {
             try {
-                if (path) {
-                    setLedgerHdPath({ accountId, path });
-                }
+                setLedgerHdPath({ accountId, path });
                 await dispatch(addLedgerAccountId({ accountId })).unwrap();
                 dispatch(ledgerSlice.actions.setLedgerTxSigned({ status: false, accountId }));
             } catch (e) {


### PR DESCRIPTION
Changes:
 - fixing closing dropdown while changing HD path - now it will close only when confirmed by clicking a button
 - fixing saving HD path in the local storage - before HD path was saved only if it wasn't the default path, which causes a few problems, now it's saved always in `signInWithLedgerAddAndSaveAccounts` thunk so it's always up to date
  - fixing choosing HD path, it was problematic if a user opens dropdown and changed path a few times
   - fixing closing dropdown without any action