### PR TITLE
feat: add batch export to ledger wallet route

### DIFF
--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -56,6 +56,7 @@ import {
 import AccessKeysWrapper from './access-keys/v2/AccessKeysWrapper';
 import { AutoImportWrapper } from './accounts/auto_import/AutoImportWrapper';
 import BatchImportAccounts from './accounts/batch_import_accounts';
+import BatchLedgerExport from './accounts/batch_ledger_export';
 import { ExistingAccountWrapper } from './accounts/create/existing_account/ExistingAccountWrapper';
 import { InitialDepositWrapper } from './accounts/create/initial_deposit/InitialDepositWrapper';
 import { CreateAccountLanding } from './accounts/create/landing/CreateAccountLanding';
@@ -579,6 +580,11 @@ class Routing extends Component {
                                 }, {});
                                 return <BatchImportAccounts accountIdToKeyMap={accountIdToKeyMap} onCancel={() => this.props.history.replace('/')}/>;
                             })} />
+                            <Route
+                                exact
+                                path="/batch-ledger-export"
+                                component={BatchLedgerExport}
+                            />
                             <Route
                                 exact
                                 path="/sign-in-ledger"

--- a/packages/frontend/src/components/accounts/batch_import_accounts/BatchImportAccountsSuccessScreen.js
+++ b/packages/frontend/src/components/accounts/batch_import_accounts/BatchImportAccountsSuccessScreen.js
@@ -26,7 +26,7 @@ const CustomContainer = styled.div`
       }
 `;
 
