### PR TITLE
feat: add blocking batch 2fa disable modal

### DIFF
--- a/packages/frontend/src/components/accounts/batch_import_accounts/sequentialAccountImportReducer.js
+++ b/packages/frontend/src/components/accounts/batch_import_accounts/sequentialAccountImportReducer.js
@@ -20,6 +20,9 @@ export const ACTIONS = {
     SET_CURRENT_FAILED: 'SET_CURRENT_FAILED',
     CONFIRM_URL: 'CONFIRM_URL',
     REMOVE_ACCOUNTS: 'REMOVE_ACCOUNTS',
+    ADD_ACCOUNTS: 'ADD_ACCOUNTS',
+    SET_CURRENT_FAILED_AND_END_PROCESS: 'SET_CURRENT_FAILED_AND_END_PROCESS',
+    RESTART_PROCESS: 'RESTART_PROCESS'
 };
 
 /**
@@ -86,6 +89,22 @@ const sequentialAccountImportReducer = (state = initialState, action) => {
             }
             return;
         }
+        case ACTIONS.SET_CURRENT_FAILED_AND_END_PROCESS: {
+            const currentIndex = state.accounts.findIndex(
+                (account) => account.status === IMPORT_STATUS.PENDING
+            );
+            state.accounts[currentIndex].status = IMPORT_STATUS.FAILED;
+            return;
+        };
+        case ACTIONS.RESTART_PROCESS: {
+            const [firstAccount, ...remainingAccounts] = state.accounts;
+
+            firstAccount.status = IMPORT_STATUS.PENDING;
+            remainingAccounts.forEach(
+                (account) => (account.status = IMPORT_STATUS.UP_NEXT)
+            );
+            return;
+        };
         case ACTIONS.CONFIRM_URL:
             state.urlConfirmed = true;
             return;

--- a/packages/frontend/src/components/wallet-migration/Disable2FA.jsx
+++ b/packages/frontend/src/components/wallet-migration/Disable2FA.jsx
@@ -1,0 +1,166 @@
+import React, { useState, useEffect, useMemo, useRef } from 'react';
+import { Translate } from 'react-localize-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import styled from 'styled-components';
+import { useImmerReducer } from 'use-immer';
+
+import { NETWORK_ID } from '../../config';
+import IconSecurityLock from '../../images/wallet-migration/IconSecurityLock';
+import { switchAccount } from '../../redux/actions/account';
+import { selectAccountId } from '../../redux/slices/account';
+import WalletClass, { wallet } from '../../utils/wallet';
+import AccountListImport from '../accounts/AccountListImport';
+import { IMPORT_STATUS } from '../accounts/batch_import_accounts';
+import sequentialAccountImportReducer, { ACTIONS } from '../accounts/batch_import_accounts/sequentialAccountImportReducer';
+import FormButton from '../common/FormButton';
+import LoadingDots from '../common/loader/LoadingDots';
+import Modal from '../common/modal/Modal';
+import { WALLET_MIGRATION_VIEWS } from './WalletMigration';
+
+
+const Container = styled.div`
+    padding: 15px 0;
+    text-align: center;
+    margin: 0 auto;
+
+    @media (max-width: 360px) {
+        padding: 0;
+    }
+
+    @media (min-width: 500px) {
+        padding: 48px 28px 12px;
+    }
+
+    .accountsTitle {
+        text-align: left;
+        font-size: 12px;
+        padding-top: 72px;
+        padding-bottom: 6px;
+    }
+
+    .title{
+        font-weight: 800;
+        font-size: 20px;
+        margin-top: 40px;
+    }
+`;
+
+const ButtonsContainer = styled.div`
+    text-align: center;
+    width: 100% !important;
+    display: flex;
+`;
+
+const StyledButton = styled(FormButton)`
+    width: calc((100% - 16px) / 2);
+    margin: 48px 0 0 !important;
+
+    &:last-child{
+        margin-left: 16px !important;
+    }
+`;
+
+
+const Disable2FAModal = ({ handleSetActiveView, onClose }) => {
+    const [state, localDispatch] = useImmerReducer(sequentialAccountImportReducer, {
+        accounts: []
+    });
+    const [loadingMultisigAccounts, setLoadingMultisigAccounts] = useState(true);
+    const initialAccountIdOnStart = useSelector(selectAccountId);
+    const initialAccountId = useRef(initialAccountIdOnStart);
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        const update2faAccounts = async () => {
+            const accounts = await wallet.keyStore.getAccounts(NETWORK_ID);
+            const getAccountWithAccessKeysAndType = async (accountId) => {
+                const keyType = await wallet.getAccountKeyType(accountId);
+                return { accountId, keyType };
+            };
+            const accountsKeyTypes = await Promise.all(
+                accounts.map(getAccountWithAccessKeysAndType)
+            );
+            localDispatch({
+                type: ACTIONS.ADD_ACCOUNTS,
+                accounts: accountsKeyTypes.reduce(((acc, { accountId, keyType }) => keyType === WalletClass.KEY_TYPES.MULTISIG ? acc.concat({ accountId, status: null }) : acc), [])
+            });
+            setLoadingMultisigAccounts(false);
+        };
+        setLoadingMultisigAccounts(true);
+        update2faAccounts();
+    }, []);
+
+    const failed = useMemo(() => state.accounts.some((account) => account.status === IMPORT_STATUS.FAILED), [state.accounts]);
+    const currentAccount = useMemo(() => !failed && state.accounts.find((account) => account.status === IMPORT_STATUS.PENDING), [failed, state.accounts]);
+    const batchDisableNotStarted = useMemo(() => state.accounts.every((account) => account.status === null), [state.accounts]);
+    const completedWithSuccess = useMemo(() => !loadingMultisigAccounts && state.accounts.every((account) => account.status === IMPORT_STATUS.SUCCESS), [state.accounts, loadingMultisigAccounts]);
+
+    useEffect(() => {
+        if (batchDisableNotStarted) {
+            initialAccountId.current = initialAccountIdOnStart;
+        }
+    },[initialAccountIdOnStart, batchDisableNotStarted]);
+
+    useEffect(() => {
+        const disable2faForCurrentAccount = async () => {
+            try {
+                await dispatch(switchAccount({accountId: currentAccount.accountId}));
+                const account = await wallet.getAccount(currentAccount.accountId);
+                await account.disableMultisig();
+                localDispatch({ type: ACTIONS.SET_CURRENT_DONE });
+            } catch (e) {
+                localDispatch({ type: ACTIONS.SET_CURRENT_FAILED_AND_END_PROCESS });
+            } finally {
+                await dispatch(switchAccount({accountId: initialAccountId.current}));
+            }
+        };
+        if (currentAccount) {
+            disable2faForCurrentAccount();
+        }
+    }, [currentAccount]);
+
+    useEffect(() => {
+        if (completedWithSuccess) {
+            handleSetActiveView(WALLET_MIGRATION_VIEWS.SELECT_DESTINATION_WALLET);
+        }
+    }, [completedWithSuccess]);
+
+    return (
+        <Modal
+            modalClass="slim"
+            id='migration-modal'
+            isOpen={true}
+            disableClose={true}
+            modalSize='md'
+            style={{ maxWidth: '435px' }}
+        >
+            <Container>
+                {loadingMultisigAccounts ? <LoadingDots /> :
+                    (
+                        <>
+                            <IconSecurityLock />
+                            <h4 className='title'><Translate id='walletMigration.disable2fa.title' /></h4>
+                            <p><Translate id='walletMigration.disable2fa.desc' /></p>
+                            <div className="accountsTitle">
+                                <Translate id='importAccountWithLink.accountsFound' data={{ count: state.accounts.length }} />
+                            </div>
+                            <AccountListImport accounts={state.accounts} />
+                            <ButtonsContainer>
+                                <StyledButton className="gray-blue" onClick={onClose} disabled={!batchDisableNotStarted && !failed}>
+                                    <Translate id='button.cancel' />
+                                </StyledButton>
+                                <StyledButton onClick={() =>
+                                    localDispatch({ type: failed ? ACTIONS.RESTART_PROCESS : ACTIONS.BEGIN_IMPORT })
+                                } disabled={!failed && !batchDisableNotStarted}>
+                                    <Translate id={failed ? 'button.retry' : 'button.continue'} />
+                                </StyledButton>
+                            </ButtonsContainer>
+                        </>
+                    )
+                }
+            </Container>
+        </Modal>
+    );
+};
+
+export default Disable2FAModal;

--- a/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
+++ b/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
@@ -6,6 +6,7 @@ import { selectAvailableAccounts } from '../../redux/slices/availableAccounts';
 import { encodeAccountsToHash, generatePublicKey, keyToString } from '../../utils/encoding';
 import { getLedgerHDPath } from '../../utils/localStorage';
 import { wallet } from '../../utils/wallet';
+import Disable2FAModal from './Disable2FA';
 import MigrateAccounts from './MigrateAccounts';
 import MigrationSecret from './MigrationSecret';
 import SelectDestinationWallet from './SelectDestinationWallet';
@@ -14,6 +15,7 @@ export const WALLET_MIGRATION_VIEWS = {
     MIGRATION_SECRET: 'MIGRATION_SECRET',
     SELECT_DESTINATION_WALLET: 'SELECT_DESTINATION_WALLET',
     MIGRATE_ACCOUNTS: 'MIGRATE_ACCOUNTS',
+    DISABLE_2FA: 'DISABLE_2FA'
 };
 
 const initialState = {
@@ -82,7 +84,7 @@ const WalletMigration = ({ open, onClose }) => {
 
     useEffect(() => {
         if (open) {
-            handleSetActiveView(WALLET_MIGRATION_VIEWS.SELECT_DESTINATION_WALLET);
+            handleSetActiveView(WALLET_MIGRATION_VIEWS.DISABLE_2FA);
         } else {
             handleSetActiveView(null);
         }
@@ -90,6 +92,14 @@ const WalletMigration = ({ open, onClose }) => {
 
     return (
         <div>
+            {state.activeView === WALLET_MIGRATION_VIEWS.DISABLE_2FA && (
+                <Disable2FAModal
+                    walletType={state.walletType}
+                    onClose={onClose}
+                    handleSetWalletType={handleSetWalletType}
+                    handleSetActiveView={handleSetActiveView}
+                />
+            )}
             {
                 state.activeView === WALLET_MIGRATION_VIEWS.MIGRATION_SECRET && (
                     <MigrationSecret

--- a/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
+++ b/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
@@ -94,9 +94,7 @@ const WalletMigration = ({ open, onClose }) => {
         <div>
             {state.activeView === WALLET_MIGRATION_VIEWS.DISABLE_2FA && (
                 <Disable2FAModal
-                    walletType={state.walletType}
                     onClose={onClose}
-                    handleSetWalletType={handleSetWalletType}
                     handleSetActiveView={handleSetActiveView}
                 />
             )}

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1843,6 +1843,10 @@
         }
     },
     "walletMigration": {
+        "disable2fa": {
+            "desc": "2FA must be disabled before you can transfer an account to a new wallet.",
+            "title": "Disable two-factor authentication"
+        },
         "migrateAccounts": {
             "desc": "The following accounts will be transferred:",
             "title": "We found ${count} active accounts"
@@ -1853,10 +1857,6 @@
         },
         "selectWallet": {
             "title": "Select a wallet to transfer accounts"
-        },
-        "disable2fa": {
-            "title": "Disable two-factor authentication",
-            "desc": "2FA must be disabled before you can transfer an account to a new wallet."
         }
     },
     "warning": "Warning",

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1853,6 +1853,10 @@
         },
         "selectWallet": {
             "title": "Select a wallet to transfer accounts"
+        },
+        "disable2fa": {
+            "title": "Disable two-factor authentication",
+            "desc": "2FA must be disabled before you can transfer an account to a new wallet."
         }
     },
     "warning": "Warning",


### PR DESCRIPTION
This PR adds a blocking modal forcing users to disable 2fa before they can proceed with the wallet migration

Design: https://www.figma.com/file/w4SQVO6kBvAP5D65TGlm7y/Wallet-Domain-Migration?node-id=1050%3A2322

Testing instructions:

1. Ensure `SHOW_MIGRATION_BANNER` flag is enabled
2. Create an account and enable 2fa
3. Initiate migration flow by clicking "Transfer my accounts" on the banner
4. You should not be able to migrate your account without disabling 2fa on that account