### PR TITLE
Kwlt 6 ability to export private keys

### DIFF
--- a/packages/frontend/src/components/profile/Profile.js
+++ b/packages/frontend/src/components/profile/Profile.js
@@ -203,8 +203,8 @@ export function Profile({ match }) {
 
     useEffect(() => {
         wallet.getLocalKeyPair(accountId).then(async (keyPair) => {
-            const isFullAccessKey = await wallet.isFullAccessKey(accountId, keyPair);
-            setSecretKey(isFullAccessKey ? keyPair : null);
+            const isFullAccessKey = keyPair && await wallet.isFullAccessKey(accountId, keyPair);
+            setSecretKey(isFullAccessKey ? keyPair.toString() : null);
         });
     },[userRecoveryMethods]);
 

--- a/packages/frontend/src/components/profile/export_private_key/ExportKeyModal.js
+++ b/packages/frontend/src/components/profile/export_private_key/ExportKeyModal.js
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import CheckMarkNoBorderIcon from '../../../images/icon-check-no-border.svg';
 import { selectAccountId } from '../../../redux/slices/account';
 import isMobile from '../../../utils/isMobile';
+import ClickToCopy from '../../common/ClickToCopy';
 import FormButton from '../../common/FormButton';
 import Modal from '../../common/modal/Modal';
 
@@ -128,9 +129,11 @@ const ExportKeyModalBody = ({ currentView, setCurrentView, onClose, secretKey })
     case VIEWS.VIEW_PRIVATE_KEY:
       return (
         <>
-          <div className='text-select-display'>
-            {secretKey}
-          </div>
+          <ClickToCopy copy={secretKey}>
+            <div className='text-select-display'>
+              {secretKey}
+            </div>
+          </ClickToCopy>
           <FormButton onClick={onClose}>
             <Translate id='button.dismiss' />
           </FormButton>

--- a/packages/frontend/src/components/profile/export_private_key/ExportKeyModal.js
+++ b/packages/frontend/src/components/profile/export_private_key/ExportKeyModal.js
@@ -67,11 +67,7 @@ const Container = styled.div`
           display: flex;
           flex-direction: row;
           align-items: flex-start;
-          padding: 12px;
-          gap: 8px;
-
-          height: 96px;
-          width: 99%;
+          padding: 20px;
 
           background: #272729;
           border-radius: 8px;

--- a/packages/frontend/src/components/profile/export_private_key/ExportKeyModal.js
+++ b/packages/frontend/src/components/profile/export_private_key/ExportKeyModal.js
@@ -1,0 +1,175 @@
+import React, { useState } from 'react';
+import { Translate } from 'react-localize-redux';
+import { useSelector } from 'react-redux';
+import styled from 'styled-components';
+
+import CheckMarkNoBorderIcon from '../../../images/icon-check-no-border.svg';
+import { selectAccountId } from '../../../redux/slices/account';
+import isMobile from '../../../utils/isMobile';
+import FormButton from '../../common/FormButton';
+import Modal from '../../common/modal/Modal';
+
+const Container = styled.div`
+    &&&&& {
+        padding: 15px 0 10px 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+
+        h3 {
+            margin: 15px 0;
+            font-size: 18px;
+            font-weight: 700;
+        }
+
+        p {
+            line-height: 1.5;
+            font-size: 14px;
+        }
+
+        label {
+            text-align: left;
+            display: flex;
+            background-color: #F5FAFF;
+            margin: 25px -25px 0 -25px;
+            padding: 15px 25px;
+            line-height: 1.5;
+
+            > div {
+                > div {
+                    border-color: #0081F1;
+                }
+            }
+
+            > span {
+                margin-left: 10px;
+                word-break: break-word;
+                color: #006ADC;
+            }
+
+            b {
+                color: #272729;
+            }
+        }
+
+        > button {
+            margin-top: 32px;
+            width: 100%;
+        }
+
+        .link {
+          margin-top: 20px;
+        }
+
+        .text-select-display {
+          display: flex;
+          flex-direction: row;
+          align-items: flex-start;
+          padding: 12px;
+          gap: 8px;
+
+          height: 96px;
+          width: 99%;
+
+          background: #272729;
+          border-radius: 8px;
+
+          word-break: break-word;
+          text-align: left;
+        }
+
+        input.success {
+          background: url(${CheckMarkNoBorderIcon}) no-repeat right;
+          background-position: 97%;
+        }
+    }
+`;
+
+const VIEWS = {
+  ACCOUNT_ID_CONFIRMATION: 'accountIdConfirmation',
+  VIEW_PRIVATE_KEY: 'viewPrivateKey'
+};
+
+export default ({
+    isOpen,
+    onClose,
+    secretKey
+}) => {
+  const [currentView, setCurrentView] = useState(VIEWS.ACCOUNT_ID_CONFIRMATION);
+
+    return (
+        <Modal
+            id='remove-account-modal'
+            isOpen={isOpen}
+            onClose={onClose}
+            modalSize='sm'
+        >
+            <Container>
+                <h3><Translate id='exportPrivateKey.title' /></h3>
+                <p><Translate id='exportPrivateKey.desc' /></p>
+                <ExportKeyModalBody 
+                  currentView={currentView} 
+                  setCurrentView={setCurrentView} 
+                  onClose={onClose} 
+                  secretKey={secretKey}
+                />
+            </Container>
+        </Modal>
+    );
+};
+
+const ExportKeyModalBody = ({ currentView, setCurrentView, onClose, secretKey }) => {
+  switch (currentView) {
+    case VIEWS.ACCOUNT_ID_CONFIRMATION: 
+      return (
+        <ConfirmationScreen setCurrentView={setCurrentView} onClose={onClose} />
+      );
+    case VIEWS.VIEW_PRIVATE_KEY:
+      return (
+        <>
+          <div className='text-select-display'>
+            {secretKey}
+          </div>
+          <FormButton onClick={onClose}>
+            <Translate id='button.dismiss' />
+          </FormButton>
+        </>
+      );
+  }
+};
+ 
+const ConfirmationScreen = ({ setCurrentView, onClose }) => {
+  const [typedAccountId, setTypedAccountId] = useState('');
+  const accountId = useSelector(selectAccountId);
+  const accountIdConfirmed = accountId === typedAccountId;
+
+  return (
+    <>
+      <Translate>
+          {({ translate }) => (
+              <input
+                  placeholder={translate('input.accountId.placeholder')}
+                  onChange={(e) => setTypedAccountId(e.target.value)}
+                  value={typedAccountId}
+                  autoCapitalize='off'
+                  spellCheck='false'
+                  autoFocus={!isMobile()}
+                  className={accountIdConfirmed ? 'success' : undefined}
+              />
+          )}
+      </Translate>
+      <FormButton
+          disabled={!accountIdConfirmed}
+          onClick={() => setCurrentView(VIEWS.VIEW_PRIVATE_KEY)}
+      >
+          <Translate id='button.viewPrivateKey' />
+      </FormButton>
+      <FormButton
+          className='link'
+          onClick={onClose}>
+          <Translate id='button.cancel' />
+      </FormButton>
+    </>
+  );
+};

--- a/packages/frontend/src/components/profile/export_private_key/ExportKeyModal.js
+++ b/packages/frontend/src/components/profile/export_private_key/ExportKeyModal.js
@@ -80,6 +80,22 @@ const Container = styled.div`
           background: url(${CheckMarkNoBorderIcon}) no-repeat right;
           background-position: 97%;
         }
+
+        form {
+          width: 100%
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          text-align: center;
+          > button {
+            margin-top: 32px;
+            width: 100%;
+          }
+
+          .link {
+            margin-top: 20px;
+          }
+        }
     }
 `;
 
@@ -144,7 +160,7 @@ const ConfirmationScreen = ({ setCurrentView, onClose }) => {
   const accountIdConfirmed = accountId === typedAccountId;
 
   return (
-    <>
+    <form onSubmit={() => setCurrentView(VIEWS.VIEW_PRIVATE_KEY)}>
       <p><Translate id='exportPrivateKey.enterAccountAddress' /></p>
       <Translate>
           {({ translate }) => (
@@ -161,7 +177,7 @@ const ConfirmationScreen = ({ setCurrentView, onClose }) => {
       </Translate>
       <FormButton
           disabled={!accountIdConfirmed}
-          onClick={() => setCurrentView(VIEWS.VIEW_PRIVATE_KEY)}
+          type='submit'
       >
           <Translate id='button.viewPrivateKey' />
       </FormButton>
@@ -170,6 +186,6 @@ const ConfirmationScreen = ({ setCurrentView, onClose }) => {
           onClick={onClose}>
           <Translate id='button.cancel' />
       </FormButton>
-    </>
+    </form>
   );
 };

--- a/packages/frontend/src/components/profile/export_private_key/ExportKeyModal.js
+++ b/packages/frontend/src/components/profile/export_private_key/ExportKeyModal.js
@@ -146,6 +146,7 @@ const ConfirmationScreen = ({ setCurrentView, onClose }) => {
 
   return (
     <>
+      <p><Translate id='exportPrivateKey.enterAccountAddress' /></p>
       <Translate>
           {({ translate }) => (
               <input

--- a/packages/frontend/src/components/profile/export_private_key/ExportKeyWrapper.js
+++ b/packages/frontend/src/components/profile/export_private_key/ExportKeyWrapper.js
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Translate } from 'react-localize-redux';
 import styled from 'styled-components';
 
 import ExportPrivateKeyImage from '../../../images/icon-key.svg';
 import FormButton from '../../common/FormButton';
 import Container from '../../common/styled/Container.css';
+import ExportKeyModal from './ExportKeyModal';
 
 const StyledContainer = styled(Container)`
     margin-top: 16px;
