### PR TITLE
feat: made Sentry lazy

### DIFF
--- a/packages/frontend/src/index.html
+++ b/packages/frontend/src/index.html
@@ -30,6 +30,7 @@
             // react-google-recaptcha Use `recaptcha.net` rather than `google.com` for international recaptcha
             window.recaptchaOptions = { useRecaptchaNet: true, };
         </script>
+        <script src="./utils/sentryLazy.js" crossorigin="anonymous" defer></script>
         <script src="./index.js"></script>
     </body>
 </html>

--- a/packages/frontend/src/index.js
+++ b/packages/frontend/src/index.js
@@ -12,9 +12,6 @@ import Routing from './components/Routing';
 import { RECAPTCHA_ENTERPRISE_SITE_KEY } from './config';
 import createRootReducer from './redux/createReducers';
 import createMiddleware from './redux/middleware';
-import { initSentry } from './utils/sentry';
-
-initSentry();
 
 const history = createBrowserHistory();
 

--- a/packages/frontend/src/redux/actions/staking.js
+++ b/packages/frontend/src/redux/actions/staking.js
@@ -8,9 +8,10 @@ import {
     STAKING_GAS_BASE,
     FARMING_CLAIM_GAS,
     FARMING_CLAIM_YOCTO,
-    LOCKUP_ACCOUNT_ID_SUFFIX
+    LOCKUP_ACCOUNT_ID_SUFFIX,
+    FT_MINIMUM_STORAGE_BALANCE_LARGE
 } from '../../config';
-import { fungibleTokensService, FT_MINIMUM_STORAGE_BALANCE_LARGE } from '../../services/FungibleTokens';
+import { fungibleTokensService } from '../../services/FungibleTokens';
 import { listStakingPools } from '../../services/indexer';
 import StakingFarmContracts from '../../services/StakingFarmContracts';
 import { getLockupAccountId, getLockupMinBalanceForStorage } from '../../utils/account-with-lockup';

