### PR TITLE
fix: only include NEAR contractName with optional prop

### DIFF
--- a/packages/frontend/src/components/swap/Swap.js
+++ b/packages/frontend/src/components/swap/Swap.js
@@ -115,7 +115,7 @@ const StyledContainer = styled(Container)`
 `;
 
 function Swap({ history }) {
-    const fungibleTokensList = useFungibleTokensIncludingNEAR({showTokensWithZeroBalance: true});
+    const fungibleTokensList = useFungibleTokensIncludingNEAR({showTokensWithZeroBalance: true, includeNearContractName: true});
     const accountId = useSelector(selectAccountId);
     const multiplier = useSelector(selectMetadataSlice);
     const [amountTokenFrom, setAmountTokenFrom] = useState(0);

--- a/packages/frontend/src/hooks/fungibleTokensIncludingNEAR.js
+++ b/packages/frontend/src/hooks/fungibleTokensIncludingNEAR.js
@@ -8,8 +8,8 @@ import { selectTokensWithMetadataForAccountId } from '../redux/slices/tokens';
 import compare from '../utils/compare';
 
 
-export const useFungibleTokensIncludingNEAR = function ({ showTokensWithZeroBalance = false } = {}) {
-    const NEARAsTokenWithMetadata = useSelector(selectNEARAsTokenWithMetadata);
+export const useFungibleTokensIncludingNEAR = function ({ showTokensWithZeroBalance = false, includeNearContractName = false } = {}) {
+    const NEARAsTokenWithMetadata = useSelector(state => selectNEARAsTokenWithMetadata(state, {includeNearContractName}));
     const accountId = useSelector(selectActiveAccountId);
     const fungibleTokens = useSelector((state) =>
         selectTokensWithMetadataForAccountId(state, { accountId, showTokensWithZeroBalance })

--- a/packages/frontend/src/redux/selectors/crossStateSelectors/selectNEARAsTokenWithMetadata.js
+++ b/packages/frontend/src/redux/selectors/crossStateSelectors/selectNEARAsTokenWithMetadata.js
@@ -4,10 +4,10 @@ import { selectAvailableBalance } from '../../slices/account';
 import { selectNearTokenFiatValueUSD } from '../../slices/tokenFiatValues';
 
 export default createSelector(
-    [selectAvailableBalance, selectNearTokenFiatValueUSD],
-    (balanceAvailable, usd) => ({
+    [selectAvailableBalance, selectNearTokenFiatValueUSD, (_, params) => params?.includeNearContractName],
+    (balanceAvailable, usd, includeNearContractName) => ({
         balance: balanceAvailable || '',
-        contractName: 'NEAR',
+        contractName: includeNearContractName ? 'NEAR' : undefined,
         onChainFTMetadata: { symbol: 'NEAR', decimals: 24 },
         fiatValueMetadata: { usd },
     })


### PR DESCRIPTION
This PR fixes reliance on NEAR token instances not having a `contractName` prop by only including that prop optionally and setting explicitly to true in cases where `contractName` is required