### PR TITLE
fix: Show error toast if there is an error loading account

### DIFF
--- a/packages/frontend/src/redux/sharedThunks/refreshAccountOwner.js
+++ b/packages/frontend/src/redux/sharedThunks/refreshAccountOwner.js
@@ -53,7 +53,6 @@ export default createAsyncThunk(
                     ...(!wallet.isEmpty() && !accountIdNotConfirmed && await wallet.loadAccount())
                 };
             } else {
-                console.log('here is da error', error);
                 dispatch(showCustomAlert({
                     success: false,
                     messageCodeHeader: 'error',

--- a/packages/frontend/src/redux/sharedThunks/refreshAccountOwner.js
+++ b/packages/frontend/src/redux/sharedThunks/refreshAccountOwner.js
@@ -4,6 +4,7 @@ import { isImplicitAccount } from '../../utils/account';
 import { getAccountConfirmed, setAccountConfirmed } from '../../utils/localStorage';
 import { wallet } from '../../utils/wallet';
 import { makeAccountActive } from '../actions/account';
+import { showCustomAlert } from '../actions/status';
 
 export default createAsyncThunk(
     'refreshAccountOwner',
@@ -51,6 +52,14 @@ export default createAsyncThunk(
                     },
                     ...(!wallet.isEmpty() && !accountIdNotConfirmed && await wallet.loadAccount())
                 };
+            } else {
+                console.log('here is da error', error);
+                dispatch(showCustomAlert({
+                    success: false,
+                    messageCodeHeader: 'error',
+                    messageCode: 'walletErrorCodes.refreshAccountOwner.error',
+                    errorMessage: error.message
+                }));
             }
 
             throw error;

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1725,6 +1725,9 @@
             "lastMethod": "Cannot delete your last recovery method. Unless you have Ledger enabled, you need to keep at least one recovery method active to ensure recoverability of your account.",
             "setupMethod": "An error occurred. Please check your recovery method."
         },
+        "refreshAccountOwner": {
+            "error": "An error occured while loading your account. Some wallet data may not be up-to-date. Please try refreshing your browser."
+        },
         "sendFungibleToken": {
             "error": "An error occurred. Your send transaction was cancelled."
         },


### PR DESCRIPTION
Show an error toast with the text: `An error occured while loading your account. Some wallet data may not be up-to-date. Please try refreshing your browser.` if the `refreshAccountOwner` action throws an error.

<img width="1320" alt="Screen Shot 2022-06-08 at 3 46 15 PM" src="https://user-images.githubusercontent.com/24921205/172704426-44c58ad9-fd3e-4bb5-b613-68b589507e6c.png">
