### PR TITLE
fix: enable and fix USN with copy update

### DIFF
--- a/features/flags.json
+++ b/features/flags.json
@@ -47,44 +47,44 @@
     "createdBy": "OlegYak ",
     "createdAt": "2022-03-24T13:11:21.223Z",
     "development": {
-      "enabled": false,
+      "enabled": true,
       "lastEditedBy": "esaminu",
-      "lastEditedAt": "2022-05-05T22:23:33.682Z"
+      "lastEditedAt": "2022-05-11T20:22:15.771Z"
     },
     "testnet": {
-      "enabled": false,
+      "enabled": true,
       "lastEditedBy": "esaminu",
-      "lastEditedAt": "2022-05-05T22:23:33.682Z"
+      "lastEditedAt": "2022-05-11T22:37:08.020Z"
     },
     "mainnet": {
-      "enabled": false,
+      "enabled": true,
       "lastEditedBy": "esaminu",
-      "lastEditedAt": "2022-05-05T22:23:33.682Z"
+      "lastEditedAt": "2022-05-11T22:37:08.020Z"
     },
     "mainnet_STAGING": {
-      "enabled": false,
+      "enabled": true,
       "lastEditedBy": "esaminu",
-      "lastEditedAt": "2022-05-05T22:23:33.682Z"
+      "lastEditedAt": "2022-05-11T22:37:08.020Z"
     },
     "testnet_STAGING": {
-      "enabled": false,
+      "enabled": true,
       "lastEditedBy": "esaminu",
-      "lastEditedAt": "2022-05-05T22:23:33.682Z"
+      "lastEditedAt": "2022-05-11T22:37:08.020Z"
     },
     "testnet_NEARORG": {
       "enabled": false,
       "lastEditedBy": "esaminu",
-      "lastEditedAt": "2022-05-05T18:07:50.110Z"
+      "lastEditedAt": "2022-05-11T22:37:08.020Z"
     },
     "mainnet_NEARORG": {
       "enabled": false,
       "lastEditedBy": "esaminu",
-      "lastEditedAt": "2022-05-05T18:06:54.374Z"
+      "lastEditedAt": "2022-05-11T22:37:08.020Z"
     },
     "mainnet_STAGING_NEARORG": {
       "enabled": false,
       "lastEditedBy": "esaminu",
-      "lastEditedAt": "2022-05-05T18:07:28.665Z"
+      "lastEditedAt": "2022-05-11T22:37:08.020Z"
     }
   },
   "DONATE_TO_UKRAINE": {

--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -13,6 +13,7 @@ import styled, { ThemeProvider } from 'styled-components';
 import {
     CREATE_IMPLICIT_ACCOUNT,
     IMPORT_ACCOUNT_WITH_LINK_V2,
+    CREATE_USN_CONTRACT
 } from '../../../../features';
 import TwoFactorVerifyModal from '../components/accounts/two_factor/TwoFactorVerifyModal';
 import {
@@ -92,10 +93,9 @@ import { Profile } from './profile/Profile';
 import { ReceiveContainerWrapper } from './receive-money/ReceiveContainerWrapper';
 import { SendContainerWrapper } from './send/SendContainerWrapper';
 import { StakingContainer } from './staking/StakingContainer';
+import SwapContainerWrapper from './Swap/SwapContainerWrapper';
 import Terms from './terms/Terms';
 import { SwapNear } from './wrap/SwapNear';
-
-
 import '../index.css';
 
 const { fetchTokenFiatValues, getTokenWhiteList } = tokenFiatValueActions;
@@ -620,11 +620,12 @@ class Routing extends Component {
                                 path="/buy"
                                 component={BuyNear}
                             />
+                            {CREATE_USN_CONTRACT &&    
                             <PrivateRoute
                                 exact
-                                path='/swap'
-                                component={SwapNear}
-                            />  
+                                path="/swap-usn"
+                                component={SwapContainerWrapper}
+                            />}
                             <PrivateRoute
                                 exact
                                 path="/swap"

--- a/packages/frontend/src/components/Swap/views/SwapPage.js
+++ b/packages/frontend/src/components/Swap/views/SwapPage.js
@@ -72,7 +72,7 @@ const SwapPage = ({
         <>
             <Loader onRefreshMultiplier={() => dispatch(fetchMultiplier())}/>
             <h1>
-                <Translate id="button.swap"/>
+                <Translate id="button.swapUSN"/>
             </h1>
             <SwapTokenContainer
                 text="swap.from"

--- a/packages/frontend/src/components/navigation/NavLinks.js
+++ b/packages/frontend/src/components/navigation/NavLinks.js
@@ -124,7 +124,7 @@ const NavLinks = () => (
         </a>
         {CREATE_USN_CONTRACT && 
         <NavLink
-            to="/swap-money"
+            to="/swap-usn"
             activeClassName="selected"
             onClick={() => Mixpanel.track('Click Swap button on nav')}
         >
@@ -137,7 +137,7 @@ const NavLinks = () => (
                 />
             </div>
 
-            <Translate id="button.swap" />
+            <Translate id="button.swapUSN" />
         </NavLink>}
         {DONATE_TO_UKRAINE && 
         <NavLink

--- a/packages/frontend/src/components/wallet/TokenBox.js
+++ b/packages/frontend/src/components/wallet/TokenBox.js
@@ -229,7 +229,7 @@ const TokenBox = ({ token, onClick, currentLanguage }) => {
                         <Swap
                             symbol={token.onChainFTMetadata?.symbol === 'NEAR'}
                             disable={!token.balance || token.balance === '0'} 
-                            linkTo={!token.balance || token.balance === '0' ? false : '/swap-money'}
+                            linkTo={!token.balance || token.balance === '0' ? false : '/swap-usn'}
                             onClick={() => dispatch(handleSwapByContractName(token.onChainFTMetadata?.symbol === 'NEAR' ? 'USN' : 'NEAR'))}
                         />
                     </div>

--- a/packages/frontend/src/components/wallet/Wallet.js
+++ b/packages/frontend/src/components/wallet/Wallet.js
@@ -423,14 +423,14 @@ const FungibleTokens = ({
                 {CREATE_USN_CONTRACT && (
                     <FormButton
                         color="dark-gray"
-                        linkTo="/swap-money"
+                        linkTo="/swap-usn"
                         trackingId="Click Receive on Wallet page"
                         data-test-id="balancesTab.buy"
                     >
                         <div>
                             <Swap />
                         </div>
-                        <Translate id="button.swap" />
+                        <Translate id="button.swapUSN" />
                     </FormButton>
                 )}
                 <FormButton

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -274,6 +274,7 @@
         "startOver": "Start over",
         "subscribe": "Subscribe",
         "swap": "Swap",
+        "swapUSN": "Swap USN",
         "ToMaine": "To the main screen",
         "topUp": "Top Up",
         "transferring": "Transferring",


### PR DESCRIPTION
This PR:

- Enables USN feature on non `_NEARORG` environments
- Re-adds the USN route (removed in #2621)
- Updates the USN route to `/swap-usn` from `/swap-money`
- Updates the copy on the Swap button, Swap navlink and `swap-usn` title to "Swap USN" from "Swap" to avoid duplicate

