### PR TITLE
When importing an implicit account it's showing FT data from a previous active account

### DIFF
--- a/packages/frontend/src/components/accounts/CouldNotFindAccountModalWrapper.js
+++ b/packages/frontend/src/components/accounts/CouldNotFindAccountModalWrapper.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 
 import {
-    redirectTo,
     refreshAccount,
-    getLedgerPublicKey
+    getLedgerPublicKey,
+    redirectToApp
 } from '../../redux/actions/account';
 import { showCustomAlert, clearGlobalAlert } from '../../redux/actions/status';
 import { setLedgerHdPath } from '../../utils/localStorage';
@@ -87,7 +87,7 @@ export function CouldNotFindAccountModalWrapper({
                 try {
                     await dispatch(refreshAccount());
                 } finally {
-                    dispatch(redirectTo('/'));
+                    dispatch(redirectToApp());
                     dispatch(clearGlobalAlert());
                 }
             }}

--- a/packages/frontend/src/components/accounts/CouldNotFindAccountModalWrapper.js
+++ b/packages/frontend/src/components/accounts/CouldNotFindAccountModalWrapper.js
@@ -84,9 +84,12 @@ export function CouldNotFindAccountModalWrapper({
                 } else {
                     await handleImportNonLedgerImplicitAccount();
                 }
-                dispatch(refreshAccount());
-                dispatch(redirectTo('/'));
-                dispatch(clearGlobalAlert());
+                try {
+                    await dispatch(refreshAccount());
+                } finally {
+                    dispatch(redirectTo('/'));
+                    dispatch(clearGlobalAlert());
+                }
             }}
         />
     );


### PR DESCRIPTION
Three fixes:
1. Fix refreshing account, we need to wait till the `refreshAccount` action is resolved, even if currently it's throwing an error. That's because the active account is changed by `refreshAccount` action.
If we redirect to the dashboard before the `refreshAccount` is resolved, FTs are fetched for the precious account, because it's still an active account.
2. Fixed redirect. We should use `redirectToApp` instead of `redirectTo`. If for example the user will be redirected to Wallet to login to the app in case there is no imported account yet, and he will import a zero balance account, we should redirect the user to the `/login` page anyway, so user will be able to import different account and proceed with login.
3. Clean up the code formatting.