### PR TITLE
fix: MYNW-72 Update ref.indexer endpoints

### DIFF
--- a/packages/frontend/src/config/environmentDefaults/development.js
+++ b/packages/frontend/src/config/environmentDefaults/development.js
@@ -50,7 +50,7 @@ export default {
     NEAR_TOKEN_ID: 'wrap.testnet',
     FARMING_CLAIM_GAS: parseNearAmount('0.00000000015'),
     FARMING_CLAIM_YOCTO: '1',
-    REF_FINANCE_API_ENDPOINT: 'https://dev-indexer.ref-finance.com/',
+    REF_FINANCE_API_ENDPOINT: 'https://testnet-indexer.ref-finance.com/',
     REF_FINANCE_CONTRACT: 'ref-finance-101.testnet',
     USN_CONTRACT: 'usdn.testnet'
 };

--- a/packages/frontend/src/config/environmentDefaults/mainnet.js
+++ b/packages/frontend/src/config/environmentDefaults/mainnet.js
@@ -56,7 +56,7 @@ export default {
     NEAR_TOKEN_ID: 'wrap.near',
     FARMING_CLAIM_GAS: parseNearAmount('0.00000000015'),
     FARMING_CLAIM_YOCTO: '1',
-    REF_FINANCE_API_ENDPOINT: 'https://indexer.ref-finance.net',
+    REF_FINANCE_API_ENDPOINT: 'https://indexer.ref.finance',
     REF_FINANCE_CONTRACT: 'v2.ref-finance.near',
     USN_CONTRACT: 'usn'
 };

--- a/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.js
+++ b/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.js
@@ -56,7 +56,7 @@ export default {
     NEAR_TOKEN_ID: 'wrap.near',
     FARMING_CLAIM_GAS: parseNearAmount('0.00000000015'),
     FARMING_CLAIM_YOCTO: '1',
-    REF_FINANCE_API_ENDPOINT: 'https://indexer.ref-finance.net',
+    REF_FINANCE_API_ENDPOINT: 'https://indexer.ref.finance',
     REF_FINANCE_CONTRACT: 'v2.ref-finance.near',
     USN_CONTRACT: 'usn'
 };

--- a/packages/frontend/src/config/environmentDefaults/testnet.js
+++ b/packages/frontend/src/config/environmentDefaults/testnet.js
@@ -50,7 +50,7 @@ export default {
     NEAR_TOKEN_ID: 'wrap.testnet',
     FARMING_CLAIM_GAS: parseNearAmount('0.00000000015'),
     FARMING_CLAIM_YOCTO: '1',
-    REF_FINANCE_API_ENDPOINT: 'https://dev-indexer.ref-finance.com/',
+    REF_FINANCE_API_ENDPOINT: 'https://testnet-indexer.ref-finance.com/',
     REF_FINANCE_CONTRACT: 'ref-finance-101.testnet',
     USN_CONTRACT: 'usdn.testnet'
 };

--- a/packages/frontend/src/config/environmentDefaults/testnet_STAGING.js
+++ b/packages/frontend/src/config/environmentDefaults/testnet_STAGING.js
@@ -50,7 +50,7 @@ export default {
     NEAR_TOKEN_ID: 'wrap.testnet',
     FARMING_CLAIM_GAS: parseNearAmount('0.00000000015'),
     FARMING_CLAIM_YOCTO: '1',
-    REF_FINANCE_API_ENDPOINT: 'https://dev-indexer.ref-finance.com/',
+    REF_FINANCE_API_ENDPOINT: 'https://testnet-indexer.ref-finance.com/',
     REF_FINANCE_CONTRACT: 'ref-finance-101.testnet',
     USN_CONTRACT: 'usdn.testnet'
 };


### PR DESCRIPTION
Current REF_FINANCE_API_ENDPOINT is deprecated and doesnt work now.
This problem affected token exchange rates on wallet view.
![image](https://user-images.githubusercontent.com/4532214/178513988-e6d458bb-92ba-494c-a584-b16245e4a670.png)
![telegram-cloud-photo-size-2-5361976587421072708-y](https://user-images.githubusercontent.com/4532214/178514267-14544c5f-c8e3-4a9c-9fc1-644f1257c02c.jpg)



This PR is updating mainnet/testnet endpoint URL for /list-token-price method according to information getting from directly messaging with guys from Ref Finance.

OLD: [https://indexer.ref-finance/list-token-price](https://indexer.ref-finance/list-token-price)
NEW: [https://indexer.ref.finance/list-token-price](https://indexer.ref.finance/list-token-price)