@@ -25,15 +26,25 @@ const StyledContainer = styled(Container)`
     }
 `;
 
-export default () => {
+export default ({ secretKey }) => {
+    const [showExportKeyModal, setShowExportKeyModal] = useState(false);
+
     return (
         <StyledContainer>
             <FormButton 
                 color='gray-blue'
+                onClick={() => setShowExportKeyModal(true)}
             >
-                <img src={ExportPrivateKeyImage} className='export-private-key-icon' />
+                <img src={ExportPrivateKeyImage} className='export-private-key-icon' alt='export-private-key-icon' />
                 <Translate id='exportPrivateKey.button' />
             </FormButton>
+            {showExportKeyModal &&
+                <ExportKeyModal
+                    onClose={() => setShowExportKeyModal(false)}
+                    isOpen={showExportKeyModal}
+                    secretKey={secretKey}
+                />
+            }
         </StyledContainer>
     );
 };

--- a/packages/frontend/src/components/profile/export_private_key/ExportKeyWrapper.js
+++ b/packages/frontend/src/components/profile/export_private_key/ExportKeyWrapper.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Translate } from 'react-localize-redux';
+import styled from 'styled-components';
+
+import ExportPrivateKeyImage from '../../../images/icon-key.svg';
+import FormButton from '../../common/FormButton';
+import Container from '../../common/styled/Container.css';
+
+const StyledContainer = styled(Container)`
+    margin-top: 16px;
+    padding-top: 0;
+    padding-bottom: 0;
+
+    > button {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+
+    .export-private-key-icon {
+       margin-right: 12px;
+       width: 20px;
+       height: 19px;
+    }
+`;
+
+export default () => {
+    return (
+        <StyledContainer>
+            <FormButton 
+                color='gray-blue'
+            >
+                <img src={ExportPrivateKeyImage} className='export-private-key-icon' />
+                <Translate id='exportPrivateKey.button' />
+            </FormButton>
+        </StyledContainer>
+    );
+};

