### PR TITLE
Revert "fix: Fix desktop nav horizontal overflow"

### DIFF
--- a/packages/frontend/src/components/navigation/DesktopContainer.js
+++ b/packages/frontend/src/components/navigation/DesktopContainer.js
@@ -20,7 +20,6 @@ const Container = styled.div`
 
     @media (min-width: 992px) {
         display: flex;
-        overflow-y: auto;
     }
 
     background-color: white;


### PR DESCRIPTION
Reverts near/near-wallet#2677

Reverting this fix as it causes desktop menu to be hidden because of overflow