### PR TITLE
fix: MYNW-114 Temporary hide bridge section from topup-page

### DIFF
--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -211,7 +211,7 @@ class Routing extends Component {
     }
 
     componentDidMount = async () => {
-        if (isWhitelabel() && document) {
+        if (isWhitelabel && document) {
             document.title = 'MyNearWallet';
             document.querySelector('link[rel~="icon"]').href = favicon;
         }

--- a/packages/frontend/src/components/buy/BuyNear.js
+++ b/packages/frontend/src/components/buy/BuyNear.js
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
 import { getPayMethods } from '../../config/buyNearConfig';
+import { isWhitelabel } from '../../config/whitelabel';
 import { Mixpanel } from '../../mixpanel';
 import { selectAccountId } from '../../redux/slices/account';
 import { isMoonpayAvailable, getSignedUrl } from '../../utils/moonpay';
@@ -225,11 +226,13 @@ export function BuyNear({ match, location, history }) {
                     subTitle='buyNear.nearPurchaseSubTitle'
                     actions={[PayMethods.nearPay, PayMethods.moonPay, PayMethods.utorg, PayMethods.ftx]}
                 />
-                <FundingCard
-                    title='buyNear.bridgeTokens'
-                    subTitle='buyNear.bridgeSubTitle'
-                    actions={[PayMethods.rainbow]}
-                />
+                {!isWhitelabel && (
+                    <FundingCard
+                        title='buyNear.bridgeTokens'
+                        subTitle='buyNear.bridgeSubTitle'
+                        actions={[PayMethods.rainbow]}
+                    />
+                )}
                 <FundingCard title='buyNear.supportedExchanges'
                     subTitle='buyNear.supportedSubTitle'
                     link={{

--- a/packages/frontend/src/components/common/Footer.js
+++ b/packages/frontend/src/components/common/Footer.js
@@ -91,7 +91,7 @@ const Footer = () => {
         <StyledContainer className='wallet-footer'>
             <div className='left'>
                 {
-                    isWhitelabel() ? (
+                    isWhitelabel ? (
                         <StyledLogo>
                             <MyNearWalletLogo mode='footer' />
                         </StyledLogo>
@@ -133,7 +133,7 @@ const Footer = () => {
             <div className='right'>
                 <Translate id='footer.needHelp' /><br />
                 <a
-                    href={isWhitelabel() ? 'https://discord.com/invite/Vj74PpQYsh' : 'https://near.chat'}
+                    href={isWhitelabel ? 'https://discord.com/invite/Vj74PpQYsh' : 'https://near.chat'}
                     rel='noopener noreferrer'
                     target='_blank'
                     onClick={() => Mixpanel.track('Footer Click Join Community')}

--- a/packages/frontend/src/components/navigation/DesktopContainer.js
+++ b/packages/frontend/src/components/navigation/DesktopContainer.js
@@ -107,7 +107,7 @@ class DesktopContainer extends Component {
         return (
             <Container>
                 {
-                    isWhitelabel() ?
+                    isWhitelabel ?
                         <Logo link={!flowLimitationMainMenu}/> :
                         <DeprecatedLogo link={!flowLimitationMainMenu}/>
                 }

--- a/packages/frontend/src/components/navigation/MobileContainer.js
+++ b/packages/frontend/src/components/navigation/MobileContainer.js
@@ -184,7 +184,7 @@ class MobileContainer extends Component {
             <Container className={menuOpen ? 'show' : ''} id='mobile-menu'>
                 <Collapsed>
                     {
-                        isWhitelabel() ?
+                        isWhitelabel ?
                             <Logo link={!flowLimitationMainMenu} mode='mobile' /> :
                             <DeprecatedLogo link={!flowLimitationMainMenu}/>
                     }

--- a/packages/frontend/src/config/whitelabel.js
+++ b/packages/frontend/src/config/whitelabel.js
@@ -1,15 +1,11 @@
-import Environments from '../../../../features/environments.json';
-import environmentConfig from './configFromEnvironment';
+import { DEVELOPMENT, TESTNET, TESTNET_STAGING, MAINNET, MAINNET_STAGING  } from '../../../../features/environments.json';
+import { NEAR_WALLET_ENV } from './configFromEnvironment';
 
-const isWhitelabel = () => {
-    const { NEAR_WALLET_ENV } = environmentConfig;
-
-    return NEAR_WALLET_ENV === Environments.DEVELOPMENT ||
-        NEAR_WALLET_ENV === Environments.TESTNET ||
-        NEAR_WALLET_ENV === Environments.TESTNET_STAGING ||
-        NEAR_WALLET_ENV === Environments.MAINNET ||
-        NEAR_WALLET_ENV === Environments.MAINNET_STAGING;
-};
+const isWhitelabel = NEAR_WALLET_ENV === DEVELOPMENT
+    || NEAR_WALLET_ENV === TESTNET
+    || NEAR_WALLET_ENV === TESTNET_STAGING
+    || NEAR_WALLET_ENV === MAINNET
+    || NEAR_WALLET_ENV === MAINNET_STAGING;
 
 module.exports = {
     isWhitelabel

--- a/packages/frontend/src/utils/getWalletURL.js
+++ b/packages/frontend/src/utils/getWalletURL.js
@@ -36,4 +36,4 @@ export const getMyNearWalletUrlFromNEARORG = (https = true) => {
     return `${https ? 'https://' : ''}${prefix || ''}mynearwallet.com`;
 };
 
-export default isWhitelabel() ? getMyNearWalletUrl : getNearOrgWalletUrl;
+export default isWhitelabel ? getMyNearWalletUrl : getNearOrgWalletUrl;


### PR DESCRIPTION
MYNW team decided to hide bridge section from Topup page because the only one option here is Rainbow Bridge. Right now MYNW users can't use Rainbow Bridge because of lack of integration. Work in progress on this issue, but for now best option is not to confuse users and hide section.