### PR TITLE
feat: add copy button to address list

### DIFF
--- a/packages/frontend/src/components/accounts/account_selector/Account.js
+++ b/packages/frontend/src/components/accounts/account_selector/Account.js
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import Balance from '../../common/balance/Balance';
+import ClickToCopy from '../../common/ClickToCopy';
+import CopyIcon from '../../svg/CopyIcon';
 import EyeIcon from './EyeIcon';
 
 const StyledContainer = styled.div`
@@ -14,13 +16,21 @@ const StyledContainer = styled.div`
     color: #72727A;
     margin: 8px 0;
 
-    > div {
+    > .details {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
         margin-right: 10px;
     }
 
+    > .copy {
+        margin: 0 8px 0 auto;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+
+    > .copy,
     > svg {
         cursor: pointer;
         min-width: 32px;
@@ -85,7 +95,7 @@ export default ({
     const [showBalance, setShowBalance] = useState(defaultShowBalance);
     return (
         <StyledContainer className={active ? 'active' : ''} onClick={onSelectAccount}>
-            <div>
+            <div className='details'>
                 <div className='account-id'>{accountId}</div>
                 <div className='balance'>
                     {showBalance
@@ -99,6 +109,9 @@ export default ({
                     }
                 </div>
             </div>
+            <ClickToCopy copy={accountId} className='copy'>
+                <CopyIcon color='#2B9AF4' />
+            </ClickToCopy>
             <EyeIcon
                 show={showBalance}
                 onClick={(e) => {

--- a/packages/frontend/src/components/accounts/account_selector/Account.js
+++ b/packages/frontend/src/components/accounts/account_selector/Account.js
@@ -109,7 +109,7 @@ export default ({
                     }
                 </div>
             </div>
-            <ClickToCopy copy={accountId} className='copy'>
+            <ClickToCopy copy={accountId} className='copy' onClick={(e) => e.stopPropagation()}>
                 <CopyIcon color='#2B9AF4' />
             </ClickToCopy>
             <EyeIcon

--- a/packages/frontend/src/components/accounts/account_selector/Account.js
+++ b/packages/frontend/src/components/accounts/account_selector/Account.js
@@ -109,7 +109,7 @@ export default ({
                     }
                 </div>
             </div>
-            <ClickToCopy copy={accountId} className='copy' onClick={(e) => e.stopPropagation()}>
+            <ClickToCopy copy={accountId} className='copy' compact={true} onClick={(e) => e.stopPropagation()}>
                 <CopyIcon color='#2B9AF4' />
             </ClickToCopy>
             <EyeIcon

--- a/packages/frontend/src/components/common/ClickToCopy.js
+++ b/packages/frontend/src/components/common/ClickToCopy.js
@@ -34,7 +34,7 @@ const Container = styled.div`
     }
 `;
 
-const ClickToCopy = ({ className, children, copy, translate = 'default' }) => {
+const ClickToCopy = ({ className, children, copy, successTranslation = 'default' }) => {
     const [show, setShow] = useState(false);
 
     const handleCopy = () => {
@@ -51,12 +51,20 @@ const ClickToCopy = ({ className, children, copy, translate = 'default' }) => {
     };
 
     return (
-        <Container title="Copy to clipboard" className={classNames([className, show ? 'show' : ''])} onClick={handleCopy}>
-            {children}
-            <div className='copy-success'>
-                <Translate id={`copy.${translate}`}/>
-            </div>
-        </Container>
+        <Translate>
+            {({ translate }) =>
+                <Container
+                    title={translate('copy.title')}
+                    className={classNames([className, show ? 'show' : ''])}
+                    onClick={handleCopy}
+                >
+                    {children}
+                    <div className='copy-success'>
+                        <Translate id={`copy.${successTranslation}`}/>
+                    </div>
+                </Container>
+            }
+        </Translate>
     );
 };
 

--- a/packages/frontend/src/components/common/ClickToCopy.js
+++ b/packages/frontend/src/components/common/ClickToCopy.js
@@ -34,10 +34,10 @@ const Container = styled.div`
     }
 `;
 
-const ClickToCopy = ({ className, children, copy, successTranslation = 'default' }) => {
+const ClickToCopy = ({ className, children, copy, onClick, successTranslation = 'default' }) => {
     const [show, setShow] = useState(false);
 
-    const handleCopy = () => {
+    const handleCopy = (e) => {
         Mixpanel.track('Click to copy text');
         setShow(true);
         setTimeout (() => setShow(false), 2000);
@@ -47,6 +47,9 @@ const ClickToCopy = ({ className, children, copy, successTranslation = 'default'
         input.select();
         const result = document.execCommand('copy');
         document.body.removeChild(input);
+        if (onClick) {
+            onClick(e);
+        }
         return result;
     };
 

--- a/packages/frontend/src/components/common/ClickToCopy.js
+++ b/packages/frontend/src/components/common/ClickToCopy.js
@@ -19,7 +19,7 @@ const Container = styled.div`
         border-radius: 4px;
         padding: 6px 8px;
         font-size: 13px;
-        top: -24px;
+        top: -30px;
         opacity: 0;
         pointer-events: none;
         transition: 200ms;
@@ -28,13 +28,22 @@ const Container = styled.div`
 
     &.show {
         .copy-success {
-            top: -32px;
+            top: -40px;
             opacity: 1;
+        }
+    }
+
+    &.compact {
+        .copy-success {
+            top: -18px;
+        }
+        &.show .copy-success {
+            top: -28px;
         }
     }
 `;
 
-const ClickToCopy = ({ className, children, copy, onClick, successTranslation = 'default' }) => {
+const ClickToCopy = ({ className, children, compact, copy, onClick, successTranslation = 'default' }) => {
     const [show, setShow] = useState(false);
 
     const handleCopy = (e) => {
@@ -58,7 +67,11 @@ const ClickToCopy = ({ className, children, copy, onClick, successTranslation = 
             {({ translate }) =>
                 <Container
                     title={translate('copy.title')}
-                    className={classNames([className, show ? 'show' : ''])}
+                    className={classNames([
+                        className,
+                        show ? 'show' : '',
+                        compact ? 'compact': ''
+                    ])}
                     onClick={handleCopy}
                 >
                     {children}

--- a/packages/frontend/src/components/common/ClickToCopy.js
+++ b/packages/frontend/src/components/common/ClickToCopy.js
@@ -19,7 +19,7 @@ const Container = styled.div`
         border-radius: 4px;
         padding: 6px 8px;
         font-size: 13px;
-        top: -30px;
+        top: -24px;
         opacity: 0;
         pointer-events: none;
         transition: 200ms;
@@ -28,7 +28,7 @@ const Container = styled.div`
 
     &.show {
         .copy-success {
-            top: -40px;
+            top: -32px;
             opacity: 1;
         }
     }
@@ -51,7 +51,7 @@ const ClickToCopy = ({ className, children, copy, translate = 'default' }) => {
     };
 
     return (
-        <Container title={copy} className={classNames([className, show ? 'show' : ''])} onClick={handleCopy}>
+        <Container title="Copy to clipboard" className={classNames([className, show ? 'show' : ''])} onClick={handleCopy}>
             {children}
             <div className='copy-success'>
                 <Translate id={`copy.${translate}`}/>


### PR DESCRIPTION
Adds a "Copy to clipboard" button to the accounts list.

This required a nudge on the "Copied" text so that it doesn't cut off by the surrounding list.
Also changes the tooltip text to a description of what the button does.

Fixes https://github.com/near/near-wallet/issues/2620

<img width="325" alt="image" src="https://user-images.githubusercontent.com/94780425/168972090-ed768dfb-de73-4022-a0c7-4fb1b9627e09.png">

<img width="493" alt="image" src="https://user-images.githubusercontent.com/94780425/168972571-7e96f4b4-babd-486a-acbf-154d6f69f706.png">