-const BatchImportAccountsSuccessScreen = ({ accounts = [] }) => {
+const BatchImportAccountsSuccessScreen = ({ accounts = [], customTitleId }) => {
   const dispatch = useDispatch();
   const accountUrlReferrer = useSelector(selectAccountUrlReferrer);
 
@@ -36,7 +36,7 @@ const BatchImportAccountsSuccessScreen = ({ accounts = [] }) => {
           <AvatarSuccessIcon />
           <div className='screen-descripton'>
             <h3>
-              <Translate id="batchImportAccounts.successScreen.title" data={{ noOfAccounts: accounts.length }}/>
+              <Translate id={customTitleId || 'batchImportAccounts.successScreen.title'} data={{ noOfAccounts: accounts.length }}/>
               {accountUrlReferrer || <Translate id="sign.unknownApp" />}
             </h3>
             <br />

--- a/packages/frontend/src/components/accounts/batch_import_accounts/sequentialAccountImportReducer.js
+++ b/packages/frontend/src/components/accounts/batch_import_accounts/sequentialAccountImportReducer.js
@@ -1,4 +1,4 @@
-import { differenceBy } from 'lodash';
+import { differenceBy, uniqWith, isEqual } from 'lodash';
 
 import { IMPORT_STATUS } from '.';
 
@@ -6,8 +6,9 @@ import { IMPORT_STATUS } from '.';
  * @typedef {{ 
  *  accountId: string, 
  *  status: "pending" | "success" | "waiting" | "error" | null ,
- *  key: string,
- *  ledgerHdPath: string
+ *  key?: string,
+ *  ledgerHdPath?: string,
+ *  keyType?: string
  * }} account
  * 
  * @typedef {{accounts: account[], urlConfirmed: boolean}} state
@@ -42,6 +43,13 @@ const sequentialAccountImportReducer = (state = initialState, action) => {
                     action.accounts,
                     (accountOrId) => accountOrId?.accountId || accountOrId
                 );
+            }
+
+            return;
+        }
+        case ACTIONS.ADD_ACCOUNTS: {
+            if (state.accounts.every(({ status }) => status === null)) {
+                state.accounts = uniqWith(state.accounts.concat(action.accounts), isEqual);
             }
 
             return;

--- a/packages/frontend/src/components/accounts/batch_ledger_export/AccountExportModal.js
+++ b/packages/frontend/src/components/accounts/batch_ledger_export/AccountExportModal.js
@@ -1,0 +1,124 @@
+import BN from 'bn.js';
+import { KeyPair, transactions } from 'near-api-js';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Translate } from 'react-localize-redux';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { actions as ledgerActions, LEDGER_HD_PATH_PREFIX, selectLedgerConnectionAvailable } from '../../../redux/slices/ledger';
+import { getEstimatedFees } from '../../../redux/slices/sign';
+import { setLedgerHdPath } from '../../../utils/localStorage';
+import WalletClass, { wallet } from '../../../utils/wallet';
+import FormButton from '../../common/FormButton';
+import FormButtonGroup from '../../common/FormButtonGroup';
+import Modal from '../../common/modal/Modal';
+import SignTransaction from '../../sign/v2/SignTransaction';
+import SignTransactionDetails from '../../sign/v2/SignTransactionDetails';
+import { HDPathSelect } from '../ledger/LedgerHdPaths';
+import { ModalContainer } from './styles';
+
+const { checkAndHideLedgerModal, handleShowConnectModal } = ledgerActions;
+
+
+const AccountExportModal = ({ account, onSuccess, onFail }) => {
+    const [accountBalance, setAccountBalance] = useState(null);
+    const [showTxDetails, setShowTxDetails] = useState(false);
+    const [addingKey, setAddingKey] = useState(false);
+    const [error, setError] = useState(false);
+    const [path, setPath] = useState(1);
+    const ledgerConnectionAvailable = useSelector(selectLedgerConnectionAvailable);
+
+    const addFAKTransaction = {
+        receiverId: account.accountId,
+        actions: [transactions.addKey(KeyPair.fromRandom('ed25519').getPublicKey(), transactions.fullAccessKey())]
+    };
+
+    const estimatedAddFAKTransactionFees = useMemo(() => addFAKTransaction ? getEstimatedFees([addFAKTransaction]) : new BN('0') ,[addFAKTransaction]);
+    const dispatch = useDispatch();
+  
+    useEffect(() => {
+      setAccountBalance(null);
+      setShowTxDetails(false);
+      setAddingKey(false);
+      setError(false);
+  
+      wallet
+          .getBalance(account.accountId)
+          .then(({ available }) => setAccountBalance(available));
+    },[account]);
+  
+    const addKeyToWalletKeyStore = useCallback(async () => {
+        setAddingKey(true);
+        setError(false);
+
+        if (!ledgerConnectionAvailable) {
+            setAddingKey(false);
+            return dispatch(handleShowConnectModal());
+        }
+        
+        try {
+            const ledgerHdPath = `${LEDGER_HD_PATH_PREFIX}${path}'`;
+            if (account.keyType === WalletClass.KEY_TYPES.MULTISIG) {
+                await wallet.exportToLedgerWallet(ledgerHdPath, account.accountId);
+            } else {
+                setLedgerHdPath({ accountId: account.accountId, path: ledgerHdPath });
+                await wallet.addLedgerAccessKey(ledgerHdPath, account.accountId);
+            }
+            onSuccess();
+        } catch (error) {
+            setError(true);
+            setAddingKey(false);
+        }
+        dispatch(checkAndHideLedgerModal());
+    }, [onSuccess, account.accountId, ledgerConnectionAvailable]);
+  
+    return (
+        <Modal
+            isOpen={account}
+            modalSize="md"
+            modalClass="slim"
+            onClose={() => {}}
+            disableClose
+        >
+            {showTxDetails ? (
+                <SignTransactionDetails
+                    onClickGoBack={() => setShowTxDetails(false)}
+                    transactions={[addFAKTransaction]}
+                    signGasFee={estimatedAddFAKTransactionFees.toString()}
+                />
+            ) : (
+                <ModalContainer>
+                    <h3 style={{padding: '6px 24px'}}>
+                        <Translate id="batchExportAccounts.confirmExportModal.title" />
+                    </h3>
+                    <HDPathSelect path={path} setPath={setPath} type="export" />
+                    <SignTransaction
+                        sender={account.accountId}
+                        availableBalance={accountBalance}
+                        estimatedFees={estimatedAddFAKTransactionFees}
+                        fromLabelId="batchExportAccounts.confirmExportModal.accountToExport"
+                    />
+                    <FormButton className="link" onClick={() => setShowTxDetails(true)}>
+                        <Translate id="batchExportAccounts.confirmExportModal.transactionDetails" />
+                    </FormButton>
+                    {error ? <div className='error-label'><Translate id="reduxActions.default.error" /></div> : null}
+                    <FormButtonGroup>
+                        <FormButton onClick={onFail} className="gray-blue">
+                            <Translate id="button.cancel" />
+                        </FormButton>
+                        <FormButton
+                            onClick={addKeyToWalletKeyStore}
+                            disabled={
+                                !account.keyType || account.keyType === WalletClass.KEY_TYPES.OTHER || account.keyType === WalletClass.KEY_TYPES.LEDGER
+                            }
+                            sending={addingKey}
+                        >
+                            <Translate id="button.approve" />
+                        </FormButton>
+                    </FormButtonGroup>
+                </ModalContainer>
+            )}
+        </Modal>
+    );
+  };
+
+  export default AccountExportModal;

--- a/packages/frontend/src/components/accounts/batch_ledger_export/AccountExportModal.js
+++ b/packages/frontend/src/components/accounts/batch_ledger_export/AccountExportModal.js
@@ -69,7 +69,7 @@ const AccountExportModal = ({ account, onSuccess, onFail }) => {
             setAddingKey(false);
         }
         dispatch(checkAndHideLedgerModal());
-    }, [onSuccess, account.accountId, ledgerConnectionAvailable]);
+    }, [path, account.accountId, ledgerConnectionAvailable]);
   
     return (
         <Modal

--- a/packages/frontend/src/components/accounts/batch_ledger_export/index.js
+++ b/packages/frontend/src/components/accounts/batch_ledger_export/index.js
@@ -1,0 +1,139 @@
+import { partition } from 'lodash';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Translate } from 'react-localize-redux';
+import { useSelector } from 'react-redux';
+import styled from 'styled-components';
+import { useImmerReducer } from 'use-immer';
+
+import { NETWORK_ID } from '../../../config';
+import { selectAvailableAccountsIsLoading } from '../../../redux/slices/availableAccounts';
+import WalletClass, { wallet } from '../../../utils/wallet';
+import FormButton from '../../common/FormButton';
+import FormButtonGroup from '../../common/FormButtonGroup';
+import Container from '../../common/styled/Container.css';
+import LedgerImageCircle from '../../svg/LedgerImageCircle';
+import AccountListImport from '../AccountListImport';
+import { IMPORT_STATUS } from '../batch_import_accounts';
+import BatchImportAccountsSuccessScreen from '../batch_import_accounts/BatchImportAccountsSuccessScreen';
+import reducer, { ACTIONS } from '../batch_import_accounts/sequentialAccountImportReducer';
+import AccountExportModal from './AccountExportModal';
+
+const CustomContainer = styled.div`
+    width: 100%;
+    margin-top: 40px;
+
+    .buttons-bottom-buttons {
+        margin-top: 40px;
+    }
+
+    .title {
+        text-align: left;
+        font-size: 12px;
+    }
+
+    .screen-descripton {
+      margin-top: 40px;
+      margin-bottom: 56px;
+    }
+`;
+
+const BatchLedgerExport = ({ onCancel }) => {
+    const availableAccountsIsLoading = useSelector(selectAvailableAccountsIsLoading);
+    const [, setLedgerAccounts] = useState([]);
+
+    const [state, dispatch] = useImmerReducer(reducer, {
+        accounts: []
+    });
+
+    useEffect(() => {
+        const addAccountsToList = async () => {
+            const accounts = await wallet.keyStore.getAccounts(NETWORK_ID);
+            const getAccountWithAccessKeysAndType = async (accountId) => {
+                const keyType = await wallet.getAccountKeyType(accountId);
+                const accessKeys = await wallet.getAccessKeys(accountId);
+                return {accountId, accessKeys, keyType};
+            };
+            const accountsWithKeys = await Promise.all(
+                accounts.map(getAccountWithAccessKeysAndType)
+            );
+            const [ledgerAccounts, nonLedgerAccounts] = partition(
+                accountsWithKeys,
+                ({ keyType, accessKeys }) =>
+                    keyType === WalletClass.KEY_TYPES.LEDGER ||
+                    accessKeys.some(
+                        (accessKey) => accessKey.meta.type === 'ledger'
+                    )
+            );
+            setLedgerAccounts(ledgerAccounts);
+            dispatch({type: ACTIONS.ADD_ACCOUNTS, accounts: nonLedgerAccounts.map(({accountId, keyType}) => ({
+                accountId,
+                status: null,
+                keyType
+            }))});
+        };
+        addAccountsToList();
+    },[]);
+
+    const currentAccount = useMemo(() => state.accounts.find((account) => account.status === IMPORT_STATUS.PENDING), [state.accounts]);
+    const accountsApproved = useMemo(() => state.accounts.filter((account) => account.status === IMPORT_STATUS.SUCCESS), [state.accounts]);
+    const completed = useMemo(() => state.accounts.every((account) => account.status === IMPORT_STATUS.SUCCESS || account.status === IMPORT_STATUS.FAILED), [state.accounts]);
+    const showSuccessScreen = useMemo(() => completed && state.accounts.some((account) => account.status === IMPORT_STATUS.SUCCESS), [completed, state.accounts]);
+
+    if (showSuccessScreen) {
+        return <BatchImportAccountsSuccessScreen accounts={accountsApproved} />;
+    }
+
+    return (
+        <>
+            <Container className="small-centered border ledger-theme">
+              <CustomContainer>
+                  <LedgerImageCircle color='#D6EDFF' />
+                  <div className='screen-descripton'>
+                    <h3>
+                      <Translate id="batchExportAccounts.exportScreen.weFound" data={{ noOfAccounts: state.accounts.length }}/>
+                    </h3>
+                    <br />
+                    <br />
+                    <Translate id="batchExportAccounts.exportScreen.desc"/>
+                  </div>
+                    <div className="title">
+                        {accountsApproved.length}/{state.accounts.length}{' '}
+                        <Translate id="signInLedger.modal.accountsApproved" />
+                    </div>
+                    <AccountListImport accounts={state.accounts} />
+                    <div style={{ borderTop: '2px solid #f5f5f5' }} />
+                    <FormButtonGroup>
+                        <FormButton
+                            onClick={onCancel}
+                            className="gray-blue"
+                            disabled={availableAccountsIsLoading}
+                        >
+                            <Translate id="button.cancel" />
+                        </FormButton>
+                        <FormButton
+                            onClick={() =>
+                                dispatch({ type: ACTIONS.BEGIN_IMPORT })
+                            }
+                            disabled={availableAccountsIsLoading || completed}
+                        >
+                            <Translate id="button.beginExport" />
+                        </FormButton>
+                    </FormButtonGroup>
+                </CustomContainer>
+            </Container>
+            {currentAccount ? (
+                <AccountExportModal
+                    account={currentAccount}
+                    onSuccess={() =>
+                        dispatch({ type: ACTIONS.SET_CURRENT_DONE })
+                    }
+                    onFail={() =>
+                        dispatch({ type: ACTIONS.SET_CURRENT_FAILED })
+                    }
+                />
+            ) : null}
+        </>
+    );
+};
+
+export default BatchLedgerExport;

