### PR TITLE
fix: wallet buttons overflow

### DIFF
--- a/packages/frontend/src/components/wallet/Wallet.js
+++ b/packages/frontend/src/components/wallet/Wallet.js
@@ -121,10 +121,10 @@ const StyledContainer = styled(Container)`
 
         .buttons {
             display: flex;
-            justify-content: center;
-            align-items: center;
+            align-items: flex-start;
             margin: 30px 0;
             width: 100%;
+            overflow: scroll;
 
             button {
                 display: flex;
@@ -148,6 +148,14 @@ const StyledContainer = styled(Container)`
                     > div {
                         background-color: black;
                     }
+                }
+
+                :first-child { 
+                    margin-left: auto;
+                }
+    
+                :last-child {
+                    margin-right: auto;
                 }
 
                 > div {

--- a/packages/frontend/src/components/wallet/Wallet.js
+++ b/packages/frontend/src/components/wallet/Wallet.js
@@ -122,9 +122,26 @@ const StyledContainer = styled(Container)`
         .buttons {
             display: flex;
             align-items: flex-start;
-            margin: 30px 0;
-            width: 100%;
+            margin: 30px -14px;
+            width: calc(100% + 28px);
             overflow: scroll;
+            padding: 0 14px;
+
+            background-image: linear-gradient(to right, white, white),
+            linear-gradient(to right, white, white),
+            linear-gradient(to right, rgba(0, 0, 0, 0.25), rgba(255, 255, 255, 0)),
+            linear-gradient(to left, rgba(0, 0, 0, 0.25), rgba(255, 255, 255, 0));
+            background-position: left center, right center, left center, right center;
+            background-repeat: no-repeat;
+            background-color: white;
+            background-size: 20px 100%, 20px 100%, 10px 100%, 10px 100%;
+            background-attachment: local, local, scroll, scroll;
+
+            @media (min-width: 992px) {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+            }
 
             button {
                 display: flex;


### PR DESCRIPTION
This PR fixes styles on mobile when 5 buttons are rendered on the wallet dashboard and adds a shadow to indicate that the content can be horizontally scrolled