### PR TITLE
feat: Enable `RENDER_MIGRATION` in `mainnet` environments

### DIFF
--- a/features/flags.json
+++ b/features/flags.json
@@ -145,9 +145,9 @@
       "lastEditedAt": "2022-06-29T18:19:13.377Z"
     },
     "mainnet": {
-      "enabled": false,
-      "lastEditedBy": "Andy Haynes",
-      "lastEditedAt": "2022-06-22T01:17:14.439Z"
+      "enabled": true,
+      "lastEditedBy": "Morgan McCauley",
+      "lastEditedAt": "2022-07-26T22:40:11.936Z"
     },
     "mainnet_STAGING": {
       "enabled": true,
@@ -165,9 +165,9 @@
       "lastEditedAt": "2022-06-29T18:19:13.377Z"
     },
     "mainnet_NEARORG": {
-      "enabled": false,
-      "lastEditedBy": "Andy Haynes",
-      "lastEditedAt": "2022-06-22T01:17:14.439Z"
+      "enabled": true,
+      "lastEditedBy": "Morgan McCauley",
+      "lastEditedAt": "2022-07-26T22:40:11.936Z"
     },
     "mainnet_STAGING_NEARORG": {
       "enabled": true,


### PR DESCRIPTION
Enables `RENDER_MIGRATION` in both `mainnet` and `mainnet_NEARORG` making wallet.near.org use the contract-helper service in AWS rather than Render.