### PR TITLE
feat: Encourage users to disable link recovery methods

### DIFF
--- a/packages/frontend/src/components/common/Banner.js
+++ b/packages/frontend/src/components/common/Banner.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Translate } from 'react-localize-redux';
+import styled from 'styled-components';
+
+import FormButton from './FormButton';
+
+const Container = styled.div`
+    background-color: #fafafa;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    padding: 25px;
+    margin: 25px 0;
+    line-height: 1.5;
+
+    .content {
+        margin-right: 20px;
+    }
+
+    .title {
+        font-weight: 700;
+    }
+
+    .desc {
+        margin-top: 10px;
+    }
+
+    &&& {
+        button {
+            margin: 0;
+            margin-left: auto;
+            padding: 10px;
+            min-width: 150px;
+            border-radius: 8px;
+        }
+
+        @media (max-width: 767px) {
+            button {
+                width: 100%;
+                margin-top: 25px;
+            }
+        }
+    }
+
+    @media (max-width: 767px) {
+        flex-direction: column;
+    }
+`;
+
+const Banner = ({
+    title,
+    desc,
+    buttonTitle,
+    onButtonClick,
+    linkTo,
+    buttonColor
+}) => {
+    return (
+        <Container className='banner-container'>
+            <div className='content'>
+                <h4 className='title'>
+                    <Translate id={title} />
+                </h4>
+                <div className='desc'>
+                    <Translate id={desc} />
+                </div>
+            </div>
+            <FormButton
+                onClick={onButtonClick}
+                linkTo={linkTo}
+                color={buttonColor}
+            >
+                <Translate id={buttonTitle} />
+            </FormButton>
+        </Container>
+    );
+};
+
+export default Banner;

--- a/packages/frontend/src/components/common/RemoveLinkRecoveryBanner.js
+++ b/packages/frontend/src/components/common/RemoveLinkRecoveryBanner.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import Banner from './Banner';
+
+const StyledBanner = styled.div`
+    .banner-container {
+        background-color: #FEF2F2;
+        .title, .desc, a {
+            color: #DC1F25;
+        }
+    }
+
+    a {
+        font-weight: 700;
+        text-decoration: underline;
+    }
+`;
+
+export default function RemoveLinkRecoveryBanner() {
+    return (
+        <StyledBanner>
+            <Banner
+                linkTo='/profile'
+                title='removeLinkRecovery.title'
+                desc='removeLinkRecovery.desc'
+                buttonTitle='removeLinkRecovery.button'
+                buttonColor='red'
+            />
+        </StyledBanner>
+    );
+};

--- a/packages/frontend/src/components/wallet/Wallet.js
+++ b/packages/frontend/src/components/wallet/Wallet.js
@@ -11,6 +11,7 @@ import classNames from '../../utils/classNames';
 import { SHOW_NETWORK_BANNER } from '../../utils/wallet';
 import { getTotalBalanceInFiat } from '../common/balance/helpers';
 import FormButton from '../common/FormButton';
+import RemoveLinkRecoveryBanner from '../common/RemoveLinkRecoveryBanner';
 import Container from '../common/styled/Container.css';
 import Tooltip from '../common/Tooltip';
 import DownArrowIcon from '../svg/DownArrowIcon';
