### PR TITLE
feat: Enable import of zero balance Ledger account (testnet)

### DIFF
--- a/packages/frontend/src/components/accounts/CouldNotFindAccountModal.js
+++ b/packages/frontend/src/components/accounts/CouldNotFindAccountModal.js
@@ -27,7 +27,8 @@ const Container = styled.div`
 export function CouldNotFindAccountModal ({
     isOpen,
     onClickImport,
-    onClose
+    onClose,
+    recoveryMethod
  }) {
     return (
         <Modal
@@ -38,7 +39,10 @@ export function CouldNotFindAccountModal ({
         >
             <Container>
                 <h3><Translate id='recoverSeedPhrase.couldNotFindAccountModal.title'/></h3>
-                <p><Translate id='recoverSeedPhrase.couldNotFindAccountModal.desc'/></p>
+                {recoveryMethod === 'ledger'
+                    ? <p><Translate id='recoverSeedPhrase.couldNotFindAccountModal.desc.ledger'/></p>
+                    : <p><Translate id='recoverSeedPhrase.couldNotFindAccountModal.desc.phrase'/></p>
+                }
                 <FormButton onClick={onClickImport}><Translate id='recoverSeedPhrase.couldNotFindAccountModal.buttonImport'/></FormButton>
                 <FormButton className='link' onClick={onClose}><Translate id='button.cancel'/></FormButton>
             </Container>

--- a/packages/frontend/src/components/accounts/CouldNotFindAccountModalWrapper.js
+++ b/packages/frontend/src/components/accounts/CouldNotFindAccountModalWrapper.js
@@ -3,38 +3,91 @@ import { useDispatch } from 'react-redux';
 
 import {
     redirectTo,
-    refreshAccount
+    refreshAccount,
+    getLedgerPublicKey
 } from '../../redux/actions/account';
 import { showCustomAlert, clearGlobalAlert } from '../../redux/actions/status';
+import { setLedgerHdPath } from '../../utils/localStorage';
 import { getImplicitAccountIdFromSeedPhrase, getKeyPairFromSeedPhrase } from '../../utils/parseSeedPhrase';
-import { wallet } from '../../utils/wallet';
+import { wallet, setKeyMeta } from '../../utils/wallet';
 import { CouldNotFindAccountModal } from './CouldNotFindAccountModal';
 
-export function CouldNotFindAccountModalWrapper ({
+export function CouldNotFindAccountModalWrapper({
     isOpen,
     onClose,
-    seedPhrase
+    seedPhrase,
+    ledgerHdPath,
+    recoveryMethod
 }) {
     const dispatch = useDispatch();
+
+    const handleImportNonLedgerImplicitAccount = async () => {
+        const recoveryKeyPair = getKeyPairFromSeedPhrase(seedPhrase);
+        const implicitAccountId = getImplicitAccountIdFromSeedPhrase(seedPhrase);
+        try {
+            await wallet.importZeroBalanceAccount(implicitAccountId, recoveryKeyPair);
+            dispatch(refreshAccount());
+            dispatch(redirectTo('/'));
+            dispatch(clearGlobalAlert());
+        } catch (e) {
+            dispatch(showCustomAlert({
+                success: false,
+                messageCodeHeader: 'error',
+                messageCode: 'walletErrorCodes.recoverAccountSeedPhrase.errorNotAbleToImportAccount',
+                errorMessage: e.message
+            }));
+        }
+    };
+
+    const handleImportLedgerImplicitAccount = async () => {
+        try {
+            const ledgerPublicKey = await dispatch(getLedgerPublicKey(ledgerHdPath));
+            const implicitAccountId = Buffer.from(ledgerPublicKey.data).toString('hex');
+            const account = wallet.getAccountBasic(implicitAccountId);
+            try {
+                const accountState = await account.state();
+                if (accountState) {
+                    const errorMessage = `Implicit account ID ${implicitAccountId} derived from Ledger HD path ${ledgerHdPath} already exists but is not controlled by this Ledger device.`;
+                    // This could happen if user creates an implicit account with Ledger but then switches to seed phrase recovery, etc.
+                    console.log(errorMessage);
+                    dispatch(showCustomAlert({
+                        errorMessage: errorMessage,
+                        success: false,
+                        messageCodeHeader: 'error'
+                    }));
+                    return;
+                }
+            } catch (e) {
+                if (e.message.includes('does not exist while viewing')) {
+                    console.log('Ledger implicit Account ID does not exist on chain. Importing as zero balance account.');
+                    await setKeyMeta(ledgerPublicKey, { type: 'ledger' });
+                    await setLedgerHdPath({ accountId: implicitAccountId, path: ledgerHdPath });
+                    await wallet.importZeroBalanceAccount(implicitAccountId);
+                    dispatch(refreshAccount());
+                    dispatch(redirectTo('/'));
+                } else {
+                    throw e;
+                }
+            }
+        } catch (e) {
+            dispatch(showCustomAlert({
+                errorMessage: e.message,
+                success: false,
+                messageCodeHeader: 'error'
+            }));
+        }
+    };
+
     return (
         <CouldNotFindAccountModal
             isOpen={isOpen}
             onClose={onClose}
+            recoveryMethod={recoveryMethod}
             onClickImport={async () => {
-                const recoveryKeyPair = getKeyPairFromSeedPhrase(seedPhrase);
-                const implicitAccountId = getImplicitAccountIdFromSeedPhrase(seedPhrase);
-                try {
-                    await wallet.importZeroBalanceAccount(implicitAccountId, recoveryKeyPair);
-                    dispatch(refreshAccount());
-                    dispatch(redirectTo('/'));
-                    dispatch(clearGlobalAlert());
-                } catch (e) {
-                    dispatch(showCustomAlert({
-                        success: false,
-                        messageCodeHeader: 'error',
-                        messageCode: 'walletErrorCodes.recoverAccountSeedPhrase.errorNotAbleToImportAccount',
-                        errorMessage: e.message
-                    }));
+                if (recoveryMethod === 'ledger') {
+                    await handleImportLedgerImplicitAccount();
+                } else {
+                    await handleImportNonLedgerImplicitAccount();
                 }
             }}
         />

--- a/packages/frontend/src/components/accounts/CouldNotFindAccountModalWrapper.js
+++ b/packages/frontend/src/components/accounts/CouldNotFindAccountModalWrapper.js
@@ -26,9 +26,6 @@ export function CouldNotFindAccountModalWrapper({
         const implicitAccountId = getImplicitAccountIdFromSeedPhrase(seedPhrase);
         try {
             await wallet.importZeroBalanceAccount(implicitAccountId, recoveryKeyPair);
-            dispatch(refreshAccount());
-            dispatch(redirectTo('/'));
-            dispatch(clearGlobalAlert());
         } catch (e) {
             dispatch(showCustomAlert({
                 success: false,
@@ -63,8 +60,6 @@ export function CouldNotFindAccountModalWrapper({
                     await setKeyMeta(ledgerPublicKey, { type: 'ledger' });
                     await setLedgerHdPath({ accountId: implicitAccountId, path: ledgerHdPath });
                     await wallet.importZeroBalanceAccount(implicitAccountId);
-                    dispatch(refreshAccount());
-                    dispatch(redirectTo('/'));
                 } else {
                     throw e;
                 }
@@ -89,6 +84,9 @@ export function CouldNotFindAccountModalWrapper({
                 } else {
                     await handleImportNonLedgerImplicitAccount();
                 }
+                dispatch(refreshAccount());
+                dispatch(redirectTo('/'));
+                dispatch(clearGlobalAlert());
             }}
         />
     );

--- a/packages/frontend/src/components/accounts/ledger/SignInLedgerWrapper.js
+++ b/packages/frontend/src/components/accounts/ledger/SignInLedgerWrapper.js
@@ -41,7 +41,7 @@ export function SignInLedgerWrapper(props) {
 
     const [accountId, setAccountId] = useState('');
     const [loader, setLoader] = useState(false);
-    const [confirmedPath, setConfirmedPath] = useState(10);
+    const [confirmedPath, setConfirmedPath] = useState(1);
     const [showCouldNotFindAccountModal, setShowCouldNotFindAccountModal] = useState(false);
     const ledgerHdPath = `${LEDGER_HD_PATH_PREFIX}${confirmedPath}'`;
 