--- a/packages/frontend/src/utils/sentryLazy.js
+++ b/packages/frontend/src/utils/sentryLazy.js
@@ -1,0 +1,245 @@
+// Based on https://raw.githubusercontent.com/getsentry/sentry-javascript/master/packages/browser/src/loader.js
+// See more https://docs.sentry.io/platforms/javascript/install/lazy-load-sentry/
+(function(
+  _window,
+  _document,
+  _script,
+  _onerror,
+  _onunhandledrejection,
+  _namespace,
+  _publicKey,
+  _sdkBundleUrl,
+  _config
+) {
+  var lazy = true;
+  var forceLoad = false;
+
+  for (var i = 0; i < document.scripts.length; i++) {
+    if (document.scripts[i].src.indexOf(_publicKey) > -1) {
+      lazy = !(document.scripts[i].getAttribute('data-lazy') === 'no');
+      break;
+    }
+  }
+
+  var injected = false;
+  var onLoadCallbacks = [];
+
+  // Create a namespace and attach function that will store captured exception
+  // Because functions are also objects, we can attach the queue itself straight to it and save some bytes
+  var queue = function(content) {
+    // content.e = error
+    // content.p = promise rejection
+    // content.f = function call the Sentry
+    if (
+      ('e' in content ||
+        'p' in content ||
+        (content.f && content.f.indexOf('capture') > -1) ||
+        (content.f && content.f.indexOf('showReportDialog') > -1)) &&
+      lazy
+    ) {
+      // We only want to lazy inject/load the sdk bundle if
+      // an error or promise rejection occured
+      // OR someone called `capture...` on the SDK
+      injectSdk(onLoadCallbacks);
+    }
+    queue.data.push(content);
+  };
+  queue.data = [];
+
+  function injectSdk(callbacks) {
+    if (injected) {
+      return;
+    }
+    injected = true;
+
+    // Create a `script` tag with provided SDK `url` and attach it just before the first, already existing `script` tag
+    // Scripts that are dynamically created and added to the document are async by default,
+    // they don't block rendering and execute as soon as they download, meaning they could
+    // come out in the wrong order. Because of that we don't need async=1 as GA does.
+    // it was probably(?) a legacy behavior that they left to not modify few years old snippet
+    // https://www.html5rocks.com/en/tutorials/speed/script-loading/
+    var _currentScriptTag = _document.scripts[0];
+    var _newScriptTag = _document.createElement(_script);
+    _newScriptTag.src = _sdkBundleUrl;
+    _newScriptTag.setAttribute('crossorigin', 'anonymous');
+
+    // Once our SDK is loaded
+    _newScriptTag.addEventListener('load', function() {
+      try {
+        // Restore onerror/onunhandledrejection handlers
+        _window[_onerror] = _oldOnerror;
+        _window[_onunhandledrejection] = _oldOnunhandledrejection;
+
+        var SDK = _window[_namespace];
+
+        var oldInit = SDK.init;
+
+        // Configure it using provided DSN and config object
+        SDK.init = function(options) {
+          var target = _config;
+          for (var key in options) {
+            if (Object.prototype.hasOwnProperty.call(options, key)) {
+              target[key] = options[key];
+            }
+          }
+          oldInit(target);
+        };
+
+        sdkLoaded(callbacks, SDK);
+      } catch (o_O) {
+        console.error(o_O);
+      }
+    });
+
+    _currentScriptTag.parentNode.insertBefore(_newScriptTag, _currentScriptTag);
+  }
+
+  function sdkLoaded(callbacks, SDK) {
+    try {
+      var data = queue.data;
+
+      // We have to make sure to call all callbacks first
+      for (var i = 0; i < callbacks.length; i++) {
+        if (typeof callbacks[i] === 'function') {
+          callbacks[i]();
+        }
+      }
+
+      var initAlreadyCalled = false;
+      var __sentry = _window['__SENTRY__'];
+      // If there is a global __SENTRY__ that means that in any of the callbacks init() was already invoked
+      if (!(typeof __sentry === 'undefined') && __sentry.hub && __sentry.hub.getClient()) {
+        initAlreadyCalled = true;
+      }
+
+      // We want to replay all calls to Sentry and also make sure that `init` is called if it wasn't already
+      // We replay all calls to `Sentry.*` now
+      var calledSentry = false;
+      // eslint-disable-next-line no-redeclare
+      for (var i = 0; i < data.length; i++) {
+        if (data[i].f) {
+          calledSentry = true;
+          var call = data[i];
+          if (initAlreadyCalled === false && call.f !== 'init') {
+            // First call always has to be init, this is a conveniece for the user so call to init is optional
+            SDK.init();
+          }
+          initAlreadyCalled = true;
+          SDK[call.f].apply(SDK, call.a);
+        }
+      }
+      if (initAlreadyCalled === false && calledSentry === false) {
+        // Sentry has never been called but we need Sentry.init() so call it
+        SDK.init();
+      }
+
+      // Because we installed the SDK, at this point we have an access to TraceKit's handler,
+      // which can take care of browser differences (eg. missing exception argument in onerror)
+      var tracekitErrorHandler = _window[_onerror];
+      var tracekitUnhandledRejectionHandler = _window[_onunhandledrejection];
+
+      // And now capture all previously caught exceptions
+      // eslint-disable-next-line no-redeclare
+      for (var i = 0; i < data.length; i++) {
+        if ('e' in data[i] && tracekitErrorHandler) {
+          tracekitErrorHandler.apply(_window, data[i].e);
+        } else if ('p' in data[i] && tracekitUnhandledRejectionHandler) {
+          tracekitUnhandledRejectionHandler.apply(_window, [data[i].p]);
+        }
+      }
+    } catch (o_O) {
+      console.error(o_O);
+    }
+  }
+
+  // We make sure we do not overwrite window.Sentry since there could be already integrations in there
+  _window[_namespace] = _window[_namespace] || {};
+
+  _window[_namespace].onLoad = function (callback) {
+    onLoadCallbacks.push(callback);
+    if (lazy && !forceLoad) {
+      return;
+    }
+    injectSdk(onLoadCallbacks);
+  };
+
+  _window[_namespace].forceLoad = function() {
+    forceLoad = true;
+    if (lazy) {
+      setTimeout(function() {
+        injectSdk(onLoadCallbacks);
+      });
+    }
+  };
+
+
+  [
+    'init',
+    'addBreadcrumb',
+    'captureMessage',
+    'captureException',
+    'captureEvent',
+    'configureScope',
+    'withScope',
+    'showReportDialog'
+  ].forEach(function(f) {
+    _window[_namespace][f] = function() {
+      queue({ f: f, a: arguments });
+    };
+  });
+
+  // Store reference to the old `onerror` handler and override it with our own function
+  // that will just push exceptions to the queue and call through old handler if we found one
+  var _oldOnerror = _window[_onerror];
+  _window[_onerror] = function(message, source, lineno, colno, exception) {
+    // Use keys as "data type" to save some characters"
+    queue({
+      e: [].slice.call(arguments)
+    });
+
+    if (_oldOnerror) _oldOnerror.apply(_window, arguments);
+  };
+
+  // Do the same store/queue/call operations for `onunhandledrejection` event
+  var _oldOnunhandledrejection = _window[_onunhandledrejection];
+  _window[_onunhandledrejection] = function(e) {
+    queue({
+      p: 'reason' in e ? e.reason : 'detail' in e && 'reason' in e.detail ? e.detail.reason : e
+    });
+    if (_oldOnunhandledrejection) _oldOnunhandledrejection.apply(_window, arguments);
+  };
+
+  if (!lazy) {
+    setTimeout(function () {
+      injectSdk(onLoadCallbacks);
+    });
+  }
+})(
+  window,
+  document,
+  'script',
+  'onerror',
+  'onunhandledrejection',
+  'Sentry',
+  window.__SENTRY_CLIENT_KEY__ || '', // TODO: need to pass Sentry client key
+  'https://browser.sentry-cdn.com/6.16.1/bundle.min.js',
+  {
+    // eslint-disable-next-line no-process-env
+    dsn: process.env.SENTRY_DSN || '', // TODO: stay the same or import vars from config.js
+    // eslint-disable-next-line no-process-env
+    release: process.env.SENTRY_RELEASE || '',
+    beforeSend(event) {
+        if (event.request.url.includes('recover-with-link')) {
+            delete event.request.url;
+        }
+        return event;
+    },
+    beforeBreadcrumb(breadcrumb) {
+        if (breadcrumb.category === 'navigation' &&
+            (breadcrumb.data.from.includes('recover-with-link') ||
+                breadcrumb.data.to.includes('recover-with-link'))) {
+            delete breadcrumb.data;
+        }
+        return breadcrumb;
+    }
+});


### PR DESCRIPTION
This reverted commit 7b24611caa04513a30e9f1f7a5d688dbecc461f4 highlighted the problem that when main js bundle has an errror than sentry will not initialize and we don't see the problem. This PR moves Sentry to separate script that loads before the main bundle. This is the lightweight sentry lazy skeleton around main sentry SDK. For now this PR isn't completed because I don't have access to Senty web interface to get Setry_client_key. Someone who have access should pass the key into bundle. Then me or someone else could continue work and test this PR.  

Also you could see more details on https://docs.sentry.io/platforms/javascript/install/lazy-load-sentry/