### PR TITLE
fix(translation): translation href escapes and validation

### DIFF
--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -682,7 +682,7 @@
         },
         "v2": {
             "connectConfirm": {
-                "desc": "Only connect to sites that you trust. Once connected, <a href=${contractIdUrl} target='_blank' rel='noreferrer'>${appReferrer}</a> will have <b>${accessType}</b>:",
+                "desc": "Only connect to sites that you trust. Once connected, <a href='${contractIdUrl}' target='_blank' rel='noreferrer'>${appReferrer}</a> will have <b>${accessType}</b>:",
                 "feeAllowance": {
                     "desc": "The application will be given permission to spend up to <b>${amount} NEAR</b> towards network fees incurred during use.",
                     "title": "Network Fee Allowance"

--- a/packages/frontend/src/translations/it.global.json
+++ b/packages/frontend/src/translations/it.global.json
@@ -1299,7 +1299,7 @@
                 "title": "Importo totale in staking"
             },
             "unclaimed": {
-                "info": "Le ricompense che sono state guadagnate, ma non ritirate. I premi guadagnati vengono &lt;a target=&#39;_blank&#39; href=&#39;https://www.investopedia.com/terms/c/compoundinterest.asp&#39;&gt; composizione&lt;/a&gt;.&quot;, automaticamente reimpegnati,.",
+                "info": "Le ricompense che sono state guadagnate, ma non ritirate. I premi guadagnati vengono <a target='_blank' href='https://www.investopedia.com/terms/c/compoundinterest.asp'>composizione</a> automaticamente reimpegnati.",
                 "title": "Ricompense guadagnate",
                 "unavailable": {
                     "cta": "Per saperne di più",

--- a/packages/frontend/src/translations/it.global.json
+++ b/packages/frontend/src/translations/it.global.json
@@ -629,7 +629,7 @@
         },
         "v2": {
             "connectConfirm": {
-                "desc": "Connettiti solo a siti di cui ti fidi. Una volta connesso, <a href=${contractIdUrl} target='_blank' rel='noreferrer'>${appReferrer}</a> avrà <b>${accessType}</b>:",
+                "desc": "Connettiti solo a siti di cui ti fidi. Una volta connesso, <a href='${contractIdUrl}' target='_blank' rel='noreferrer'>${appReferrer}</a> avrà <b>${accessType}</b>:",
                 "feeAllowance": {
                     "desc": "L'applicazione riceverà il permesso di spendere fino a <b>${quantità} di NEAR</b> verso le tariffe di rete sostenute durante l'uso.",
                     "title": "Idennità di Rete"

--- a/packages/frontend/src/translations/pt.global.json
+++ b/packages/frontend/src/translations/pt.global.json
@@ -606,7 +606,7 @@
         },
         "v2": {
             "connectConfirm": {
-                "desc": "Só conecte-se a sites em que confia. Uma vez conectado, <a href=${contractIdUrl} target='_blank' rel='noreferrer'>${appReferrer}</a> terá <b>${accessType}</b>:",
+                "desc": "Só conecte-se a sites em que confia. Uma vez conectado, <a href='${contractIdUrl}' target='_blank' rel='noreferrer'>${appReferrer}</a> terá <b>${accessType}</b>:",
                 "feeAllowance": {
                     "desc": "A aplicação será autorizada a gastar até <b>${amount} NEAR</b> em taxas de rede que incidam durante o uso.",
                     "title": "Taxa de Allowance da Rede"

--- a/packages/frontend/src/translations/ru.global.json
+++ b/packages/frontend/src/translations/ru.global.json
@@ -494,7 +494,7 @@
         },
         "v2": {
             "connectConfirm": {
-                "desc": "Подключайтесь только к сайтам, которым вы доверяете. Однажды подключенный, <a href=${contractIdUrl} target='_blank' rel='noreferrer'>${appReferrer}</a>сможет <b>${accessType}</b>:",
+                "desc": "Подключайтесь только к сайтам, которым вы доверяете. Однажды подключенный, <a href='${contractIdUrl}' target='_blank' rel='noreferrer'>${appReferrer}</a>сможет <b>${accessType}</b>:",
                 "feeAllowance": {
                     "desc": "Приложению будет разрешено потратить до <b>${amount} NEAR</b> в счет сетевых сборов, понесенных во время использования.",
                     "title": "Надбавка за Сетевую плату"

--- a/packages/frontend/src/translations/tr.global.json
+++ b/packages/frontend/src/translations/tr.global.json
@@ -585,7 +585,7 @@
         },
         "v2": {
             "connectConfirm": {
-                "desc": "Yalnızca güvendiğiniz sitelere bağlanın. bağlantı kurulduğunda, <a href=${contractIdUrl} target='_blank' rel='noreferrer'>${appReferrer}</a> yetkilerine sahip olacak <b>${accessType}</b>:",
+                "desc": "Yalnızca güvendiğiniz sitelere bağlanın. bağlantı kurulduğunda, <a href='${contractIdUrl}' target='_blank' rel='noreferrer'>${appReferrer}</a> yetkilerine sahip olacak <b>${accessType}</b>:",
                 "feeAllowance": {
                     "desc": "Uygulamaya kullanım sırasında oluşan ağ ücretleri için <b>${amount} NEAR</b> kadar harcama izni verilecektir.",
                     "title": "Ağ Ücreti Ödeneği"

--- a/packages/frontend/src/translations/ua.global.json
+++ b/packages/frontend/src/translations/ua.global.json
@@ -652,7 +652,7 @@
         },
         "v2": {
             "connectConfirm": {
-                "desc": "Підключайтеся лише до сайтів, яким ви довіряєте. Сайти, до яких ви підключалися, <a href=${contractIdUrl} target='_blank' rel='noreferrer'>${appReferrer}</a> матимуть <b>${accessType}</b>:",
+                "desc": "Підключайтеся лише до сайтів, яким ви довіряєте. Сайти, до яких ви підключалися, <a href='${contractIdUrl}' target='_blank' rel='noreferrer'>${appReferrer}</a> матимуть <b>${accessType}</b>:",
                 "feeAllowance": {
                     "desc": "Додатку буде дозволено витратити до <b>${amount} NEAR</b> за рахунок зборів, понесених під час використання.",
                     "title": "Надбавка за мережну плату"

--- a/packages/frontend/src/translations/vi.global.json
+++ b/packages/frontend/src/translations/vi.global.json
@@ -551,7 +551,7 @@
         },
         "v2": {
             "connectConfirm": {
-                "desc": "Chỉ kết nối với các trang web mà bạn tin tưởng. Sau khi kết nối, <a href=${contractIdUrl} target='_blank' rel='noreferrer'>${appReferrer}</a> sẽ có <b>${accessType}</b>:",
+                "desc": "Chỉ kết nối với các trang web mà bạn tin tưởng. Sau khi kết nối, <a href='${contractIdUrl}' target='_blank' rel='noreferrer'>${appReferrer}</a> sẽ có <b>${accessType}</b>:",
                 "feeAllowance": {
                     "desc": "Ứng dụng sẽ được phép chi tiêu TỐI ĐA <b>${amount} NEAR</b> có các phí phát sinh trên mạng trong quá trình sử dụng.",
                     "title": "Khoảng cho phép Phí xử lý Mạng"

--- a/packages/frontend/src/translations/zh-hans.global.json
+++ b/packages/frontend/src/translations/zh-hans.global.json
@@ -676,7 +676,7 @@
         },
         "v2": {
             "connectConfirm": {
-                "desc": "请连接你信任的应用。一旦连接，<a href=${contractIdUrl} target='_blank' rel='noreferrer'>${appReferrer}</a> 将拥有 <b>${accessType}</b> 权限：",
+                "desc": "请连接你信任的应用。一旦连接，<a href='${contractIdUrl}' target='_blank' rel='noreferrer'>${appReferrer}</a> 将拥有 <b>${accessType}</b> 权限：",
                 "feeAllowance": {
                     "desc": "授权该应用在使用过程中支付最多 <b>${amount} NEAR</b> 的网络费用。",
                     "title": "网络费用授权"

--- a/packages/frontend/src/translations/zh-hant.global.json
+++ b/packages/frontend/src/translations/zh-hant.global.json
@@ -676,7 +676,7 @@
         },
         "v2": {
             "connectConfirm": {
-                "desc": "請連接你信任的應用。一旦連接，<a href=${contractIdUrl} target='_blank' rel='noreferrer'>${appReferrer}</a> 將擁有 <b>${accessType}</b> 權限：",
+                "desc": "請連接你信任的應用。一旦連接，<a href='${contractIdUrl}' target='_blank' rel='noreferrer'>${appReferrer}</a> 將擁有 <b>${accessType}</b> 權限：",
                 "feeAllowance": {
                     "desc": "授權該應用在使用過程中支付最多 <b>${amount} NEAR</b> 的網絡費用。",
                     "title": "網絡費用授權"

--- a/packages/frontend/test/translations.test.js
+++ b/packages/frontend/test/translations.test.js
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import path from 'path';
+
+const TRANSLATION_BASE_PATH = path.resolve(__dirname, '../src/translations');
+
+test('translations contain no unescaped links', () => {
+    const translationPaths = fs.readdirSync(TRANSLATION_BASE_PATH)
+        .filter((fileName) => fileName.endsWith('.json'))
+        .map((fileName) => path.join(TRANSLATION_BASE_PATH, fileName));
+
+    translationPaths.forEach((fileName) => {
+        const translationLines = fs.readFileSync(fileName, 'utf-8').split('\n');
+        translationLines.forEach((line) => {
+            expect(line).toEqual(expect.not.stringMatching(/href=[^'"\\]/g));
+        });
+    });
+});


### PR DESCRIPTION
This PR adds escaping to the `href` on `v2.connectConfirm.desc` as well as a new test to catch missing quotes around `href` attributes across translation files.