### PR TITLE
Fix url warning on Recovery page

### DIFF
--- a/packages/frontend/src/utils/getWalletURL.js
+++ b/packages/frontend/src/utils/getWalletURL.js
@@ -1,4 +1,5 @@
 import { IS_MAINNET, SHOW_PRERELEASE_WARNING } from '../config';
+import { isWhitelabel } from '../config/whitelabel';
 
 export default (https = true) => {
     let networkName = '';
@@ -9,5 +10,10 @@ export default (https = true) => {
         networkName = 'testnet.';
     }
 
-    return `${https ? 'https://' : ''}wallet.${networkName}near.org`;
+    const protocol = https ? 'https://' : '';
+    if (isWhitelabel) {
+        return `${protocol}app.mynearwallet.com`;
+    }
+
+    return `${protocol}wallet.${networkName}near.org`;
 };


### PR DESCRIPTION
https://discord.com/channels/976052458205892608/979439846030467093/985832528747311145

![discord](https://user-images.githubusercontent.com/7001916/173554950-b5845caf-4b46-4cb8-82a0-cb0e0e92e8d3.png)

