### PR TITLE
fix: Add 'deposit funds' banner to sign, create pages

### DIFF
--- a/packages/frontend/src/components/accounts/CreateAccount.js
+++ b/packages/frontend/src/components/accounts/CreateAccount.js
@@ -14,7 +14,7 @@ import {
     refreshAccount
 } from '../../redux/actions/account';
 import { clearLocalAlert } from '../../redux/actions/status';
-import { selectAccountSlice, selectActiveAccountIdIsImplicitAccount } from '../../redux/slices/account';
+import { selectAccountSlice, selectActiveAccountIdIsImplicitAccount, selectAccountExists } from '../../redux/slices/account';
 import { selectStatusLocalAlert, selectStatusMainLoader } from '../../redux/slices/status';
 import { selectNearTokenFiatValueUSD } from '../../redux/slices/tokenFiatValues';
 import isMobile from '../../utils/isMobile';
@@ -29,6 +29,7 @@ import WhereToBuyNearModal from '../common/WhereToBuyNearModal';
 import SafeTranslate from '../SafeTranslate';
 import BrokenLinkIcon from '../svg/BrokenLinkIcon';
 import FundNearIcon from '../svg/FundNearIcon';
+import DepositNearBanner from '../wallet/DepositNearBanner';
 import AccountFormAccountId from './AccountFormAccountId';
 
 const StyledContainer = styled(Container)`
@@ -183,12 +184,14 @@ class CreateAccount extends Component {
             fundingKey,
             nearTokenFiatValueUSD,
             locationSearch,
-            activeAccountIdIsImplicit
+            activeAccountIdIsImplicit,
+            accountExists
         } = this.props;
         
         const isLinkDrop = fundingContract && fundingKey;
         const useLocalAlert = accountId.length > 0 ? localAlert : undefined;
         const showTermsPage = IS_MAINNET && !isLinkDrop && !termsAccepted && !ENABLE_IDENTITY_VERIFIED_ACCOUNT;
+        const cannotCreateNewAccountWithZeroBalanceAccount = !isLinkDrop && accountExists === false;
 
         if (showTermsPage) {
             return (
@@ -267,9 +270,10 @@ class CreateAccount extends Component {
                             autoFocus={isMobile() ? false : true}
                         />
                         <AccountNote />
+                        {cannotCreateNewAccountWithZeroBalanceAccount && <DepositNearBanner />}
                         <FormButton
                             type='submit'
-                            disabled={!(localAlert && localAlert.success)}
+                            disabled={!(localAlert && localAlert.success) || cannotCreateNewAccountWithZeroBalanceAccount}
                             sending={loader}
                             data-test-id="reserveAccountIdButton"
                         >
@@ -313,6 +317,7 @@ const mapStateToProps = (state, { match }) => ({
     ...selectAccountSlice(state),
     localAlert: selectStatusLocalAlert(state),
     mainLoader: selectStatusMainLoader(state),
+    accountExists: selectAccountExists(state),
     fundingContract: match.params.fundingContract,
     fundingKey: match.params.fundingKey,
     fundingAccountId: match.params.fundingAccountId,

--- a/packages/frontend/src/components/login/v2/SelectAccountLogin.js
+++ b/packages/frontend/src/components/login/v2/SelectAccountLogin.js
@@ -7,6 +7,7 @@ import FormButton from '../../common/FormButton';
 import FormButtonGroup from '../../common/FormButtonGroup';
 import LoadingDots from '../../common/loader/LoadingDots';
 import Container from '../../common/styled/Container.css';
+import DepositNearBanner from '../../wallet/DepositNearBanner';
 import ConnectWithApplication from './ConnectWithApplication';
 import LoginStyle from './style/LoginStyle.css';
 
@@ -22,7 +23,8 @@ export default ({
     loginAccessType,
     appReferrer,
     contractIdUrl,
-    failureAndSuccessUrlsAreValid
+    failureAndSuccessUrlsAreValid,
+    accountExists
 }) => (
     <Container className='small-centered border'>
         <LoginStyle className={loginAccessType === LOGIN_ACCESS_TYPES.FULL_ACCESS ? 'full-access' : ''}>
@@ -51,6 +53,7 @@ export default ({
                 onSignInToDifferentAccount={onSignInToDifferentAccount}
                 showBalanceInUSD={false}
             />
+            {accountExists === false && <DepositNearBanner />}
             <FormButtonGroup>
                 <FormButton
                     onClick={onClickCancel}
@@ -61,7 +64,7 @@ export default ({
                 </FormButton>
                 <FormButton
                     onClick={onClickNext}
-                    disabled={!failureAndSuccessUrlsAreValid}
+                    disabled={!failureAndSuccessUrlsAreValid || accountExists === false}
                 >
                     <Translate id='button.next' />
                 </FormButton>

--- a/packages/frontend/src/components/login/v2/SelectAccountLoginWrapper.js
+++ b/packages/frontend/src/components/login/v2/SelectAccountLoginWrapper.js
@@ -11,7 +11,8 @@ import {
 import {
     selectAccountLocalStorageAccountId,
     selectAccountUrlReferrer,
-    selectAccountAccountsBalances
+    selectAccountAccountsBalances,
+    selectAccountExists
 } from '../../../redux/slices/account';
 import { selectAvailableAccounts } from '../../../redux/slices/availableAccounts';
 import { isUrlNotJavascriptProtocol } from '../../../utils/helper-api';
@@ -33,6 +34,7 @@ export default ({
     const accountAccountsBalances = useSelector(selectAccountAccountsBalances);
     const accountUrlReferrer = useSelector(selectAccountUrlReferrer);
     const failureAndSuccessUrlsAreValid = isUrlNotJavascriptProtocol(failureUrl) && isUrlNotJavascriptProtocol(successUrl);
+    const accountExists = useSelector(selectAccountExists);
 
     return (
         <SelectAccountLogin
@@ -59,6 +61,7 @@ export default ({
             }}
             onClickNext={onClickNext}
             failureAndSuccessUrlsAreValid={failureAndSuccessUrlsAreValid}
+            accountExists={accountExists}
         />
     );
 };

--- a/packages/frontend/src/components/login/v2/style/LoginStyle.css.js
+++ b/packages/frontend/src/components/login/v2/style/LoginStyle.css.js
@@ -53,6 +53,10 @@ export default styled.div`
             }
         }
 
