### PR TITLE
feat: enable RENDER_MIGRATION in testnet environments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,7 +160,6 @@ pipeline {
                     }
                     environment {
                         NEAR_WALLET_ENV = 'testnet_STAGING'
-                        REACT_APP_ACCOUNT_HELPER_URL = 'https://preflight-api.kitwallet.app'
                     }
                     steps {
                         dir("$WORKSPACE/packages/frontend") {
@@ -176,7 +175,6 @@ pipeline {
                     }
                     environment {
                         NEAR_WALLET_ENV = 'testnet'
-                        REACT_APP_ACCOUNT_HELPER_URL = 'https://testnet-api.kitwallet.app'
                     }
                     steps {
                         dir("$WORKSPACE/packages/frontend") {

--- a/features/flags.json
+++ b/features/flags.json
@@ -91,14 +91,14 @@
     "createdBy": "Andy Haynes",
     "createdAt": "2022-06-22T01:17:14.439Z",
     "development": {
-      "enabled": false,
+      "enabled": true,
       "lastEditedBy": "Andy Haynes",
-      "lastEditedAt": "2022-06-22T01:17:14.438Z"
+      "lastEditedAt": "2022-06-29T18:19:13.375Z"
     },
     "testnet": {
-      "enabled": false,
+      "enabled": true,
       "lastEditedBy": "Andy Haynes",
-      "lastEditedAt": "2022-06-22T01:17:14.439Z"
+      "lastEditedAt": "2022-06-29T18:19:13.377Z"
     },
     "mainnet": {
       "enabled": false,
@@ -111,14 +111,14 @@
       "lastEditedAt": "2022-06-22T01:17:14.439Z"
     },
     "testnet_STAGING": {
-      "enabled": false,
+      "enabled": true,
       "lastEditedBy": "Andy Haynes",
-      "lastEditedAt": "2022-06-22T01:17:14.439Z"
+      "lastEditedAt": "2022-06-29T18:19:13.377Z"
     },
     "testnet_NEARORG": {
-      "enabled": false,
+      "enabled": true,
       "lastEditedBy": "Andy Haynes",
-      "lastEditedAt": "2022-06-22T01:17:14.439Z"
+      "lastEditedAt": "2022-06-29T18:19:13.377Z"
     },
     "mainnet_NEARORG": {
       "enabled": false,


### PR DESCRIPTION
Prior to merging, the `REACT_APP_ACCOUNT_HELPER_URL` environment variable configured in render.com (testnet) must be removed.