### PR TITLE
feat: render.com migration

### DIFF
--- a/features/features.d.ts
+++ b/features/features.d.ts
@@ -4,5 +4,6 @@
 export type Features = {
     CREATE_USN_CONTRACT: boolean;
 	DONATE_TO_UKRAINE: boolean;
+	RENDER_MIGRATION: boolean;
 	SHOW_MIGRATION_BANNER: boolean;
 };

--- a/features/flags.json
+++ b/features/flags.json
@@ -87,6 +87,50 @@
       "lastEditedAt": "2022-05-10T17:07:20.351Z"
     }
   },
+  "RENDER_MIGRATION": {
+    "createdBy": "Andy Haynes",
+    "createdAt": "2022-06-22T01:17:14.439Z",
+    "development": {
+      "enabled": false,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2022-06-22T01:17:14.438Z"
+    },
+    "testnet": {
+      "enabled": false,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2022-06-22T01:17:14.439Z"
+    },
+    "mainnet": {
+      "enabled": false,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2022-06-22T01:17:14.439Z"
+    },
+    "mainnet_STAGING": {
+      "enabled": false,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2022-06-22T01:17:14.439Z"
+    },
+    "testnet_STAGING": {
+      "enabled": false,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2022-06-22T01:17:14.439Z"
+    },
+    "testnet_NEARORG": {
+      "enabled": false,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2022-06-22T01:17:14.439Z"
+    },
+    "mainnet_NEARORG": {
+      "enabled": false,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2022-06-22T01:17:14.439Z"
+    },
+    "mainnet_STAGING_NEARORG": {
+      "enabled": false,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2022-06-22T01:17:14.439Z"
+    }
+  },
   "SHOW_MIGRATION_BANNER": {
     "createdBy": "gutsyphilip",
     "createdAt": "2022-05-25T01:11:55.121Z",

--- a/packages/frontend/netlify.toml
+++ b/packages/frontend/netlify.toml
@@ -6,7 +6,6 @@
 [build.environment]
     DISABLE_PHONE_RECOVERY = "yes"
     REACT_APP_NETWORK_ID = "default"
-    REACT_APP_ACCOUNT_HELPER_URL = "https://helper.mainnet.near.org"
     REACT_APP_NODE_URL = "https://rpc.mainnet.near.org"
     REACT_APP_ACCESS_KEY_FUNDING_AMOUNT = "250000000000000000000000"
     NEW_ACCOUNT_AMOUNT = "500000001000000000000000000"

--- a/packages/frontend/src/config/environmentDefaults/development.js
+++ b/packages/frontend/src/config/environmentDefaults/development.js
@@ -1,8 +1,10 @@
 import * as nearApiJs from 'near-api-js';
 import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
+import { RENDER_MIGRATION } from '../../../../../features';
+
 export default {
-    ACCOUNT_HELPER_URL:'https://near-contract-helper.onrender.com',
+    ACCOUNT_HELPER_URL: RENDER_MIGRATION ? 'https://testnet-api.kitwallet.app' : 'https://near-contract-helper.onrender.com',
     ACCOUNT_ID_SUFFIX: 'testnet',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     ALLOW_2FA_ENABLE_HASHES: [

--- a/packages/frontend/src/config/environmentDefaults/mainnet.js
+++ b/packages/frontend/src/config/environmentDefaults/mainnet.js
@@ -1,8 +1,10 @@
 import * as nearApiJs from 'near-api-js';
 import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
+import { RENDER_MIGRATION } from '../../../../../features';
+
 export default {
-  ACCOUNT_HELPER_URL: 'https://helper.mainnet.near.org',
+  ACCOUNT_HELPER_URL: RENDER_MIGRATION ? 'https://api.kitwallet.app' : 'https://helper.mainnet.near.org',
   ACCOUNT_ID_SUFFIX: 'near',
   ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
   ALLOW_2FA_ENABLE_HASHES: [

--- a/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.js
+++ b/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.js
@@ -1,8 +1,10 @@
 import * as nearApiJs from 'near-api-js';
 import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
+import { RENDER_MIGRATION } from '../../../../../features';
+
 export default {
-    ACCOUNT_HELPER_URL: 'https://helper.mainnet.near.org',
+    ACCOUNT_HELPER_URL: RENDER_MIGRATION ? 'https://staging-api.kitwallet.app' : 'https://helper.mainnet.near.org',
     ACCOUNT_ID_SUFFIX: 'near',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     ALLOW_2FA_ENABLE_HASHES: [

--- a/packages/frontend/src/config/environmentDefaults/testnet.js
+++ b/packages/frontend/src/config/environmentDefaults/testnet.js
@@ -1,8 +1,10 @@
 import * as nearApiJs from 'near-api-js';
 import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
+import { RENDER_MIGRATION } from '../../../../../features';
+
 export default {
-    ACCOUNT_HELPER_URL: 'https://near-contract-helper.onrender.com',
+    ACCOUNT_HELPER_URL: RENDER_MIGRATION ? 'https://testnet-api.kitwallet.app' : 'https://near-contract-helper.onrender.com',
     ACCOUNT_ID_SUFFIX: 'testnet',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     ALLOW_2FA_ENABLE_HASHES: [

--- a/packages/frontend/src/config/environmentDefaults/testnet_STAGING.js
+++ b/packages/frontend/src/config/environmentDefaults/testnet_STAGING.js
@@ -1,8 +1,10 @@
 import * as nearApiJs from 'near-api-js';
 import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
+import { RENDER_MIGRATION } from '../../../../../features';
+
 export default {
-    ACCOUNT_HELPER_URL: 'https://near-contract-helper.onrender.com',
+    ACCOUNT_HELPER_URL: RENDER_MIGRATION ? 'https://preflight-api.kitwallet.app' : 'https://near-contract-helper.onrender.com',
     ACCOUNT_ID_SUFFIX: 'testnet',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     ALLOW_2FA_ENABLE_HASHES: [


### PR DESCRIPTION
This PR adds a new `RENDER_MIGRATION` feature flag which will update the API URL for contract helper to use the endpoints deployed to AWS. Since the `ACCOUNT_HELPER_URL` environment variable still needs to be overridden for local development, part of the rollout for this functionality requires that the environment variable is removed from the `near-wallet` build environments in render.com (testnet) and Netlify (mainnet). These variables are vestigial since the introduction of defined per-environment configurations and can be removed safely.