@@ -311,7 +312,8 @@ export function Wallet({
     handleCloseLinkdropModal,
     handleSetCreateFromImplicitSuccess,
     handleSetCreateCustomName,
-    handleSetZeroBalanceAccountImportMethod
+    handleSetZeroBalanceAccountImportMethod,
+    userRecoveryMethods
 }) {
     const currentLanguage = getCurrentLanguage();
     const totalAmount = getTotalBalanceInFiat(
@@ -319,10 +321,16 @@ export function Wallet({
         currentLanguage
     );
 
+    const shouldShowRemoveLinkRecoveryBanner = userRecoveryMethods.some(({ kind }) => kind === 'email')
+        || userRecoveryMethods.some(({ kind }) => kind === 'phone');
+
     return (
         <StyledContainer
             className={SHOW_NETWORK_BANNER ? 'showing-banner' : ''}
         >
+            {shouldShowRemoveLinkRecoveryBanner &&
+                <RemoveLinkRecoveryBanner />
+            }
             <div className="split">
                 <div className="left">
                     <div className="tab-selector">
@@ -418,7 +426,7 @@ const FungibleTokens = ({
         <>
             <div className='total-balance'>
                 <Textfit mode='single' max={48}>
-                    <AllTokensTotalBalanceUSD allFungibleTokens={fungibleTokensList}/>
+                    <AllTokensTotalBalanceUSD allFungibleTokens={fungibleTokensList} />
                 </Textfit>
             </div>
             <div className="sub-title balance">
@@ -492,7 +500,7 @@ const FungibleTokens = ({
                         tokens={fungibleTokens}
                         currentLanguage={currentLanguage}
                     />
-                    <div className='coingecko'><Translate id='poweredByCoinGecko'/></div>
+                    <div className='coingecko'><Translate id='poweredByCoinGecko' /></div>
                 </>
             )}
         </>

--- a/packages/frontend/src/components/wallet/Wallet.js
+++ b/packages/frontend/src/components/wallet/Wallet.js
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import {
     CREATE_USN_CONTRACT,
 } from '../../../../../features';
+import { isWhitelabel } from '../../config/whitelabel';
 import getCurrentLanguage from '../../hooks/getCurrentLanguage';
 import classNames from '../../utils/classNames';
 import { SHOW_NETWORK_BANNER } from '../../utils/wallet';
@@ -321,8 +322,8 @@ export function Wallet({
         currentLanguage
     );
 
-    const shouldShowRemoveLinkRecoveryBanner = userRecoveryMethods.some(({ kind }) => kind === 'email')
-        || userRecoveryMethods.some(({ kind }) => kind === 'phone');
+    const shouldShowRemoveLinkRecoveryBanner = !isWhitelabel() && (userRecoveryMethods.some(({ kind }) => kind === 'email')
+        || userRecoveryMethods.some(({ kind }) => kind === 'phone'));
 
     return (
         <StyledContainer

--- a/packages/frontend/src/routes/WalletWrapper.js
+++ b/packages/frontend/src/routes/WalletWrapper.js
@@ -10,6 +10,7 @@ import { selectCreateFromImplicitSuccess, selectCreateCustomName, actions as cre
 import { selectZeroBalanceAccountImportMethod, actions as importZeroBalanceAccountActions } from '../redux/slices/importZeroBalanceAccount';
 import { selectLinkdropAmount, actions as linkdropActions } from '../redux/slices/linkdrop';
 import { selectTokensWithMetadataForAccountId, actions as nftActions } from '../redux/slices/nft';
+import { actions as recoveryMethodsActions, selectRecoveryMethodsByAccountId } from '../redux/slices/recoveryMethods';
 import { actions as tokensActions, selectTokensLoading } from '../redux/slices/tokens';
 
 const { fetchNFTs } = nftActions;
@@ -17,6 +18,8 @@ const { fetchTokens } = tokensActions;
 const { setLinkdropAmount } = linkdropActions;
 const { setCreateFromImplicitSuccess, setCreateCustomName } = createFromImplicitActions;
 const { setZeroBalanceAccountImportMethod } = importZeroBalanceAccountActions;
+const { fetchRecoveryMethods } = recoveryMethodsActions;
+
 
 export function WalletWrapper({
     tab,
@@ -34,6 +37,7 @@ export function WalletWrapper({
     const tokensLoading = useSelector((state) => selectTokensLoading(state, { accountId }));
     const availableAccounts = useSelector(selectAvailableAccounts);
     const sortedNFTs = useSelector((state) => selectTokensWithMetadataForAccountId(state, { accountId }));
+    const userRecoveryMethods = useSelector((state) => selectRecoveryMethodsByAccountId(state, { accountId }));
 
     useEffect(() => {
         if (accountId) {
@@ -42,6 +46,10 @@ export function WalletWrapper({
 
             dispatch(fetchNFTs({ accountId }));
             dispatch(fetchTokens({ accountId }));
+
+            if (userRecoveryMethods.length === 0) {
+                dispatch(fetchRecoveryMethods({ accountId }));
+            }
         }
     }, [accountId]);
 
@@ -69,6 +77,7 @@ export function WalletWrapper({
             handleSetCreateFromImplicitSuccess={() => dispatch(setCreateFromImplicitSuccess(false))}
             handleSetCreateCustomName={() => dispatch(setCreateCustomName(false))}
             handleSetZeroBalanceAccountImportMethod={() => dispatch(setZeroBalanceAccountImportMethod(''))}
+            userRecoveryMethods={userRecoveryMethods}
         />
     );
 }

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1876,7 +1876,7 @@
     },
     "removeLinkRecovery": {
         "title": "Important Security Update",
-        "desc": "We have updated our security measures to protect your account. Please enable a passphrase or Ledger recovery method and <a href=\"/profile\">disable all email and SMS recovery methods</a> to ensure your account is protected. Read more about our security measures in our <a href=\"https://near.org/blog/near-web-wallet-security-update/\" target=\"_blank\">blog post</a>.",
+        "desc": "We have updated our security measures to protect your account. Please enable a passphrase or Ledger recovery method and <a href=\"/profile\">disable all email and SMS recovery methods</a> to ensure your account is protected. <a href=\"https://near.org/blog/near-web-wallet-security-update/\" target=\"_blank\">Learn more</a>.",
         "button": "Go to Account"
     }
 }

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1873,5 +1873,10 @@
         "scamWarning": "This address has a high level of risk and marked as scam. Make sure that this address is safe before sending funds.",
         "checkbox": "I accept responsibility for sending funds to this address."
 
+    },
+    "removeLinkRecovery": {
+        "title": "Important Security Update",
+        "desc": "We have updated our security measures to protect your account. Please enable a passphrase or Ledger recovery method and <a href=\"/profile\">disable all email and SMS recovery methods</a> to ensure your account is protected. Read more about our security measures in our <a href=\"https://near.org/blog/near-web-wallet-security-update/\" target=\"_blank\">blog post</a>.",
+        "button": "Go to Account"
     }
 }


### PR DESCRIPTION
Add a banner on the wallet dashboard to encourage users to enable a passphrase or Ledger recovery method and disable all email and SMS recovery methods. The banner will only show if the currently active account has any email or SMS recovery methods.

More information is available on the near.org blog: https://near.org/blog/near-web-wallet-security-update/

<img width="1256" alt="Screen Shot 2022-08-05 at 1 20 19 PM" src="https://user-images.githubusercontent.com/24921205/183128726-78835748-49d3-4bac-b038-3a32b57e71ba.png">

