### PR TITLE
MYNW-162: remove .env variables from netlify.yaml

### DIFF
--- a/packages/frontend/example.netlify.toml
+++ b/packages/frontend/example.netlify.toml
@@ -1,0 +1,61 @@
+[build]
+    publish = "./dist"
+    command = "yarn build"
+    ignore = "/bin/false"
+
+[build.environment]
+    DISABLE_PHONE_RECOVERY = "yes"
+    REACT_APP_NETWORK_ID = "default"
+    REACT_APP_NODE_URL = "https://rpc.mainnet.near.org"
+    REACT_APP_ACCESS_KEY_FUNDING_AMOUNT = "250000000000000000000000"
+    NEW_ACCOUNT_AMOUNT = "500000001000000000000000000"
+    REACT_APP_ACCOUNT_ID_SUFFIX = "near"
+    EXPLORER_URL = "https://explorer.mainnet.near.org"
+    REACT_APP_IS_MAINNET = "true"
+    DISABLE_SEND_MONEY = "no"
+    DISABLE_CREATE_ACCOUNT = "true"
+    REACT_APP_MULTISIG_MIN_AMOUNT = "4"
+    LOCKUP_ACCOUNT_ID_SUFFIX = "lockup.near"
+    SENTRY_ORG = "near-protocol"
+    SENTRY_PROJECT = "mainnet-staging-wallet"
+    MOONPAY_API_KEY = "pk_live_jYDdkGL7bJsrwalHZs1lVIhdOHOtK8BR"
+    TOKEN_CONTRACTS = 'berryclub.ek.near,wrap.near,6b175474e89094c44da98b954eedeac495271d0f.factory.bridge.near'
+    RECAPTCHA_ENTERPRISE_SITE_KEY = "6LcpJ3EcAAAAAFgA-nixKFNGWMo9IG9FQhH4XjSY"
+    RECAPTCHA_CHALLENGE_API_KEY = "6LeRzswaAAAAAGeS7mSasZ1wDcGnMcH3D7W1gy1b"
+    NETLIFY_USE_YARN = "true"
+
+[context.production.environment]
+    BROWSER_MIXPANEL_TOKEN = "7c5730e5b3556a06b73829b3c3b40a86"
+    SENTRY_PROJECT = "mainnet-wallet"
+    
+[[headers]]
+    for = "/*"
+    [headers.values]
+        X-Frame-Options = "deny"
+        Content-Security-Policy = """
+            frame-ancestors 'none'
+        """
+[[headers]]
+    for = "/auto-import-secret-key*"
+    [headers.values]
+        X-Robots-Tag = "noindex"
+[[headers]]
+    for = "/auto-import-seed-phrase*"
+    [headers.values]
+        X-Robots-Tag = "noindex"
+[[headers]]
+    for = "/recover-seed-phrase*"
+    [headers.values]
+        X-Robots-Tag = "noindex"
+[[headers]]
+    for = "/recover-with-link*"
+    [headers.values]
+        X-Robots-Tag = "noindex"
+
+[[redirects]]
+    from = "/*"
+    to = "/index.html"
+    status = 200
+
+[[plugins]]
+    package = "@sentry/netlify-build-plugin"

--- a/packages/frontend/netlify.toml
+++ b/packages/frontend/netlify.toml
@@ -3,31 +3,6 @@
     command = "yarn build"
     ignore = "/bin/false"
 
-[build.environment]
-    DISABLE_PHONE_RECOVERY = "yes"
-    REACT_APP_NETWORK_ID = "default"
-    REACT_APP_NODE_URL = "https://rpc.mainnet.near.org"
-    REACT_APP_ACCESS_KEY_FUNDING_AMOUNT = "250000000000000000000000"
-    NEW_ACCOUNT_AMOUNT = "500000001000000000000000000"
-    REACT_APP_ACCOUNT_ID_SUFFIX = "near"
-    EXPLORER_URL = "https://explorer.mainnet.near.org"
-    REACT_APP_IS_MAINNET = "true"
-    DISABLE_SEND_MONEY = "no"
-    DISABLE_CREATE_ACCOUNT = "true"
-    REACT_APP_MULTISIG_MIN_AMOUNT = "4"
-    LOCKUP_ACCOUNT_ID_SUFFIX = "lockup.near"
-    SENTRY_ORG = "near-protocol"
-    SENTRY_PROJECT = "mainnet-staging-wallet"
-    MOONPAY_API_KEY = "pk_live_jYDdkGL7bJsrwalHZs1lVIhdOHOtK8BR"
-    TOKEN_CONTRACTS = 'berryclub.ek.near,wrap.near,6b175474e89094c44da98b954eedeac495271d0f.factory.bridge.near'
-    RECAPTCHA_ENTERPRISE_SITE_KEY = "6LcpJ3EcAAAAAFgA-nixKFNGWMo9IG9FQhH4XjSY"
-    RECAPTCHA_CHALLENGE_API_KEY = "6LeRzswaAAAAAGeS7mSasZ1wDcGnMcH3D7W1gy1b"
-    NETLIFY_USE_YARN = "true"
-
-[context.production.environment]
-    BROWSER_MIXPANEL_TOKEN = "7c5730e5b3556a06b73829b3c3b40a86"
-    SENTRY_PROJECT = "mainnet-wallet"
-
 [[headers]]
     for = "/*"
     [headers.values]


### PR DESCRIPTION
Also see: #2891 

Removed all .env variables from netlify.yaml
From now everything should be set in Netlify UI

Removed variables:
```
DISABLE_PHONE_RECOVERY = "yes"
REACT_APP_NETWORK_ID = "default"
REACT_APP_NODE_URL = "https://rpc.mainnet.near.org"
REACT_APP_ACCESS_KEY_FUNDING_AMOUNT = "250000000000000000000000"
NEW_ACCOUNT_AMOUNT = "500000001000000000000000000"
REACT_APP_ACCOUNT_ID_SUFFIX = "near"
EXPLORER_URL = "https://explorer.mainnet.near.org"
REACT_APP_IS_MAINNET = "true"
DISABLE_SEND_MONEY = "no"
DISABLE_CREATE_ACCOUNT = "true"
REACT_APP_MULTISIG_MIN_AMOUNT = "4"
LOCKUP_ACCOUNT_ID_SUFFIX = "lockup.near"
SENTRY_ORG = "near-protocol"
SENTRY_PROJECT = "mainnet-staging-wallet"
MOONPAY_API_KEY = "pk_live_jYDdkGL7bJsrwalHZs1lVIhdOHOtK8BR"
TOKEN_CONTRACTS = "berryclub.ek.near,wrap.near,6b175474e89094c44da98b954eedeac495271d0f.factory.bridge.near"
RECAPTCHA_ENTERPRISE_SITE_KEY = "6LcpJ3EcAAAAAFgA-nixKFNGWMo9IG9FQhH4XjSY"
RECAPTCHA_CHALLENGE_API_KEY = "6LeRzswaAAAAAGeS7mSasZ1wDcGnMcH3D7W1gy1b"
NETLIFY_USE_YARN = "true"
```

To make it run in Netlify, at least those variables should be set in UI:
<img width="672" alt="изображение" src="https://user-images.githubusercontent.com/8269834/187774244-f737c933-8f06-472c-af61-03624a2406a8.png">
