### PR TITLE
fix: Ensure `Account` is instantiated with valid `accountId`

### DIFF
--- a/packages/frontend/src/redux/actions/staking.js
+++ b/packages/frontend/src/redux/actions/staking.js
@@ -480,7 +480,7 @@ export const handleStakingUpdateAccount = (recentlyStakedValidators = [], exAcco
     const validatorDepositMap = await getStakingDeposits(accountId);
 
     if (!selectStakingAllValidatorsLength(getState())) {
-        await dispatch(staking.getValidators(null, exAccountId));
+        await dispatch(staking.getValidators(null, accountId));
     }
 
     const validators = selectStakingAllValidators(getState())


### PR DESCRIPTION
`getValidators` creates an `Account` with the passed `accountId` to call view methods on the validator contracts. Now that this `Account` is 2FA aware (#2680), it will also call `account.state()` to check if the current account has 2FA enabled. This call will fail if the original `accountId` is `undefined`, which `exAccountId` sometimes is. This PR updates `getValidators()` call to use `accountId` which is known to exist.
