### PR TITLE
feat: linting enhancements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,7 @@ pipeline {
                     }
                     steps {
                         dir("$WORKSPACE/packages/frontend") {
+                            sh 'yarn lint'
                             sh 'yarn install --frozen-lockfile'
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,8 +46,8 @@ pipeline {
                     }
                     steps {
                         dir("$WORKSPACE/packages/frontend") {
-                            sh 'yarn lint'
                             sh 'yarn install --frozen-lockfile'
+                            sh 'yarn lint'
                         }
                     }
                 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -76,8 +76,8 @@
     "fix": "eslint --ext .js --ext .jsx . --fix",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "prepush": "yarn run test",
-    "precommit": "concurrently \"yarn run fix\" \".githooks/format-json\"",
+    "prepush": "concurrently \"yarn run test\" \"yarn lint\"",
+    "precommit": ".githooks/format-json",
     "preinstall": "npx only-allow yarn"
   },
   "browserslist": [


### PR DESCRIPTION
This PR updates the CI configuration to run `yarn lint` before building, ensuring broken builds on branches with eslint rule violations. It also moves the local lint run to `prepush` from `precommit`, avoiding a 10+ second commit time and dropping the `--fix` to make it more difficult to push changes with eslint breaks.