### PR TITLE
chore: Use react-gtm-module vs manual script tag

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -47,6 +47,7 @@
     "react-dom": "^16.13.1",
     "react-google-recaptcha": "^2.1.0",
     "react-google-recaptcha-v3-near": "^2.0.0",
+    "react-gtm-module": "^2.0.11",
     "react-helmet": "^6.1.0",
     "react-localize-redux": "^3.5.3",
     "react-phone-number-input": "2.3.11",

--- a/packages/frontend/src/components/accounts/RecoverAccount.js
+++ b/packages/frontend/src/components/accounts/RecoverAccount.js
@@ -135,6 +135,7 @@ const RecoverAccount = ({
                             linkTo={`/recover-seed-phrase${locationSearch}`}
                             onClick={() => Mixpanel.track('IE Click seed phrase recovery button')}
                             data-test-id="recoverAccountWithPassphraseButton"
+                            id='IE Click seed phrase recovery button'
                         >
                             <Translate id='button.recoverAccount' />
                         </FormButton>
@@ -146,6 +147,7 @@ const RecoverAccount = ({
                             color='seafoam-blue'
                             linkTo={`/sign-in-ledger${locationSearch}`}
                             onClick={() => Mixpanel.track('IE Click ledger recovery button')}
+                            id='IE Click ledger recovery button'
                         >
                             <Translate id='button.signInLedger' />
                         </FormButton>

--- a/packages/frontend/src/components/navigation/AccessAccountBtn.js
+++ b/packages/frontend/src/components/navigation/AccessAccountBtn.js
@@ -19,7 +19,7 @@ const Button = styled(FormButton)`
 `;
 
 const AccessAccountBtn = () => (
-    <Button linkTo='/recover-account' trackingId='IE Click add account button'>
+    <Button linkTo='/recover-account' trackingId='IE Click add account button' id='IE Click add account button'>
         <ImportIcon/>
         <Translate id='button.importAccount'/>
     </Button>

--- a/packages/frontend/src/config/configFromEnvironment.js
+++ b/packages/frontend/src/config/configFromEnvironment.js
@@ -74,6 +74,7 @@ module.exports = {
     ),
     RECAPTCHA_CHALLENGE_API_KEY: process.env.RECAPTCHA_CHALLENGE_API_KEY,
     RECAPTCHA_ENTERPRISE_SITE_KEY: process.env.RECAPTCHA_ENTERPRISE_SITE_KEY,
+    GOOGLE_TAG_MANAGER_ID: process.env.GOOGLE_TAG_MANAGER_ID || 'GTM-T8R4N65',
     SENTRY_DSN: process.env.SENTRY_DSN,
     SENTRY_RELEASE: process.env.SENTRY_RELEASE
         ? parseBooleanFromShell(process.env.RENDER)

--- a/packages/frontend/src/index.html
+++ b/packages/frontend/src/index.html
@@ -30,18 +30,6 @@
         window.recaptchaOptions = { useRecaptchaNet: true, };
     </script>
     <script src="./index.js"></script>
-    <!-- Google Tag Manager -->
-    <script>
-        (function (w, d, s, l, i) {
-            w[l] = w[l] || []; w[l].push({
-                'gtm.start':
-                    new Date().getTime(), event: 'gtm.js'
-            }); var f = d.getElementsByTagName(s)[0],
-                j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
-                    'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
-        })(window, document, 'script', 'dataLayer', 'GTM-T8R4N65');
-    </script>
-    <!-- End Google Tag Manager -->
 </body>
 
 </html>

--- a/packages/frontend/src/index.js
+++ b/packages/frontend/src/index.js
@@ -4,15 +4,22 @@ import { createBrowserHistory } from 'history';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { GoogleReCaptchaProvider } from 'react-google-recaptcha-v3-near';
+import TagManager from 'react-gtm-module';
 import { LocalizeProvider } from 'react-localize-redux';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 
 import Routing from './components/Routing';
-import { RECAPTCHA_ENTERPRISE_SITE_KEY } from './config';
+import { RECAPTCHA_ENTERPRISE_SITE_KEY, GOOGLE_TAG_MANAGER_ID } from './config';
 import createRootReducer from './redux/createReducers';
 import createMiddleware from './redux/middleware';
 import { initSentry } from './utils/sentry';
+
+const tagManagerArgs = {
+    gtmId: GOOGLE_TAG_MANAGER_ID
+};
+ 
+TagManager.initialize(tagManagerArgs);
 
 initSentry();
 

--- a/packages/frontend/src/index.js
+++ b/packages/frontend/src/index.js
@@ -11,6 +11,7 @@ import { createStore } from 'redux';
 
 import Routing from './components/Routing';
 import { RECAPTCHA_ENTERPRISE_SITE_KEY, GOOGLE_TAG_MANAGER_ID } from './config';
+import { isWhitelabel } from './config/whitelabel';
 import createRootReducer from './redux/createReducers';
 import createMiddleware from './redux/middleware';
 import { initSentry } from './utils/sentry';
@@ -18,8 +19,10 @@ import { initSentry } from './utils/sentry';
 const tagManagerArgs = {
     gtmId: GOOGLE_TAG_MANAGER_ID
 };
- 
-TagManager.initialize(tagManagerArgs);
+
+if (!isWhitelabel()) {
+    TagManager.initialize(tagManagerArgs);
+}
 
 initSentry();
 


### PR DESCRIPTION
Changes:
1. Use `react-gtm-module` for Google Tag Manager to enable environment specific IDs
2. Add some initial tracking IDs for recovery buttons for testing in GTM