--- a/packages/frontend/src/components/profile/remove_account/RemoveAccountWrapper.js
+++ b/packages/frontend/src/components/profile/remove_account/RemoveAccountWrapper.js
@@ -15,26 +15,30 @@ const StyledContainer = styled(Container)`
     margin-top: 16px;
     padding-top: 0;
     padding-bottom: 0;
-    > button {
-        width: 100%;
-        display: flex;
-        justify-content: center;
-        align-items: center;
 
-        > svg {
-            width: 22px !important;
-            height: 22px !important;
-            margin-right: 10px !important;
-        }
 
-        :hover {
-            > svg {
-                path {
-                    stroke: #E5484D;
+    &&& {
+        > button {
+            width: 100%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+
+            svg {
+                width: 22px;
+                height: 22px;
+                margin-right: 10px;
+            } 
+
+            :hover {
+                > svg {
+                    path {
+                        stroke: #E5484D;
+                    }
                 }
             }
         }
-    }
+    }   
 `;
 
 export default () => {

--- a/packages/frontend/src/components/profile/remove_account/RemoveAccountWrapper.js
+++ b/packages/frontend/src/components/profile/remove_account/RemoveAccountWrapper.js
@@ -3,6 +3,7 @@ import { Translate } from 'react-localize-redux';
 import { useSelector, useDispatch } from 'react-redux';
 import styled from 'styled-components';
 
+import RemoveAccountImage from '../../../images/icon-trash.js';
 import { switchAccount } from '../../../redux/actions/account';
 import { selectAccountId } from '../../../redux/slices/account';
 import { wallet } from '../../../utils/wallet';
@@ -11,8 +12,28 @@ import Container from '../../common/styled/Container.css';
 import RemoveAccountModal from './RemoveAccountModal';
 
 const StyledContainer = styled(Container)`
+    margin-top: 16px;
+    padding-top: 0;
+    padding-bottom: 0;
     > button {
         width: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+
+        > svg {
+            width: 22px !important;
+            height: 22px !important;
+            margin-right: 10px !important;
+        }
+
+        :hover {
+            > svg {
+                path {
+                    stroke: #E5484D;
+                }
+            }
+        }
     }
 `;
 
@@ -25,7 +46,9 @@ export default () => {
             <FormButton 
                 color='red'
                 onClick={() => setShowRemoveAccountModal(true)}
+                style={{marginTop: 0}}
             >
+                <RemoveAccountImage className='remove-account-icon' />
                 <Translate id='removeAccount.button' />
             </FormButton>
             {showRemoveAccountModal &&

--- a/packages/frontend/src/images/icon-check-no-border.svg
+++ b/packages/frontend/src/images/icon-check-no-border.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="9" viewBox="0 0 12 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.3333 1L3.99996 8.33333L0.666626 5" stroke="#008D6A" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/frontend/src/images/icon-key.svg
+++ b/packages/frontend/src/images/icon-key.svg
@@ -1,0 +1,3 @@
+<svg width="22" height="21" viewBox="0 0 22 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M20 1L18 3M10.3891 10.6109C11.3844 11.6062 12 12.9812 12 14.5C12 17.5376 9.53757 20 6.5 20C3.46244 20 1 17.5376 1 14.5C1 11.4624 3.46244 9 6.5 9C8.01878 9 9.39379 9.61561 10.3891 10.6109ZM10.3891 10.6109L14.5 6.5M14.5 6.5L17.5 9.5L21 5.99999L18 3M14.5 6.5L18 3" stroke="#2B9AF4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/frontend/src/images/icon-trash.js
+++ b/packages/frontend/src/images/icon-trash.js
@@ -11,30 +11,30 @@ export default () => (
         <path
             d="M3 6H5H21"
             stroke="#FFDEDF"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
         />
         <path
             d="M8 6V4C8 3.46957 8.21071 2.96086 8.58579 2.58579C8.96086 2.21071 9.46957 2 10 2H14C14.5304 2 15.0391 2.21071 15.4142 2.58579C15.7893 2.96086 16 3.46957 16 4V6M19 6V20C19 20.5304 18.7893 21.0391 18.4142 21.4142C18.0391 21.7893 17.5304 22 17 22H7C6.46957 22 5.96086 21.7893 5.58579 21.4142C5.21071 21.0391 5 20.5304 5 20V6H19Z"
             stroke="#FFDEDF"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
         />
         <path
             d="M10 11V17"
             stroke="#FFDEDF"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
         />
         <path
             d="M14 11V17"
             stroke="#FFDEDF"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
         />
     </svg>
 );

--- a/packages/frontend/src/images/icon-trash.js
+++ b/packages/frontend/src/images/icon-trash.js
@@ -1,0 +1,40 @@
+import React from 'react';
+
+export default () => (
+    <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path
+            d="M3 6H5H21"
+            stroke="#FFDEDF"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+        />
+        <path
+            d="M8 6V4C8 3.46957 8.21071 2.96086 8.58579 2.58579C8.96086 2.21071 9.46957 2 10 2H14C14.5304 2 15.0391 2.21071 15.4142 2.58579C15.7893 2.96086 16 3.46957 16 4V6M19 6V20C19 20.5304 18.7893 21.0391 18.4142 21.4142C18.0391 21.7893 17.5304 22 17 22H7C6.46957 22 5.96086 21.7893 5.58579 21.4142C5.21071 21.0391 5 20.5304 5 20V6H19Z"
+            stroke="#FFDEDF"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+        />
+        <path
+            d="M10 11V17"
+            stroke="#FFDEDF"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+        />
+        <path
+            d="M14 11V17"
+            stroke="#FFDEDF"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+        />
+    </svg>
+);

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -503,7 +503,8 @@
     },
     "exportPrivateKey": {
         "button": "Export Private Key",
-        "desc": "Never share your private key! Anyone with access to it will also have full access to your account.<br /><br />Enter your account address to view your<br />private key.",
+        "desc": "Never share your private key! Anyone with access to it will also have full access to your account.<br /><br />",
+        "enterAccountAddress": "Enter your account address to view your<br />private key.",
         "title": "View private key?"
     },
     "footer": {

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -500,6 +500,9 @@
         "exploreDeFi": "Explore DeFi",
         "title": "What's on NEAR?"
     },
+    "exportPrivateKey": {
+        "button": "Export Private Key"
+    },
     "footer": {
         "contactSupport": "Join Community",
         "copyrights": "Roketo Labs LTD. All Rights Reserved.",

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -502,7 +502,7 @@
         "title": "What's on NEAR?"
     },
     "exportPrivateKey": {
-        "button": "Export Private Key",
+        "button": "Export Local Private Key",
         "desc": "Never share your private key! Anyone with access to it will also have full access to your account.<br /><br />",
         "enterAccountAddress": "Enter your account address to view your<br />private key.",
         "title": "View private key?"

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -288,6 +288,7 @@
         "viewAll": "View All",
         "viewFAQ": "View FAQ",
         "viewOnExplorer": "View on Explorer",
+        "viewPrivateKey": "View private key",
         "withdrawing": "Withdrawing"
     },
     "buyNear": {
@@ -501,7 +502,9 @@
         "title": "What's on NEAR?"
     },
     "exportPrivateKey": {
-        "button": "Export Private Key"
+        "button": "Export Private Key",
+        "desc": "Never share your private key! Anyone with access to it will also have full access to your account.<br /><br />Enter your account address to view your<br />private key.",
+        "title": "View private key?"
     },
     "footer": {
         "contactSupport": "Join Community",

--- a/packages/frontend/src/utils/wallet.js
+++ b/packages/frontend/src/utils/wallet.js
@@ -175,6 +175,10 @@ class Wallet {
         return localKeyPair ? localKeyPair.toString() : null;
     }
 
+    async getLocalKeyPair(accountId) {
+        return this.keyStore.getKey(NETWORK_ID, accountId);
+    }
+
     async getLedgerKey(accountId) {
         // TODO: All callers should specify accountId explicitly
         accountId = accountId || this.accountId;
@@ -203,6 +207,13 @@ class Wallet {
 
     isLegitAccountId(accountId) {
         return ACCOUNT_ID_REGEX.test(accountId);
+    }
+
+    isFullAccessKey(accountId, keypair) {
+        return this.getAccessKeys(accountId).then((keys) => {
+            const key = keys.find(({ public_key }) => public_key === keypair.getPublicKey().toString());
+            return key?.access_key?.permission === 'FullAccess';
+        });
     }
 
     async sendMoney(receiverId, amount) {


### PR DESCRIPTION
This PR:

1. Adds [functionality to show a modal, confirm `accountId` and view private key](https://nearinc.atlassian.net/browse/KWLT-6)
2. Adds an icon to the "Remove Account from Wallet" button

[Figma link](https://www.figma.com/file/w4SQVO6kBvAP5D65TGlm7y/Wallet-Domain-Migration)