### PR TITLE
fix: don't send up custom headers on all requests from sendJson

### DIFF
--- a/packages/frontend/src/tmp_fetch_send_json.js
+++ b/packages/frontend/src/tmp_fetch_send_json.js
@@ -5,15 +5,12 @@ let fetch = (typeof window === 'undefined' || window.name === 'nodejs') ? requir
 
 const createError = require('http-errors');
 
-const { CUSTOM_REQUEST_HEADERS } = require('./utils/constants');
-
 module.exports = async function sendJson(method, url, json) {
     const response = await fetch(url, {
         method: method,
         body: method !== 'GET' ? JSON.stringify(json) : undefined,
         headers: {
             'Content-type': 'application/json; charset=utf-8',
-            ...CUSTOM_REQUEST_HEADERS,
         }
     });
     if (!response.ok) {


### PR DESCRIPTION
This PR removes the custom headers from `sendJson` requests, which currently yield CORS errors when calling out to `indexer.ref.finance` and is preventing token prices from loading. A follow-up PR will be required to ensure that all calls to the wallet indexer include the custom header.