--- a/packages/frontend/src/components/accounts/ledger/SignInLedgerWrapper.js
+++ b/packages/frontend/src/components/accounts/ledger/SignInLedgerWrapper.js
@@ -2,6 +2,7 @@ import { parse as parseQuery, stringify } from 'query-string';
 import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
+import { IMPORT_ZERO_BALANCE_ACCOUNT } from '../../../../../../features';
 import { CouldNotFindAccountModalWrapper } from '../../../components/accounts/CouldNotFindAccountModalWrapper';
 import { Mixpanel } from '../../../mixpanel/index';
 import {
@@ -67,8 +68,10 @@ export function SignInLedgerWrapper(props) {
     }, []);
 
     useEffect(() => {
-        if (signInWithLedgerStatus === LEDGER_MODAL_STATUS.ENTER_ACCOUNTID) {
-            setShowCouldNotFindAccountModal(true);
+        if (IMPORT_ZERO_BALANCE_ACCOUNT) {
+            if (signInWithLedgerStatus === LEDGER_MODAL_STATUS.ENTER_ACCOUNTID) {
+                setShowCouldNotFindAccountModal(true);
+            }
         }
     }, [signInWithLedgerStatus]);
 

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -896,7 +896,10 @@
     "recoverSeedPhrase": {
         "couldNotFindAccountModal": {
             "buttonImport": "Import Anyway",
-            "desc": "We couldn't find any <b>active account(s)</b> using the provided passphrase. This could be because the passphrase is incorrect, or because the account has no activity yet.",
+            "desc": {
+                "ledger": "We couldn't find any <b>active account(s)</b> using the provided Ledger key. This could be because the account has no activity yet.",
+                "phrase": "We couldn't find any <b>active account(s)</b> using the provided passphrase. This could be because the passphrase is incorrect, or because the account has no activity yet."
+            },
             "title": "Couldn't find account"
         },
         "pageText": "Enter the backup passphrase associated with the account.",


### PR DESCRIPTION
This enables a user to import a non-existent Ledger implicit account into the wallet (on testnet)

To test:
1. Go to `https://my-near-wallet-pr-2679.onrender.com/sign-in-ledger`
2. Change Ledger HD path to any path without an existing account
3. Try importing the account
4. Click 'Import anyway' when prompted
5. Confirm key on Ledger device
6. Observe that the Ledger account has been imported with given key