### PR TITLE
Refactor tokens selectors to take accountId from activeAccount reducer

### DIFF
--- a/packages/frontend/src/hooks/fungibleTokensIncludingNEAR.js
+++ b/packages/frontend/src/hooks/fungibleTokensIncludingNEAR.js
@@ -1,13 +1,13 @@
 import { useSelector } from 'react-redux';
 
 import selectNEARAsTokenWithMetadata from '../redux/selectors/crossStateSelectors/selectNEARAsTokenWithMetadata';
-import { selectAccountId } from '../redux/slices/account';
+import { selectActiveAccountId } from '../redux/slices/activeAccount';
 import { selectTokensFiatValueUSD } from '../redux/slices/tokenFiatValues';
 import { selectTokensWithMetadataForAccountId } from '../redux/slices/tokens';
 
 export const useFungibleTokensIncludingNEAR = function () {
     const NEARAsTokenWithMetadata = useSelector(selectNEARAsTokenWithMetadata);
-    const accountId = useSelector(selectAccountId);
+    const accountId = useSelector(selectActiveAccountId);
     const fungibleTokens = useSelector((state) =>
         selectTokensWithMetadataForAccountId(state, { accountId })
     );


### PR DESCRIPTION
Before, selectors that were selecting tokens for an active account were receiving accountId from `selectAccountId` selector. Since we introduce `activeAccount` reducer, these selectors can use accountId from `activeAccount` reducer (`selectActiveAccountId` selector). Thanks to that, while switching accounts we will be able to show the list of tokens immediately.