### PR TITLE
chore: no longer render release notes modal

### DIFF
--- a/packages/frontend/src/components/wallet/Wallet.js
+++ b/packages/frontend/src/components/wallet/Wallet.js
@@ -25,7 +25,6 @@ import DepositNearBanner from './DepositNearBanner';
 import ExploreApps from './ExploreApps';
 import LinkDropSuccessModal from './LinkDropSuccessModal';
 import NFTs from './NFTs';
-import ReleaseNotesModal from './ReleaseNotesModal';
 import Sidebar from './Sidebar';
 import Tokens from './Tokens';
 
@@ -321,7 +320,6 @@ export function Wallet({
         <StyledContainer
             className={SHOW_NETWORK_BANNER ? 'showing-banner' : ''}
         >
-            <ReleaseNotesModal />
             <div className="split">
                 <div className="left">
                     <div className="tab-selector">


### PR DESCRIPTION
This PR removes the rendering of `ReleaseNotesModal` from the main wallet page component. The information on this modal is currently woefully out of date and does not serve any productive purpose.

Until there's a process for keeping this updated with useful information it is better to not display it at all.