### PR TITLE
WAL-321 Claim validator rewards on 2FA enabled account

### DIFF
--- a/packages/frontend/src/redux/actions/staking.js
+++ b/packages/frontend/src/redux/actions/staking.js
@@ -414,7 +414,7 @@ export const { staking } = createActions({
                     .filter((v) => v.indexOf('nfvalidator') === -1 && v.match(prefix));
             }
 
-            const currentAccount = wallet.getAccountBasic(accountId);
+            const currentAccount = await wallet.getAccount(accountId);
 
             return (await Promise.all(
                 accountIds.map(async (account_id) => {


### PR DESCRIPTION
Accounts with 2FA enabled are not able to claim validator rewards.

Currently, validator `Contracts` have no awareness of 2FA enabled accounts. This means contract calls are signed with the limited access 2FA key rather than going through the accounts multisig contract. This results in an error for function calls which also have a `deposit`, like `claim`, as these [must be signed with a full access key](https://github.com/near/nearcore/blob/master/core/primitives/src/errors.rs#L170).

This PR updates validator `Contract` to be instantiated with a 2FA aware `Account`.