### PR TITLE
Update test account seed phrase with bip39Light

### DIFF
--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -9,10 +9,12 @@
   "dependencies": {
     "@pagerduty/pdjs": "^2.2.0",
     "@playwright/test": "^1.14.0",
+    "bip39-light": "^1.0.7",
     "bn.js": "^5.2.0",
     "dotenv": "^8.2.0",
     "expect-playwright": "^0.7.2",
     "express": "^4.17.1",
+    "js-sha256": "^0.9.0",
     "lodash": "^4.17.21",
     "ms": "^2.1.3",
     "near-api-js": "^0.43.1",

--- a/packages/e2e-tests/utils/E2eTestAccount.js
+++ b/packages/e2e-tests/utils/E2eTestAccount.js
@@ -70,7 +70,7 @@ class E2eTestAccount {
         }
         // creates a testinglockup subaccount with a lockup_timestamp (locked until) in 1 minute with a release_duration (period to linearly unlock) of 1 minute
         const lockupSubaccountId = `testinglockup.${this.accountId}`;
-        const lockupSubaccountSeedphrase = `${lockupSubaccountId} ${process.env.TEST_ACCOUNT_SEED_PHRASE}`;
+        const lockupSubaccountSeedphrase = getTestAccountSeedPhrase(lockupSubaccountId);
         const lockupWasm = await fetchLockupContract({ v2Wasm });
         let minuteInNanosBN = new BN("1").mul(new BN("60000000000"));
         const vesting_schedule_config = vesting_schedule || FULLY_VESTED_CONFIG.vesting_schedule;

--- a/packages/e2e-tests/utils/helpers.js
+++ b/packages/e2e-tests/utils/helpers.js
@@ -3,6 +3,8 @@ const { parseSeedPhrase } = require("near-seed-phrase");
 const assert = require("assert");
 const { random } = require("lodash");
 const { BN } = require("bn.js");
+const bip39Light = require("bip39-light");
+const sha256 = require('js-sha256');
 
 const generateNUniqueRandomNumbersInRange = ({ from, to }, n) => {
     assert(n <= Math.abs(from - to) + 1, "Range needs to have at least N unique numbers");
@@ -22,7 +24,7 @@ function generateTestAccountId() {
 }
 
 function getTestAccountSeedPhrase(testAccountId) {
-    return `${testAccountId} ${process.env.TEST_ACCOUNT_SEED_PHRASE}`;
+    return bip39Light.entropyToMnemonic(sha256(testAccountId));
 }
 
 function getWorkerAccountId(workerIndex) {


### PR DESCRIPTION
This PR contains small update on fixing function on creating test seed phrase.
https://github.com/vacuumlabs/bip39-light#reminder-for-developers

previous:
<img width="1917" alt="Greenshot 2022-08-16 11 12 09" src="https://user-images.githubusercontent.com/6027014/184779064-bdd3a48f-2993-49e6-a2e1-4cda31189555.png">

