### PR TITLE
Mynw 108 fix risk scoring bug

### DIFF
--- a/packages/frontend/src/components/send/components/InputAccountId.js
+++ b/packages/frontend/src/components/send/components/InputAccountId.js
@@ -128,7 +128,7 @@ class InputAccountId extends Component {
     }
 
     handleChangeAccountId = ({ userValue, el }) => {
-        const { handleChange, localAlert, clearLocalAlert } = this.props;
+        const { handleChange, localAlert, clearLocalAlert, setIsImplicitAccount } = this.props;
         const { wrongChar } = this.state;
         const pattern = /[^a-zA-Z0-9._-]/;
 
@@ -147,6 +147,7 @@ class InputAccountId extends Component {
             this.setState({ wrongChar: false });
         }
 
+        setIsImplicitAccount(false);
         handleChange(accountId);
 
         localAlert && clearLocalAlert();
@@ -160,7 +161,7 @@ class InputAccountId extends Component {
     isImplicitAccount = (accountId) => accountId.length === 64 && !accountId.includes('.')
 
     handleCheckAvailability = async (accountId) => {
-        const { checkAvailability, clearLocalAlert } = this.props;
+        const { checkAvailability, clearLocalAlert, setIsImplicitAccount } = this.props;
 
         if (!accountId) {
             return false;
@@ -172,6 +173,7 @@ class InputAccountId extends Component {
             if (this.isImplicitAccount(accountId) && e.toString().includes('does not exist while viewing')) {
                 console.warn(`${accountId} does not exist. Assuming this is an implicit Account ID.`);
                 clearLocalAlert();
+                setIsImplicitAccount(true);
                 return;
             }
         }

--- a/packages/frontend/src/components/send/components/ReceiverInputWithLabel.js
+++ b/packages/frontend/src/components/send/components/ReceiverInputWithLabel.js
@@ -48,6 +48,7 @@ const ReceiverInputWithLabel = ({
     receiverId,
     handleChangeReceiverId,
     checkAccountAvailable,
+    setIsImplicitAccount,
     localAlert,
     clearLocalAlert,
     autoFocus,
@@ -66,6 +67,7 @@ const ReceiverInputWithLabel = ({
                 handleChange={handleChangeReceiverId}
                 ReceiverInputWithLabel={ReceiverInputWithLabel}
                 checkAvailability={checkAccountAvailable}
+                setIsImplicitAccount={setIsImplicitAccount}
                 localAlert={localAlert}
                 clearLocalAlert={clearLocalAlert}
                 onFocus={() => setInputHasFocus(true)}

--- a/packages/frontend/src/components/send/components/RiscScoringForm.js
+++ b/packages/frontend/src/components/send/components/RiscScoringForm.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { HAPI_RISK_SCORING } from '../../../../../../features';
 import iconWarning from '../../../images/icon-warning.svg';
+import { Mixpanel } from '../../../mixpanel/index';
 import { checkAddress } from '../../../services/RiscScoring';
 import Checkbox from '../../common/Checkbox';
 
@@ -72,6 +73,11 @@ export function useRiskScoringCheck(accountId) {
                 const hapiStatus = await checkAddress({ accountId });
                 if (isActive && hapiStatus && hapiStatus[0] !== 'None') {
                     setIsRSWarned(true);
+                    Mixpanel.track('HAPI scammed address', {
+                        accountId,
+                        statusMsg: hapiStatus[0],
+                        statusCode: hapiStatus[1]
+                    });
                 }
             } catch (e) {
                 // continue work

--- a/packages/frontend/src/components/send/components/RiscScoringForm.js
+++ b/packages/frontend/src/components/send/components/RiscScoringForm.js
@@ -49,20 +49,32 @@ const RSConsent = styled.div`
     }
 `;
 
-export function useRiskScoringCheck (accountId) {
+export function useRiskScoringCheck(accountId) {
     const [isRSWarned, setIsRSWarned] = useState(false);
     const [isRSIgnored, setIsRSIgnored] = useState(false);
+    // track RiskScoring execution status, useful for loaders
+    // or indeterminate state
+    const [isRSFinished, setIsRSFinished] = useState(true);
 
     useEffect(() => {
+        setIsRSWarned(false);
+        setIsRSIgnored(false);
+
         let isActive = true;
+
         async function checkAccountWithHapi() {
             try {
-                const hapiStatus = await checkAddress({accountId});
-                if (isActive && hapiStatus && hapiStatus[0] !== 'None') { 
+                setIsRSFinished(false);
+                const hapiStatus = await checkAddress({ accountId });
+                if (isActive && hapiStatus && hapiStatus[0] !== 'None') {
                     setIsRSWarned(true);
                 }
             } catch (e) {
                 // continue work
+            } finally {
+                if (isActive) {
+                    setIsRSFinished(true);
+                }
             }
         }
 
@@ -77,11 +89,11 @@ export function useRiskScoringCheck (accountId) {
         };
     }, [accountId]);
 
-    return { isRSWarned, isRSIgnored, setIsRSIgnored };
+    return { isRSWarned, isRSIgnored, isRSFinished, setIsRSIgnored };
 }
 
 
-const RiscScoringForm = ({ setIsRSIgnored }) => {
+const RiscScoringForm = ({ setIsRSIgnored, isIgnored }) => {
     const onCheckboxChange = useCallback((e) => {
         setIsRSIgnored(e.target.checked);
     }, []);
@@ -89,14 +101,14 @@ const RiscScoringForm = ({ setIsRSIgnored }) => {
     return (
         <RSContainer className="risk-scoring-warning">
             <RSWarning>
-                <img src={iconWarning} alt="Warning"/>
+                <img src={iconWarning} alt="Warning" />
                 <div>
                     <Translate id='riscScoring.scamWarning' />
                 </div>
             </RSWarning>
             <RSConsent>
                 <label>
-                    <input type="checkbox" onChange={onCheckboxChange}/>
+                    <input type="checkbox" checked={isIgnored} onChange={onCheckboxChange} />
                     <Translate id='riscScoring.checkbox' />
                 </label>
             </RSConsent>

--- a/packages/frontend/src/components/send/components/RiscScoringForm.js
+++ b/packages/frontend/src/components/send/components/RiscScoringForm.js
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { HAPI_RISK_SCORING } from '../../../../../../features';
 import iconWarning from '../../../images/icon-warning.svg';
 import { checkAddress } from '../../../services/RiscScoring';
+import Checkbox from '../../common/Checkbox';
 
 const RSContainer = styled.div`
     margin-top: 20px;
@@ -25,11 +26,14 @@ const RSWarning = styled.div`
 `;
 
 const RSConsent = styled.div`
-    margin-top: 38px;
+    margin-top: 20px;
     line-height: 20px;
-    color: #000000;
+    color: #026bdd;
+    background-color: #f5faff;
+    border-radius: 4px;
     display: flex;
-    padding-left: 26px;
+    justify-content: center;
+    padding: 20px;
 
     & label {
       user-select: none;
@@ -108,7 +112,7 @@ const RiscScoringForm = ({ setIsRSIgnored, isIgnored }) => {
             </RSWarning>
             <RSConsent>
                 <label>
-                    <input type="checkbox" checked={isIgnored} onChange={onCheckboxChange} />
+                    <Checkbox checked={isIgnored} onChange={onCheckboxChange} />
                     <Translate id='riscScoring.checkbox' />
                 </label>
             </RSConsent>

--- a/packages/frontend/src/components/send/components/views/EnterReceiver.js
+++ b/packages/frontend/src/components/send/components/views/EnterReceiver.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Translate } from 'react-localize-redux';
 import { Textfit } from 'react-textfit';
 import styled from 'styled-components';
@@ -38,12 +38,14 @@ const EnterReceiver = ({
     onClickContinue,
     isMobile
 }) => {
+    const [isImplicitAccount, setIsImplicitAccount] = useState(false);
     const hasAccountValidationError = localAlert && localAlert.show && !localAlert.success;
     const validAccountId = hasAccountValidationError ? null : receiverId;
 
     // localAlert comes as {} object when no result is available
     // or as { show: false, success: false, message: 'ACTION_TYPE.pending' }
-    const isEmptyAlert = !localAlert || localAlert.show === undefined || localAlert.show === false;
+    let isEmptyAlert = !localAlert || localAlert.show === undefined || localAlert.show === false;
+    isEmptyAlert = isImplicitAccount ? false : isEmptyAlert;
 
     const { isRSWarned, isRSIgnored, setIsRSIgnored, isRSFinished } = useRiskScoringCheck(validAccountId);
     const hasRiskScoreValidationError = isRSWarned && !isRSIgnored;
@@ -78,6 +80,7 @@ const EnterReceiver = ({
                 receiverId={receiverId}
                 handleChangeReceiverId={handleChangeReceiverId}
                 checkAccountAvailable={checkAccountAvailable}
+                setIsImplicitAccount={setIsImplicitAccount}
                 localAlert={localAlert}
                 clearLocalAlert={clearLocalAlert}
                 autoFocus={!isMobile}


### PR DESCRIPTION
This PR:
* Fixes bug with disabled button on `Send Screen` on validated account
* Makes `Send Screen` waits on risk-score result before allowing to proceed (reduces flickering)
* Adds state reset for risk-score hook between checks for different accounts
* Fixes bug with checkbox losing state between checks

Closes #2848 