### PR TITLE
fix: fix near pay link

### DIFF
--- a/packages/frontend/src/config/buyNearConfig.js
+++ b/packages/frontend/src/config/buyNearConfig.js
@@ -16,7 +16,7 @@ export const getPayMethods = ({ accountId, moonPayAvailable, signedMoonPayUrl, u
             link: signedMoonPayUrl,
             track: () => Mixpanel.track('Wallet Click Buy with Moonpay'),
         },
-        nearPay: { icon: payNear, name: 'NearPay', link: 'https://www.nearpay.io/' },
+        nearPay: { icon: payNear, name: 'NearPay', link: 'https://www.nearpay.co/' },
         utorg: { icon: utorg, name: 'UTORG', link: utorgPayUrl },
         rainbow: { icon: rainbow, name: 'Rainbow Bridge', link: 'https://rainbowbridge.app/transfer' },
         binance: { icon: okex, name: 'Okex', link: 'https://www.okex.com/' },


### PR DESCRIPTION
# fix: fix near pay link

Near Pay link should point to `nearpay.co` not `nearpay.io`