### PR TITLE
fix: remove shuffle from in Purchase NEAR section in top up page

### DIFF
--- a/packages/frontend/src/components/buy/BuyNear.js
+++ b/packages/frontend/src/components/buy/BuyNear.js
@@ -1,4 +1,3 @@
-import { shuffle } from 'lodash';
 import React, { useState, useEffect, useMemo } from 'react';
 import { Translate } from 'react-localize-redux';
 import { useSelector } from 'react-redux';
@@ -224,7 +223,7 @@ export function BuyNear({ match, location, history }) {
                 <FundingCard
                     title='buyNear.nearPurchaseTitle'
                     subTitle='buyNear.nearPurchaseSubTitle'
-                    actions={shuffle([PayMethods.moonPay, PayMethods.nearPay, PayMethods.utorg, PayMethods.ftx])}
+                    actions={[PayMethods.nearPay, PayMethods.moonPay, PayMethods.utorg, PayMethods.ftx]}
                 />
                 <FundingCard
                     title='buyNear.bridgeTokens'


### PR DESCRIPTION
Removed shuffling and updated order in Purchase NEAR section 