--- a/packages/frontend/src/components/accounts/batch_ledger_export/index.js
+++ b/packages/frontend/src/components/accounts/batch_ledger_export/index.js
@@ -80,7 +80,7 @@ const BatchLedgerExport = ({ onCancel }) => {
     const showSuccessScreen = useMemo(() => completed && state.accounts.some((account) => account.status === IMPORT_STATUS.SUCCESS), [completed, state.accounts]);
 
     if (showSuccessScreen) {
-        return <BatchImportAccountsSuccessScreen accounts={accountsApproved} />;
+        return <BatchImportAccountsSuccessScreen accounts={accountsApproved} customTitleId="batchExportAccounts.successScreen.title" />;
     }
 
     return (

--- a/packages/frontend/src/components/accounts/batch_ledger_export/styles.js
+++ b/packages/frontend/src/components/accounts/batch_ledger_export/styles.js
@@ -1,0 +1,65 @@
+import styled from 'styled-components';
+
+import Container from '../../common/styled/Container.css';
+
+export const ModalContainer = styled(Container)`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 24px;
+
+    h3 {
+        text-align: center;
+    }
+
+    .desc {
+        text-align: left !important;
+        padding: 0 !important;
+    }
+
+    .top-icon {
+        height: 60px;
+        width: 60px;
+        margin-bottom: 40px;
+    }
+
+    .desc {
+        padding: 0 45px;
+        text-align: center;
+        margin-top: 24px;
+        p {
+            margin: 0;
+        }
+    }
+
+    button {
+        align-self: stretch;
+    }
+
+    .link {
+        margin-top: 16px !important;
+        font-weight: normal !important;
+    }
+
+    .button-group {
+        align-self: stretch;
+    }
+
+    .connect-with-application {
+        margin: 20px auto 30px auto;
+    }
+
+    .transfer-amount {
+        width: 100%;
+    }
+
+    .error-label {
+        margin-top: 16px;
+        color: #fc5b5b;
+    }
+
+    .wallet-url {
+        color: #000;
+        font-weight: bold;
+    }
+`;

--- a/packages/frontend/src/components/accounts/ledger/LedgerHdPaths.js
+++ b/packages/frontend/src/components/accounts/ledger/LedgerHdPaths.js
@@ -108,16 +108,16 @@ const Container = styled.div`
         }
     }
 `;
-
-export default function LedgerHdPaths({ 
-    confirmedPath,
-    setConfirmedPath
-}) {
-    const [path, setPath] = useState(confirmedPath);
+/**
+ * @param {Object} props
+ * @param {"import" | "export"} props.type - curently only affects copy
+ */
+export const HDPathSelect = ({ handleConfirmHdPath, path, setPath, type = 'import' }) => {
 
     onKeyDown((e) => {
-        const dropdownOpen = document.getElementById('hd-paths-dropdown').classList.contains('open');
-        if (dropdownOpen) {
+        const dropdownElement = document.getElementById('hd-paths-dropdown');
+        const dropdownOpenIfRendered = dropdownElement === null || document.getElementById('hd-paths-dropdown').classList.contains('open');
+        if (dropdownOpenIfRendered) {
             if (e.keyCode === 38) {
                 increment();
                 e.preventDefault();
@@ -138,15 +138,11 @@ export default function LedgerHdPaths({
         }
     };
 
-    const handleConfirmHdPath = () => {
-        setConfirmedPath(path);
-    };
-
-    const dropDownContent = () => {
-        return (
+    return (
+        <Container>
             <div className='ledger-dropdown-content'>
                 <div className='title'><Translate id='signInLedger.advanced.subTitle'/></div>
-                <div className='desc'><Translate id='signInLedger.advanced.desc'/></div>
+                <div className='desc'><Translate id={`signInLedger.advanced.${type === 'export' ? 'exportDesc' : 'desc'}`}/></div>
                 <div className='path-wrapper'>
                     <div className='default-paths'>44 / 397 / 0 / 0</div>
                     <span>&ndash;</span>
@@ -162,12 +158,24 @@ export default function LedgerHdPaths({
                         </div>
                     </div>
                 </div>
-                <FormButton className='hd-paths-dropdown-toggle' onClick={handleConfirmHdPath}>
-                    <Translate id='signInLedger.advanced.setPath'/>
-                </FormButton>
+                {handleConfirmHdPath ? (
+                    <FormButton
+                        className='hd-paths-dropdown-toggle'
+                        onClick={() => handleConfirmHdPath(path)}
+                    >
+                        <Translate id='signInLedger.advanced.setPath' />
+                    </FormButton>
+                ) : null}
             </div>
-        );
-    };
+        </Container>
+    );
+};
+
+export default function LedgerHdPaths({ 
+    confirmedPath,
+    setConfirmedPath
+}) {
+    const [path, setPath] = useState(confirmedPath || 1);
 
     return (
         <Container>
@@ -175,7 +183,7 @@ export default function LedgerHdPaths({
                 name='hd-paths-dropdown'
                 icon={<SettingsIcon/>}
                 title={<Translate id='signInLedger.advanced.title'/>}
-                content={dropDownContent()}
+                content={<HDPathSelect handleConfirmHdPath={setConfirmedPath} path={path} setPath={setPath} />}
                 maxHeight={false}
             />
         </Container>

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -195,6 +195,20 @@
         "available": "Available balance",
         "reserved": "Reserved for fees"
     },
+    "batchExportAccounts": {
+        "confirmExportModal": {
+            "accountToExport": "Account to Export",
+            "title": "Approve Account Export",
+            "transactionDetails": "+ Transaction Details"
+        },
+        "exportScreen": {
+            "desc": "Begin your export and confirm each account </br> when prompted.",
+            "weFound": "We found ${noOfAccounts} accounts to export to your device."
+        },
+        "successScreen": {
+            "title": "${noOfAccounts} account(s) were successfully </br> exported to your device"
+        }
+    },
     "batchImportAccounts": {
         "confirmImportModal": {
             "accountToImport": "Account to Import",
@@ -225,6 +239,7 @@
         "authorize": "Authorize",
         "authorizing": "Authorizing",
         "backToSwap": "Back to Swap",
+        "beginExport": "Begin Export",
         "beginImport": "Begin Import",
         "browseApps": "Browse Apps",
         "buy": "Buy",
@@ -1368,6 +1383,7 @@
     "signInLedger": {
         "advanced": {
             "desc": "Specify an HD path to import its linked accounts.",
+            "exportDesc": "Specify an HD path to export your account to, you’ll need to remember your choice to use this account in the future.<br/><b>For additional security use different HD paths for each unique account.</b>",
             "setPath": "Set HD Path",
             "subTitle": "HD Path",
             "title": "Advanced Options"

--- a/packages/frontend/src/utils/wallet.js
+++ b/packages/frontend/src/utils/wallet.js
@@ -202,7 +202,7 @@ export default class Wallet {
         if (accessKeys) {
             const localKey = await this.getLocalAccessKey(accountId, accessKeys);
             const ledgerKey = accessKeys.find((accessKey) => accessKey.meta.type === 'ledger');
-            const localKeyIsNullOrNonMultisigLAK = !localKey || (localKey.access_key.permission !== 'FullAccess' && !this.isMultisigKeyInfoView(accountId, localKey));
+            const localKeyIsNullOrNonMultisigLAK = !localKey || (localKey.permission !== 'FullAccess' && !this.isMultisigKeyInfoView(accountId, localKey));
             if (ledgerKey && localKeyIsNullOrNonMultisigLAK) {
                 return PublicKey.from(ledgerKey.public_key);
             }

--- a/packages/frontend/src/utils/wallet.js
+++ b/packages/frontend/src/utils/wallet.js
@@ -636,11 +636,11 @@ export default class Wallet {
         const accountId = accountIdOverride || this.accountId;
         const ledgerPublicKey = await this.getLedgerPublicKey(path);
         const accessKeys = await this.getAccessKeys(accountId);
-        const accountHasLedgerKey = accessKeys.map((key) => key.public_key).includes(ledgerPublicKey.toString());
+        const accountHasLedgerKey = accessKeys.some((key) => key.public_key === ledgerPublicKey.toString());
         await setKeyMeta(ledgerPublicKey, { type: 'ledger' });
 
-        const account = await this.getAccount(accountId);
         if (!accountHasLedgerKey) {
+            const account = await this.getAccount(accountId);
             await account.addKey(ledgerPublicKey);
             await this.postSignedJson('/account/ledgerKeyAdded', { accountId, publicKey: ledgerPublicKey.toString() });
         }
@@ -649,12 +649,12 @@ export default class Wallet {
     async exportToLedgerWallet(path, accountId) {
         const ledgerPublicKey = await this.getLedgerPublicKey(path);
         const accessKeys = await this.getAccessKeys(accountId);
-        const accountHasLedgerKey = accessKeys.map((key) => key.public_key).includes(ledgerPublicKey.toString());
-
-        const account = await this.getAccount(accountId);
-        const has2fa = await TwoFactor.has2faEnabled(account);
+        const accountHasLedgerKey = accessKeys.some((key) => key.public_key === ledgerPublicKey.toString());
 
         if (!accountHasLedgerKey) {
+            const account = await this.getAccount(accountId);
+            const has2fa = await TwoFactor.has2faEnabled(account);
+
             if (has2fa) {
                 await store.dispatch(switchAccount({accountId: account.accountId}));
             }

--- a/packages/frontend/src/utils/wallet.js
+++ b/packages/frontend/src/utils/wallet.js
@@ -9,7 +9,8 @@ import { store } from '..';
 import * as Config from '../config';
 import {
     makeAccountActive,
-    redirectTo
+    redirectTo,
+    switchAccount
 } from '../redux/actions/account';
 import { actions as ledgerActions } from '../redux/slices/ledger';
 import sendJson from '../tmp_fetch_send_json';
@@ -201,7 +202,7 @@ export default class Wallet {
         if (accessKeys) {
             const localKey = await this.getLocalAccessKey(accountId, accessKeys);
             const ledgerKey = accessKeys.find((accessKey) => accessKey.meta.type === 'ledger');
-            if (ledgerKey && (!localKey || localKey.permission !== 'FullAccess')) {
+            if (ledgerKey && (!localKey || localKey.access_key.permission !== 'FullAccess')) {
                 return PublicKey.from(ledgerKey.public_key);
             }
         }
@@ -293,6 +294,11 @@ export default class Wallet {
         }
 
         throw new Error('No matching key pair for public key');
+    }
+
+    async getAccountKeyType(accountId) {
+        const keypair = await wallet.keyStore.getKey(NETWORK_ID, accountId);
+        return this.getPublicKeyType(accountId, keypair.getPublicKey().toString());
     }
 
     isFullAccessKeyInfoView(keyInfoView) {
@@ -625,10 +631,10 @@ export default class Wallet {
         }
     }
 
-    async addLedgerAccessKey(path) {
-        const accountId = this.accountId;
+    async addLedgerAccessKey(path, accountIdOverride) {
+        const accountId = accountIdOverride || this.accountId;
         const ledgerPublicKey = await this.getLedgerPublicKey(path);
-        const accessKeys = await this.getAccessKeys();
+        const accessKeys = await this.getAccessKeys(accountId);
         const accountHasLedgerKey = accessKeys.map((key) => key.public_key).includes(ledgerPublicKey.toString());
         await setKeyMeta(ledgerPublicKey, { type: 'ledger' });
 
@@ -636,6 +642,23 @@ export default class Wallet {
         if (!accountHasLedgerKey) {
             await account.addKey(ledgerPublicKey);
             await this.postSignedJson('/account/ledgerKeyAdded', { accountId, publicKey: ledgerPublicKey.toString() });
+        }
+    }
+
+    async exportToLedgerWallet(path, accountId) {
+        const ledgerPublicKey = await this.getLedgerPublicKey(path);
+        const accessKeys = await this.getAccessKeys(accountId);
+        const accountHasLedgerKey = accessKeys.map((key) => key.public_key).includes(ledgerPublicKey.toString());
+
+        const account = await this.getAccount(accountId);
+        const has2fa = await TwoFactor.has2faEnabled(account);
+
+        if (!accountHasLedgerKey) {
+            if (has2fa) {
+                await store.dispatch(switchAccount({accountId: account.accountId}));
+            }
+            await account.addKey(ledgerPublicKey);
+            await setKeyMeta(ledgerPublicKey, {});
         }
     }
 

--- a/packages/frontend/src/utils/wallet.js
+++ b/packages/frontend/src/utils/wallet.js
@@ -202,7 +202,7 @@ export default class Wallet {
         if (accessKeys) {
             const localKey = await this.getLocalAccessKey(accountId, accessKeys);
             const ledgerKey = accessKeys.find((accessKey) => accessKey.meta.type === 'ledger');
-            if (ledgerKey && (!localKey || localKey.access_key.permission !== 'FullAccess')) {
+            if (ledgerKey && (!localKey || localKey.access_key.permission !== 'FullAccess') && !this.isMultisigKeyInfoView(accountId, localKey)) {
                 return PublicKey.from(ledgerKey.public_key);
             }
         }
@@ -658,7 +658,6 @@ export default class Wallet {
                 await store.dispatch(switchAccount({accountId: account.accountId}));
             }
             await account.addKey(ledgerPublicKey);
-            await setKeyMeta(ledgerPublicKey, {});
         }
     }
 

--- a/packages/frontend/src/utils/wallet.js
+++ b/packages/frontend/src/utils/wallet.js
@@ -202,7 +202,8 @@ export default class Wallet {
         if (accessKeys) {
             const localKey = await this.getLocalAccessKey(accountId, accessKeys);
             const ledgerKey = accessKeys.find((accessKey) => accessKey.meta.type === 'ledger');
-            if (ledgerKey && (!localKey || localKey.access_key.permission !== 'FullAccess') && !this.isMultisigKeyInfoView(accountId, localKey)) {
+            const localKeyIsNullOrNonMultisigLAK = !localKey || (localKey.access_key.permission !== 'FullAccess' && !this.isMultisigKeyInfoView(accountId, localKey));
+            if (ledgerKey && localKeyIsNullOrNonMultisigLAK) {
                 return PublicKey.from(ledgerKey.public_key);
             }
         }


### PR DESCRIPTION
This PR adds a batch export route to ledger wallet at `/batch-ledger-export` per [KWLT-24](https://nearinc.atlassian.net/browse/KWLT-24). It supports adding all non ledger accounts (phrase / 2fa) as ledger accounts which allows the user to use the ledger directly from a dapp or via the [wallet-selector](https://github.com/near/wallet-selector)