### PR TITLE
fix: specify https in readme getting started section

### DIFF
--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -16,7 +16,7 @@ The set of valid values for `NEAR_WALLET_ENV` are the JSON values defined in [en
 To build locally, run the following command in the `/frontend` directory. Substitute `testnet` for the desired environment
 as outlined above.
 
-`yarn && NEAR_WALLET_ENV=testnet yarn start`
+`yarn && NEAR_WALLET_ENV=testnet yarn start` will start a server at https://localhost:1234.
 
 The environment must be set at bundle time rather than run time. If you wish to run the frontend package with a different
 environment, please run `yarn prebuild` first.


### PR DESCRIPTION
Specify 'https' to avoid any confusion. Https is used because Ledger only supports a https connection.