### PR TITLE
MYNW-64: add MixPanel events to top-up options

### DIFF
--- a/packages/frontend/src/config/buyNearConfig.js
+++ b/packages/frontend/src/config/buyNearConfig.js
@@ -16,11 +16,42 @@ export const getPayMethods = ({ accountId, moonPayAvailable, signedMoonPayUrl, u
             link: signedMoonPayUrl,
             track: () => Mixpanel.track('Wallet Click Buy with Moonpay'),
         },
-        nearPay: { icon: payNear, name: 'NearPay', link: 'https://www.nearpay.co/' },
-        utorg: { icon: utorg, name: 'UTORG', link: utorgPayUrl, provideReferrer: true },
-        rainbow: { icon: rainbow, name: 'Rainbow Bridge', link: 'https://rainbowbridge.app/transfer' },
-        binance: { icon: okex, name: 'Okex', link: 'https://www.okex.com/' },
-        okex: { icon: binance, name: 'Binance', link: 'https://www.binance.com/' },
-        huobi: { icon: huobi, name: 'Huobi', link: 'https://c2c.huobi.com/en-us/one-trade/buy' },
+        nearPay: {
+            icon: payNear,
+            name: 'NearPay',
+            link: 'https://www.nearpay.co/',
+            track: () => Mixpanel.track('Wallet Click Buy with Nearpay')
+        },
+        utorg: {
+            icon: utorg,
+            name: 'UTORG',
+            link: utorgPayUrl,
+            provideReferrer: true,
+            track: () => Mixpanel.track('Wallet Click Buy with UTORG')
+        },
+        rainbow: {
+            icon: rainbow,
+            name: 'Rainbow Bridge',
+            link: 'https://rainbowbridge.app/transfer',
+            track: () => Mixpanel.track('Wallet Click Bridge with Rainbow Bridge')
+        },
+        binance: {
+            icon: okex,
+            name: 'Okex',
+            link: 'https://www.okex.com/',
+            track: () => Mixpanel.track('Wallet Click Exchange with Okex')
+        },
+        okex: {
+            icon: binance,
+            name: 'Binance',
+            link: 'https://www.binance.com/',
+            track: () => Mixpanel.track('Wallet Click Exchange with Binance')
+        },
+        huobi: {
+            icon: huobi,
+            name: 'Huobi',
+            link: 'https://c2c.huobi.com/en-us/one-trade/buy',
+            track: () => Mixpanel.track('Wallet Click Exchange with Huobi')
+        },
     };
 };

--- a/packages/frontend/src/config/buyNearConfig.js
+++ b/packages/frontend/src/config/buyNearConfig.js
@@ -35,13 +35,13 @@ export const getPayMethods = ({ accountId, moonPayAvailable, signedMoonPayUrl, u
             link: 'https://rainbowbridge.app/transfer',
             track: () => Mixpanel.track('Wallet Click Bridge with Rainbow Bridge')
         },
-        binance: {
+        okex: {
             icon: okex,
             name: 'Okex',
             link: 'https://www.okex.com/',
             track: () => Mixpanel.track('Wallet Click Exchange with Okex')
         },
-        okex: {
+        binance: {
             icon: binance,
             name: 'Binance',
             link: 'https://www.binance.com/',


### PR DESCRIPTION
https://mnw.atlassian.net/browse/MYNW-64

**Problem:**
MixPanel events were missing for UTORG, NearPay, RainbowBridge and all exchanges

**Fix:**
Added MixPanel events for this actions