### PR TITLE
Added copy button on UserAccount component

### DIFF
--- a/packages/frontend/src/components/navigation/UserAccount.js
+++ b/packages/frontend/src/components/navigation/UserAccount.js
@@ -2,8 +2,10 @@ import React from 'react';
 import styled from 'styled-components';
 
 import classNames from '../../utils/classNames';
+import ClickToCopy from '../common/ClickToCopy';
 import ChevronIcon from '../svg/ChevronIcon';
 import UserIcon from '../svg/UserIcon';
+import CopyIcon from '../svg/CopyIcon';
 
 const Container = styled.div`
     background-color: #F0F0F1;
@@ -28,12 +30,23 @@ const Container = styled.div`
         margin: 0 14px 0 9px;
         white-space: nowrap;
         max-width: 150px;
-        overflow: hidden;
-        text-overflow: ellipsis;
+        
         color: #72727A;
+        display: flex;
+        align-items: center;
 
         @media (max-width: 991px) {
             margin: 0 14px 0 12px;
+        }
+
+        .account-id {
+            max-width: 120px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .copy-wrapper {
+            margin-left: 10px;
         }
     }
 
@@ -67,7 +80,14 @@ const UserAccount = ({ accountId = '', onClick, withIcon = true, flowLimitationS
     <Container className={classNames(['user-account', {'no-click' : flowLimitationSubMenu }])} onClick={onClick}>
         {withIcon && <UserIcon color='#A2A2A8'/>}
         <div className="account-wrapper" data-test-id="currentUser">
-            {accountId}
+            <div className="account-id">
+                {accountId}
+            </div>
+            <div className="copy-wrapper" onClick={(e) => e.stopPropagation()}>
+                <ClickToCopy copy={accountId}>
+                    <CopyIcon />
+                </ClickToCopy>
+            </div>
         </div>
         <div className='icon-wrapper'>
             <ChevronIcon/>


### PR DESCRIPTION
This PR contains improvements on adding click to copy account Id on User Account UI
closes #2620 

![image](https://user-images.githubusercontent.com/6027014/172291788-387aa533-d5ac-4cd1-ac5c-e20e7d8954c0.png)
<img width="245" alt="image" src="https://user-images.githubusercontent.com/6027014/172291989-da3df2a7-5d66-47f1-a05e-4171101078da.png">

Clicking other area within the User Account UI will work as normal:
![image](https://user-images.githubusercontent.com/6027014/172292456-5127e4e5-4ed8-4ca4-a790-6c4e0f00e97a.png)



Short accountId:
<img width="360" alt="image" src="https://user-images.githubusercontent.com/6027014/172291959-46ab2118-3eb9-4d70-a259-8d7b7e75a3c8.png">

Long accountId:
<img width="385" alt="image" src="https://user-images.githubusercontent.com/6027014/172292129-c2396475-77ae-4c38-b6fe-ec2616f110f4.png">


