### PR TITLE
Fix (Sign TX): Include error in URL for DApp when TX is rejected because of error

### DIFF
--- a/packages/frontend/src/redux/slices/sign/index.js
+++ b/packages/frontend/src/redux/slices/sign/index.js
@@ -239,6 +239,21 @@ export const selectSignStatus = createSelector(
     (sign) => sign.status
 );
 
+export const selectSignError = createSelector(
+    [selectSignSlice],
+    (sign) => sign.error
+);
+
+export const selectSignErrorName = createSelector(
+    [selectSignError],
+    (error) => error?.name
+);
+
+export const selectSignErrorMessage = createSelector(
+    [selectSignError],
+    (error) => error?.message
+);
+
 export const selectSignGasUsed = createSelector(
     [selectSignSlice],
     (sign) => sign.gasUsed || new BN('0')

--- a/packages/frontend/src/routes/SignWrapper.js
+++ b/packages/frontend/src/routes/SignWrapper.js
@@ -20,6 +20,8 @@ import {
     selectSignStatus,
     selectSignCallbackUrl,
     selectSignMeta,
+    selectSignErrorName,
+    selectSignErrorMessage,
     selectSignTransactionHashes,
     selectSignTransactions,
     selectSignTransactionsBatchIsValid
@@ -43,6 +45,8 @@ export function SignWrapper() {
     const signStatus = useSelector(selectSignStatus);
     const signCallbackUrl = useSelector(selectSignCallbackUrl);
     const signMeta = useSelector(selectSignMeta);
+    const signErrorName = useSelector(selectSignErrorName);
+    const signErrorMessage = useSelector(selectSignErrorMessage);
     const transactionHashes = useSelector(selectSignTransactionHashes);
     const availableAccounts = useSelector(selectAvailableAccounts);
     const availableAccountsIsLoading = useSelector(selectAvailableAccountsIsLoading);
@@ -106,20 +110,19 @@ export function SignWrapper() {
     const handleCancelTransaction = async () => {
         Mixpanel.track('SIGN Deny the transaction');
         if (signCallbackUrl && isValidCallbackUrl) {
-            if (signStatus?.success !== false) {
+            if (signStatus !== SIGN_STATUS.ERROR) {
                 window.location.href = addQueryParams(signCallbackUrl, {
                     signMeta,
                     errorCode: encodeURIComponent('userRejected'),
                     errorMessage: encodeURIComponent('User rejected transaction')
                 });
-                return;
+            } else {
+                window.location.href = addQueryParams(signCallbackUrl, {
+                    signMeta,
+                    errorCode: encodeURIComponent(signErrorName) || encodeURIComponent('unknownError'),
+                    errorMessage: encodeURIComponent(signErrorMessage.substring(0, 100)) || encodeURIComponent('Unknown error')
+                });
             }
-            window.location.href = addQueryParams(signCallbackUrl, {
-                signMeta,
-                errorCode: encodeURIComponent(signStatus?.errorType) || encodeURIComponent('unknownError'),
-                errorMessage: encodeURIComponent(signStatus?.errorMessage?.substring(0, 100)) || encodeURIComponent('Unknown error')
-            });
-            return;
         } else {
             dispatch(redirectTo('/'));
         }


### PR DESCRIPTION
Include `errorCode` and `errorMessage` as params in `signCallbackUrl` whenever a user rejects a sign transaction on the wallet side because of an error