### PR TITLE
feat: Skip funding step when creating implicit account

### DIFF
--- a/packages/frontend/src/components/accounts/recovery_setup/new_account/ConfirmPassphrase.js
+++ b/packages/frontend/src/components/accounts/recovery_setup/new_account/ConfirmPassphrase.js
@@ -39,7 +39,8 @@ export default ({
     wordIndex,
     handleChangeWord,
     handleStartOver,
-    userInputValueWrongWord
+    userInputValueWrongWord,
+    finishingSetup
 }) => {
     return (
         <StyledContainer className='small-centered border'>
@@ -48,6 +49,7 @@ export default ({
                     handleConfirmPassphrase();
                     e.preventDefault();
                 }}
+                disabled={finishingSetup}
                 autoComplete='off'
             >
                 <h1><Translate id='setupSeedPhraseVerify.pageTitle' /></h1>
@@ -73,7 +75,8 @@ export default ({
                 <FormButton
                     type='submit'
                     data-test-id='seedPhraseVerificationWordSubmit'
-                    disabled={!userInputValue}
+                    sending={finishingSetup}
+                    disabled={!userInputValue || finishingSetup}
                 >
                     <Translate id='button.verify' />
                 </FormButton>
@@ -82,6 +85,7 @@ export default ({
                     color='gray'
                     className='link start-over'
                     onClick={handleStartOver}
+                    disabled={finishingSetup}
                 >
                     <Translate id='button.startOver' />
                 </FormButton>

--- a/packages/frontend/src/components/accounts/recovery_setup/new_account/SetupPassphraseNewAccount.js
+++ b/packages/frontend/src/components/accounts/recovery_setup/new_account/SetupPassphraseNewAccount.js
@@ -14,6 +14,7 @@ export default ({ handleConfirmPassphrase }) => {
     const [implicitAccountId, setImplicitAccountId] = useState('');
 
     const [confirmPassphrase, setConfirmPassphrase] = useState(false);
+    const [finishingSetup, setFinishingSetup] = useState(false);
     const [wordIndex, setWordIndex] = useState(null);
     const [userInputValue, setUserInputValue] = useState('');
     const [userInputValueWrongWord, setUserInputValueWrongWord] = useState(false);
@@ -39,6 +40,7 @@ export default ({ handleConfirmPassphrase }) => {
                 wordIndex={wordIndex}
                 userInputValue={userInputValue}
                 userInputValueWrongWord={userInputValueWrongWord}
+                finishingSetup={finishingSetup}
                 handleChangeWord={(userInputValue) => {
                     if (userInputValue.match(/[^a-zA-Z]/)) {
                         return false;
@@ -52,13 +54,18 @@ export default ({ handleConfirmPassphrase }) => {
                     setUserInputValue('');
                 }}
                 handleConfirmPassphrase={async () => {
-                    Mixpanel.track('SR-SP Verify start');
-                    if (userInputValue !== passPhrase.split(' ')[wordIndex]) {
-                        setUserInputValueWrongWord(true);
-                        return;
+                    try {
+                        setFinishingSetup(true);
+                        Mixpanel.track('SR-SP Verify start');
+                        if (userInputValue !== passPhrase.split(' ')[wordIndex]) {
+                            setUserInputValueWrongWord(true);
+                            return;
+                        }
+                        await handleConfirmPassphrase({ implicitAccountId, recoveryKeyPair });
+                        Mixpanel.track('SR-SP Verify finish');
+                    } finally {
+                        setFinishingSetup(false);
                     }
-                    handleConfirmPassphrase({ implicitAccountId, recoveryKeyPair });
-                    Mixpanel.track('SR-SP Verify finish');
                 }}
             />
         );

--- a/packages/frontend/src/redux/slices/account/createAccountThunks.js
+++ b/packages/frontend/src/redux/slices/account/createAccountThunks.js
@@ -242,8 +242,8 @@ export const initiateSetupForZeroBalanceAccountPhrase = createAsyncThunk(
                     publicKey: recoveryKeyPair.publicKey.toString()
                 });
             } catch (e) {
-                if (e.status === 400) {
-                    console.log(`Public key ${recoveryKeyPair.publicKey.toString()} has previously been added as recovery method to account. Continueing setup...`);
+                if (e.message.includes('ConditionalCheckFailedException')) {
+                    console.log(`Public key ${recoveryKeyPair.publicKey.toString()} has previously been added as recovery method to account. Continuing setup...`);
                 } else {
                     throw new WalletError(e, 'initiateSetupForZeroBalanceAccountPhrase.error');
                 }
@@ -275,14 +275,14 @@ export const initiateSetupForZeroBalanceAccountLedger = createAsyncThunk(
                     publicKey: ledgerPublicKey.toString()
                 });
             } catch (e) {
-                if (e.status === 400) {
-                    console.log(`Ledger public key ${ledgerPublicKey.toString()} has previously been added as recovery method to account. Continueing setup...`);
+                if (e.message.includes('ConditionalCheckFailedException')) {
+                    console.log(`Ledger public key ${ledgerPublicKey.toString()} has previously been added as recovery method to account. Continuing setup...`);
                 } else {
                     throw new WalletError(e, 'initiateSetupForZeroBalanceAccountLedger.error');
                 }
             }
             await setKeyMeta(ledgerPublicKey, { type: 'ledger' });
-            await setLedgerHdPath({ accountId: implicitAccountId, path: ledgerHdPath });
+            setLedgerHdPath({ accountId: implicitAccountId, path: ledgerHdPath });
             await wallet.importZeroBalanceAccount(implicitAccountId);
         } catch (e) {
             dispatch(showCustomAlert({

--- a/packages/frontend/src/routes/SetupPassphraseNewAccountWrapper.js
+++ b/packages/frontend/src/routes/SetupPassphraseNewAccountWrapper.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 
+import { IMPORT_ZERO_BALANCE_ACCOUNT } from '../../../../features';
 import SetupPassphraseNewAccount from '../components/accounts/recovery_setup/new_account/SetupPassphraseNewAccount';
 import { redirectTo } from '../redux/actions/account';
+import { initiateSetupForZeroBalanceAccountPhrase } from '../redux/slices/account/createAccountThunks';
 import { wallet } from '../utils/wallet';
 
 export function SetupPassphraseNewAccountWrapper() {
@@ -13,8 +15,16 @@ export function SetupPassphraseNewAccountWrapper() {
                 implicitAccountId,
                 recoveryKeyPair
             }) => {
-                await wallet.saveAccountKeyPair({ accountId: implicitAccountId, recoveryKeyPair });
-                dispatch(redirectTo(`/create-implicit-account?implicitAccountId=${implicitAccountId}&recoveryMethod=phrase`));
+                if (IMPORT_ZERO_BALANCE_ACCOUNT) {
+                    await dispatch(initiateSetupForZeroBalanceAccountPhrase({
+                        implicitAccountId,
+                        recoveryKeyPair
+                    }));
+                    dispatch(redirectTo('/'));
+                } else {
+                    await wallet.saveAccountKeyPair({ accountId: implicitAccountId, recoveryKeyPair });
+                    dispatch(redirectTo(`/create-implicit-account?implicitAccountId=${implicitAccountId}&recoveryMethod=phrase`));
+                }
             }}
         />
     );

--- a/packages/frontend/src/routes/SetupRecoveryImplicitAccountWrapper.js
+++ b/packages/frontend/src/routes/SetupRecoveryImplicitAccountWrapper.js
@@ -3,6 +3,7 @@ import { parseSeedPhrase } from 'near-seed-phrase';
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 
+import { IMPORT_ZERO_BALANCE_ACCOUNT } from '../../../../features';
 import SetupRecoveryImplicitAccount from '../components/accounts/create/implicit_account/SetupRecoveryImplicitAccount';
 import EnterVerificationCode from '../components/accounts/EnterVerificationCode';
 import { Mixpanel } from '../mixpanel';
@@ -79,7 +80,22 @@ export function SetupRecoveryImplicitAccountWrapper() {
                 } finally {
                     setVerifyingEmailCode(false);
                 }
-                dispatch(redirectTo(`/create-implicit-account?implicitAccountId=${implicitAccountId}&recoveryMethod=email`));
+
+                if (IMPORT_ZERO_BALANCE_ACCOUNT) {
+                    try {
+                        await wallet.importZeroBalanceAccount(implicitAccountId, recoveryKeyPair);
+                        dispatch(redirectTo('/'));
+                    } catch (e) {
+                        dispatch(showCustomAlert({
+                            success: false,
+                            messageCodeHeader: 'error',
+                            messageCode: 'walletErrorCodes.recoverAccountSeedPhrase.errorNotAbleToImportAccount',
+                            errorMessage: e.message
+                        }));
+                    }
+                } else {
+                    dispatch(redirectTo(`/create-implicit-account?implicitAccountId=${implicitAccountId}&recoveryMethod=email`));
+                }
             }}
             onGoBack={() => setShowVerifyEmailCode(false)}
             onResend={async () => {

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1680,8 +1680,11 @@
         "addAccessKeyZeroBalanceAccountSetup": {
             "error": "Something went wrong while finishing import of your now active account. Please re-import your account in the wallet."
         },
+        "initiateZeroBalanceAccount": {
+            "error": "Something went wrong while initiating your account. Please try again."
+        },
         "addAccessKeySeedPhrase": {
-            "errorSecond": "An error has occurred.<br />The passphrases was not added to your account. Please try again."
+            "errorSecond": "An error has occurred.<br />The passphrase was not added to your account. Please try again."
         },
         "addLedgerAccountId": {
             "errorRpc": "Error appears while recovering the account."


### PR DESCRIPTION
This PR treats an implicit account as a 'zero balance account' during onboarding and therefore skips the funding step and sends the user directly to the wallet dashboard.

The feature (`IMPORT_ZERO_BALANCE_ACCOUNT`) is currently turned `OFF` in all environments, and a separate PR to turn the feature `ON` on `testnet` and `staging` will be opened once this PR is merged.

To test this PR, simply turn the flag `IMPORT_ZERO_BALANCE_ACCOUNT` `ON` in your environment and then test onboarding or/and import of a zero balance account. Note that only `mainnet` accounts need funding.