### PR TITLE
fix(ci): don't run PR actions on PRs targeting stable

### DIFF
--- a/.github/workflows/bundle-and-deploy.yml
+++ b/.github/workflows/bundle-and-deploy.yml
@@ -3,6 +3,10 @@ name: Build and Deploy Frontend
 on:
   workflow_call:
     inputs:
+      deploy_preview:
+        default: true
+        required: false
+        type: boolean
       environment:
         required: true
         type: string
@@ -37,7 +41,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DEPLOYMENT_ROLE }}
           role-skip-session-tagging: true
           role-duration-seconds: 900
-      - if: ${{ github.event_name == 'pull_request' }}
+      - if: ${{ inputs.deploy_preview && github.event_name == 'pull_request' }}
         run: aws s3 sync dist/${{ inputs.environment }} s3://${{ secrets.S3_BUCKET }}/${{ github.event.pull_request.number }} --delete
-      - if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/stable') }}
+      - if: ${{ inputs.deploy_preview && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/stable') }}
         run: aws s3 sync dist/${{ inputs.environment }} s3://${{ secrets.S3_BUCKET }} --delete

--- a/.github/workflows/bundle-and-deploy.yml
+++ b/.github/workflows/bundle-and-deploy.yml
@@ -3,7 +3,7 @@ name: Build and Deploy Frontend
 on:
   workflow_call:
     inputs:
-      deploy_preview:
+      deploy:
         default: true
         required: false
         type: boolean
@@ -32,7 +32,8 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn test
-      - run: yarn bundle --outDir=dist/${{ inputs.environment }}
+      - if: inputs.deploy
+        run: yarn bundle --outDir=dist/${{ inputs.environment }}
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -41,7 +42,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DEPLOYMENT_ROLE }}
           role-skip-session-tagging: true
           role-duration-seconds: 900
-      - if: ${{ inputs.deploy_preview && github.event_name == 'pull_request' }}
+      - if: ${{ inputs.deploy && github.event_name == 'pull_request' }}
         run: aws s3 sync dist/${{ inputs.environment }} s3://${{ secrets.S3_BUCKET }}/${{ github.event.pull_request.number }} --delete
-      - if: ${{ inputs.deploy_preview && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/stable') }}
+      - if: ${{ inputs.deploy && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/stable') }}
         run: aws s3 sync dist/${{ inputs.environment }} s3://${{ secrets.S3_BUCKET }} --delete

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,6 +9,7 @@ concurrency:
 
 jobs:
   testnet-bundle-preview:
+    if: github.base_ref != 'stable'
     uses: ./.github/workflows/bundle-and-deploy.yml
     with:
       environment: testnet-preview
@@ -16,8 +17,18 @@ jobs:
     secrets: inherit
 
   mainnet-bundle-preview:
+    if: github.base_ref != 'stable'
     uses: ./.github/workflows/bundle-and-deploy.yml
     with:
       environment: mainnet-preview
       near_wallet_env: mainnet_STAGING
+    secrets: inherit
+
+  validate-release-pr:
+    if: github.base_ref == 'stable'
+    uses: ./.github/workflows/bundle-and-deploy.yml
+    with:
+      deploy_preview: false
+      environment: mainnet
+      near_wallet_env: mainnet
     secrets: inherit

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,8 @@ name: PR Preview
 
 on:
   pull_request:
+    branches-ignore:
+      - stable
 
 concurrency:
   group: ${{ github.event.pull_request.number }}
@@ -9,7 +11,6 @@ concurrency:
 
 jobs:
   testnet-bundle-preview:
-    if: github.base_ref != 'stable'
     uses: ./.github/workflows/bundle-and-deploy.yml
     with:
       environment: testnet-preview
@@ -17,18 +18,8 @@ jobs:
     secrets: inherit
 
   mainnet-bundle-preview:
-    if: github.base_ref != 'stable'
     uses: ./.github/workflows/bundle-and-deploy.yml
     with:
       environment: mainnet-preview
       near_wallet_env: mainnet_STAGING
-    secrets: inherit
-
-  validate-release-pr:
-    if: github.base_ref == 'stable'
-    uses: ./.github/workflows/bundle-and-deploy.yml
-    with:
-      deploy_preview: false
-      environment: mainnet
-      near_wallet_env: mainnet
     secrets: inherit

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,19 @@
+name: PR Preview
+
+on:
+  pull_request:
+    branches:
+      - stable
+
+concurrency:
+  group: 'release'
+  cancel-in-progress: true
+
+jobs:
+  pre-release-check:
+    uses: ./.github/workflows/bundle-and-deploy.yml
+    with:
+      deploy: false
+      environment: mainnet
+      near_wallet_env: mainnet
+    secrets: inherit


### PR DESCRIPTION
This PR updates the PR actions to not deploy preview bundles for release PRs targeting `stable`. The PR should still test and bundle the code but not deploy to any preview environments.