### PR TITLE
chore: flag migration banner off

### DIFF
--- a/features/features.d.ts
+++ b/features/features.d.ts
@@ -4,4 +4,5 @@
 export type Features = {
     CREATE_USN_CONTRACT: boolean;
 	DONATE_TO_UKRAINE: boolean;
+	SHOW_MIGRATION_BANNER: boolean;
 };

--- a/features/flags.json
+++ b/features/flags.json
@@ -91,14 +91,14 @@
     "createdBy": "gutsyphilip",
     "createdAt": "2022-05-25T01:11:55.121Z",
     "development": {
-      "enabled": true,
-      "lastEditedBy": "gutsyphilip",
-      "lastEditedAt": "2022-05-25T01:11:55.121Z"
+      "enabled": false,
+      "lastEditedBy": "esaminu",
+      "lastEditedAt": "2022-06-20T18:11:26.582Z"
     },
     "testnet": {
-      "enabled": true,
-      "lastEditedBy": "gutsyphilip",
-      "lastEditedAt": "2022-05-25T01:11:55.121Z"
+      "enabled": false,
+      "lastEditedBy": "esaminu",
+      "lastEditedAt": "2022-06-20T18:11:26.582Z"
     },
     "mainnet": {
       "enabled": false,
@@ -116,19 +116,19 @@
       "lastEditedAt": "2022-05-25T01:11:55.121Z"
     },
     "testnet_NEARORG": {
-      "enabled": true,
-      "lastEditedBy": "gutsyphilip",
-      "lastEditedAt": "2022-05-25T01:11:55.121Z"
+      "enabled": false,
+      "lastEditedBy": "esaminu",
+      "lastEditedAt": "2022-06-20T18:11:26.582Z"
     },
     "mainnet_NEARORG": {
-      "enabled": true,
-      "lastEditedBy": "gutsyphilip",
-      "lastEditedAt": "2022-05-25T01:11:55.121Z"
+      "enabled": false,
+      "lastEditedBy": "esaminu",
+      "lastEditedAt": "2022-06-20T18:11:26.582Z"
     },
     "mainnet_STAGING_NEARORG": {
-      "enabled": true,
-      "lastEditedBy": "gutsyphilip",
-      "lastEditedAt": "2022-05-25T01:11:55.121Z"
+      "enabled": false,
+      "lastEditedBy": "esaminu",
+      "lastEditedAt": "2022-06-20T18:11:26.582Z"
     }
   }
 }


### PR DESCRIPTION
This PR turns the `SHOW_MIGRATION_BANNER ` feature flag off until further notice