+        .deposit-near-banner {
+            margin: 40px 0 -15px 0;
+        }
+
         .connect-with-application {
             margin: 0 auto;
         }

--- a/packages/frontend/src/components/wallet/DepositNearBanner.js
+++ b/packages/frontend/src/components/wallet/DepositNearBanner.js
@@ -7,26 +7,10 @@ import styled from 'styled-components';
 import NearLogoAndPlusIcon from '../svg/NearLogoAndPlusIcon';
 
 const StyledContainer = styled.div`
-    width: 100%;
-
     @media (max-width: 991px) {
         margin-bottom: 40px;
     }
-
-    > div {
-        border-top: 1px solid #F0F0F1;
-        padding: 20px;
-
-        @media (max-width: 991px) {
-            margin: 0 -14px;
-            padding: 20px 0;
-            border-bottom: 15px solid #F0F0F1;
-        }
-
-        @media (max-width: 767px) {
-            padding: 20px 14px 20px 14px;
-        }
-        
+    > div {        
         > div {
             background-color: #F0F0F1;
             border-radius: 8px;
@@ -42,15 +26,16 @@ const StyledContainer = styled.div`
             > div {
                 margin-left: 15px;
         
-                .title {
+                .banner-title {
                     color: #272729;
                     font-weight: 500;
                     font-size: 16px;
                 }
         
-                .desc {
+                .banner-desc {
                     margin-top: 5px;
                     color: #72727A;
+                    line-height: 1.5;
                 }
             }
     
@@ -66,13 +51,13 @@ export default () => {
     const dispatch = useDispatch();
 
     return (
-        <StyledContainer>
+        <StyledContainer className='deposit-near-banner'>
             <div>
                 <div onClick={() => dispatch(push({ pathname: '/receive-money' }))} >
                     <NearLogoAndPlusIcon />
                     <div>
-                        <div className='title'><Translate id='wallet.depositNear.title' /></div>
-                        <div className='desc'><Translate id='wallet.depositNear.desc' /></div>
+                        <div className='banner-title'><Translate id='wallet.depositNear.title' /></div>
+                        <div className='banner-desc'><Translate id='wallet.depositNear.desc' /></div>
                     </div>
                 </div>
             </div>

--- a/packages/frontend/src/components/wallet/Wallet.js
+++ b/packages/frontend/src/components/wallet/Wallet.js
@@ -265,6 +265,26 @@ const StyledContainer = styled(Container)`
         text-align: left;
         color: #24272a;
     }
+
+    .deposit-banner-wrapper {
+        width: 100%;
+        .deposit-near-banner {
+            > div {
+                border-top: 1px solid #F0F0F1;
+                padding: 20px;
+        
+                @media (max-width: 991px) {
+                    margin: 0 -14px;
+                    padding: 20px 0;
+                    border-bottom: 15px solid #F0F0F1;
+                }
+        
+                @media (max-width: 767px) {
+                    padding: 20px 14px 20px 14px;
+                }
+            }
+        }
+    }
 `;
 
 export function Wallet({
@@ -465,7 +485,11 @@ const FungibleTokens = ({
                     <Translate id="button.swap" />
                 </FormButton>
             </div>
-            {zeroBalanceAccount && <DepositNearBanner />}
+            {zeroBalanceAccount &&
+                <div className='deposit-banner-wrapper'>
+                    <DepositNearBanner />
+                </div>
+            }
             {!hideFungibleTokenSection && (
                 <>
                     <div className="sub-title tokens">


### PR DESCRIPTION
Add the `<DepositNearBanner />` on the `/create` and `/login` pages when account is zero balance
<img width="664" alt="Screen Shot 2022-05-26 at 3 52 53 PM" src="https://user-images.githubusercontent.com/24921205/170592660-f46988d9-112f-4556-92ef-ebf8d7278240.png">
<img width="585" alt="Screen Shot 2022-05-26 at 3 52 43 PM" src="https://user-images.githubusercontent.com/24921205/170592667-3b630acd-0adb-4e76-9823-dfb55e0a55be.png">

