### PR TITLE
feat: Add custom header requests to help identify near domains

### DIFF
--- a/packages/frontend/src/services/indexer.js
+++ b/packages/frontend/src/services/indexer.js
@@ -1,8 +1,13 @@
 import { INDEXER_SERVICE_URL } from '../config';
 import sendJson from '../tmp_fetch_send_json';
+import { CUSTOM_REQUEST_HEADERS } from '../utils/constants';
 
 export function listAccountsByPublicKey(publicKey) {
-    return fetch(`${INDEXER_SERVICE_URL}/publicKey/${publicKey}/accounts`)
+    return fetch(`${INDEXER_SERVICE_URL}/publicKey/${publicKey}/accounts`, {
+        headers: {
+            ...CUSTOM_REQUEST_HEADERS,
+        }
+    })
         .then((res) => res.json());
 }
 
@@ -15,16 +20,28 @@ export function listLikelyTokens(accountId) {
 }
 
 export function listRecentTransactions(accountId) {
-    return fetch(`${INDEXER_SERVICE_URL}/account/${accountId}/activity`)
+    return fetch(`${INDEXER_SERVICE_URL}/account/${accountId}/activity`, {
+        headers: {
+            ...CUSTOM_REQUEST_HEADERS,
+        }
+    })
         .then((res) => res.json());
 }
 
 export function listStakingDeposits(accountId) {
-    return fetch(`${INDEXER_SERVICE_URL}/staking-deposits/${accountId}`)
+    return fetch(`${INDEXER_SERVICE_URL}/staking-deposits/${accountId}`, {
+        headers: {
+            ...CUSTOM_REQUEST_HEADERS,
+        }
+    })
         .then((r) => r.json());
 }
 
 export function listStakingPools() {
-    return fetch(`${INDEXER_SERVICE_URL}/stakingPools`)
+    return fetch(`${INDEXER_SERVICE_URL}/stakingPools`, {
+        headers: {
+            ...CUSTOM_REQUEST_HEADERS,
+        }
+    })
         .then((r) => r.json());
 }

--- a/packages/frontend/src/tmp_fetch_send_json.js
+++ b/packages/frontend/src/tmp_fetch_send_json.js
@@ -5,11 +5,16 @@ let fetch = (typeof window === 'undefined' || window.name === 'nodejs') ? requir
 
 const createError = require('http-errors');
 
+const { CUSTOM_REQUEST_HEADERS } = require('./utils/constants');
+
 module.exports = async function sendJson(method, url, json) {
     const response = await fetch(url, {
         method: method,
         body: method !== 'GET' ? JSON.stringify(json) : undefined,
-        headers: { 'Content-type': 'application/json; charset=utf-8' }
+        headers: {
+            'Content-type': 'application/json; charset=utf-8',
+            ...CUSTOM_REQUEST_HEADERS,
+        }
     });
     if (!response.ok) {
         const body = await response.text();

--- a/packages/frontend/src/utils/constants.js
+++ b/packages/frontend/src/utils/constants.js
@@ -13,6 +13,10 @@ export const VALIDATOR_PREFIXES_MAINNET = ['.poolv1.near'];
 export const FARMING_VALIDATOR_PREFIXES_TESTNET = ['.factory01.littlefarm.testnet','.factory.colorpalette.testnet'];
 export const VALIDATOR_PREFIXES_TESTNET = ['.m0'];
 
+export const CUSTOM_REQUEST_HEADERS = {
+    'X-requestor': 'near',
+};
+
 export const FARMING_VALIDATOR_REGEXP_TESTNET = new RegExp(`.*(${FARMING_VALIDATOR_PREFIXES_TESTNET.join('|')}|${VALIDATOR_PREFIXES_TESTNET.join('|')})`);
 export const FARMING_VALIDATOR_REGEXP_MAINNET = new RegExp(`.*(${FARMING_VALIDATOR_PREFIXES_MAINNET.join('|')}|${VALIDATOR_PREFIXES_MAINNET.join('|')})`);
 


### PR DESCRIPTION
This PR adds a custom request header to our requests made to contract-helper/indexer so that we can identify which requests to our backend come from near domains.
