### PR TITLE
fix: Disable 2FA cooldown error 

### DIFF
--- a/packages/frontend/src/utils/twoFactor.js
+++ b/packages/frontend/src/utils/twoFactor.js
@@ -75,7 +75,14 @@ export class TwoFactor extends Account2FA {
     async disableMultisig() {
         const contractBytes = new Uint8Array(await (await fetch('/main.wasm')).arrayBuffer());
         const stateCleanupContractBytes = new Uint8Array(await (await fetch('/state_cleanup.wasm')).arrayBuffer());
-        const result = await this.disable(contractBytes, stateCleanupContractBytes);
+        let result;
+        try {
+            result = await this.disable(contractBytes, stateCleanupContractBytes);
+        } catch (e) {
+            if (e.message.includes('too large to be viewed')) {
+                throw new Error('You must wait 15 minutes between each attempt to disable 2fa. Please try again in 15 minutes. ');
+            }
+        }
         await store.dispatch(refreshAccount());
         this.has2fa = false;
         return result;


### PR DESCRIPTION
Error prompt to let the user know to wait 15 minutes if they come across an error while trying to disable 2fa during the 15 minute multisig contract cooldown period. 

