### PR TITLE
Caching coingecko ids

### DIFF
--- a/packages/frontend/src/redux/slices/tokenFiatValues/index.js
+++ b/packages/frontend/src/redux/slices/tokenFiatValues/index.js
@@ -24,7 +24,7 @@ const fetchTokenFiatValues = createAsyncThunk(
     `${SLICE_NAME}/fetchTokenFiatValues`,
     async (_, {dispatch, getState}) => {
         const ownedTokens = selectContractsSymbols(getState());
-        return Promise.all([
+        return Promise.allSettled([
             dispatch(fetchCoinGeckoFiatValues([...ownedTokens, 'near'])),
             dispatch(fetchRefFinanceFiatValues()),
         ]);

--- a/packages/frontend/src/utils/fiatValueManager.js
+++ b/packages/frontend/src/utils/fiatValueManager.js
@@ -110,13 +110,13 @@ export default class FiatValueManager {
     };
 
     async fetchCoinGeckoPrices(contractNames = ['near', 'usn']) {
-        const coinGeckoIds = await this.fetchCoinGeckoIds(contractNames);
-
-        while (coinGeckoIds.includes(undefined)) {
-            const indexToClear = coinGeckoIds.indexOf(undefined);
-            this.contractNameToCoinGeckoId.clear(contractNames[indexToClear]);
-            coinGeckoIds.splice(indexToClear, 1);
-        }
+        let coinGeckoIds = await this.fetchCoinGeckoIds(contractNames);
+        coinGeckoIds.forEach((id, ndx) => {
+            if (!id) {
+                this.contractNameToCoinGeckoId.clear(contractNames[ndx]);
+            }
+        })
+        coinGeckoIds = coinGeckoIds.filter((id) => !!id);
         const byTokenName = {};
         const prices = await this.coinGeckoFiatValueDataLoader.loadMany(coinGeckoIds);
         contractNames.forEach((tokenName, ndx) => byTokenName[tokenName] = prices[ndx]);

--- a/packages/frontend/src/utils/fiatValueManager.js
+++ b/packages/frontend/src/utils/fiatValueManager.js
@@ -115,7 +115,7 @@ export default class FiatValueManager {
             if (!id) {
                 this.contractNameToCoinGeckoId.clear(contractNames[ndx]);
             }
-        })
+        });
         coinGeckoIds = coinGeckoIds.filter((id) => !!id);
         const byTokenName = {};
         const prices = await this.coinGeckoFiatValueDataLoader.loadMany(coinGeckoIds);

--- a/packages/frontend/src/utils/fiatValueManager.js
+++ b/packages/frontend/src/utils/fiatValueManager.js
@@ -104,22 +104,22 @@ export default class FiatValueManager {
         );
     };
 
-    async fetchCoinGeckoIds(contractNames = ['near', 'usn']) {
+    async fetchCoinGeckoIds(contractSymbols = ['near', 'usn']) {
         // given list of contract names, return list of coingecko IDs
-        return this.contractNameToCoinGeckoId.loadMany(contractNames);
+        return this.contractNameToCoinGeckoId.loadMany(contractSymbols);
     };
 
-    async fetchCoinGeckoPrices(contractNames = ['near', 'usn']) {
-        let coinGeckoIds = await this.fetchCoinGeckoIds(contractNames);
+    async fetchCoinGeckoPrices(contractSymbols = ['near', 'usn']) {
+        let coinGeckoIds = await this.fetchCoinGeckoIds(contractSymbols);
         coinGeckoIds.forEach((id, ndx) => {
             if (!id) {
-                this.contractNameToCoinGeckoId.clear(contractNames[ndx]);
+                this.contractNameToCoinGeckoId.clear(contractSymbols[ndx]);
             }
         });
         coinGeckoIds = coinGeckoIds.filter((id) => !!id);
         const byTokenName = {};
         const prices = await this.coinGeckoFiatValueDataLoader.loadMany(coinGeckoIds);
-        contractNames.forEach((tokenName, ndx) => byTokenName[tokenName] = prices[ndx]);
+        contractSymbols.forEach((tokenName, ndx) => byTokenName[tokenName] = prices[ndx]);
         return byTokenName;
     };
 

--- a/packages/frontend/src/utils/fiatValueManager.js
+++ b/packages/frontend/src/utils/fiatValueManager.js
@@ -76,7 +76,7 @@ export default class FiatValueManager {
                     // DataLoader must be constructed with a function which accepts 
                     // Array<key> and returns Promise<Array<value>> of the same length
                     // as the Array of keys
-                    return Promise.resolve(Array(tokenSymbols.length).fill({}));
+                    return Promise.resolve(Array(tokenIds.length).fill({}));
                 }
             },
             {


### PR DESCRIPTION
Typically, an account will load all their fungible token contract names, and then use that to hit coingecko's search API for each contract name to get their corresponding ID. This will be done only on page load, and because of this it will not hit the rate limit in most cases.

known issues/edge cases: 
1) user has more than 50 different fungible tokens -> coingecko will throttle us
2) user refreshes enough to surpass the 50 requests per minute rate limit

in this case, the next fetch (after 30 second interval) will try to fetch only the missed tokens for their ids, and will do so until the rate limit "refreshes" and all token: id pairs are loaded into the cache.