### PR TITLE
fix: changed link in deposit near banner from /recieve-money to /buy

### DIFF
--- a/packages/frontend/src/components/wallet/DepositNearBanner.js
+++ b/packages/frontend/src/components/wallet/DepositNearBanner.js
@@ -53,7 +53,7 @@ export default () => {
     return (
         <StyledContainer className='deposit-near-banner'>
             <div>
-                <div onClick={() => dispatch(push({ pathname: '/receive-money' }))} >
+                <div onClick={() => dispatch(push({ pathname: '/buy' }))} >
                     <NearLogoAndPlusIcon />
                     <div>
                         <div className='banner-title'><Translate id='wallet.depositNear.title' /></div>


### PR DESCRIPTION
Changed banner address "Deposit Near" from `/recieve-money` to `/buy`