### PR TITLE
feat: query RPC 'get_price' to estimate fees for token transfer

### DIFF
--- a/packages/frontend/src/services/FungibleTokens.js
+++ b/packages/frontend/src/services/FungibleTokens.js
@@ -102,7 +102,7 @@ export default class FungibleTokens {
             const totalGasFees = await getTotalGasFee(new BN(FT_TRANSFER_GAS).add(new BN(FT_STORAGE_DEPOSIT_GAS)));
             return new BN(totalGasFees).add(new BN(FT_MINIMUM_STORAGE_BALANCE)).toString();
         } else {
-            return await getTotalGasFee(contractName ? FT_TRANSFER_GAS : SEND_NEAR_GAS);
+            return getTotalGasFee(contractName ? FT_TRANSFER_GAS : SEND_NEAR_GAS);
         }
     }
 

--- a/packages/frontend/src/utils/gasPrice.js
+++ b/packages/frontend/src/utils/gasPrice.js
@@ -1,0 +1,18 @@
+import BN from 'bn.js';
+
+import { wallet } from './wallet';
+
+export const getLatestBlock = () => wallet.connection.provider.block({ finality: 'final' });
+
+export const getLatestGasPrice = async () => {
+    const latestBlock = await getLatestBlock();
+    return latestBlock.header.gas_price;
+};
+
+export const getTotalGasFee = async (gas) => {
+    const latestGasPrice = await getLatestGasPrice();
+    return new BN(latestGasPrice).mul(new BN(gas)).toString();
+};
+
+export const formatTGasToYoctoNEAR = (tGas) => new BN(tGas * 10 ** 12).toString();
+


### PR DESCRIPTION
Reference: https://nearinc.atlassian.net/browse/WAL-329

This PR queries RPC `get_price` to get the latest gas price. The `gas_price` is then used to estimate total fees when transferring fungible tokens.

<img width="675" alt="Screen Shot 2022-06-23 at 2 55 33 PM" src="https://user-images.githubusercontent.com/24921205/175376252-bc9c95b1-ef9e-4349-a16b-e31c1ecf615a.png">

For follow-up PR: Use `getTotalGasFee` to more accurately estimate fee's wherever a fee breakdown is shown
