### PR TITLE
fix: disable2fa error messages

### DIFF
--- a/packages/frontend/src/utils/twoFactor.js
+++ b/packages/frontend/src/utils/twoFactor.js
@@ -75,7 +75,18 @@ export class TwoFactor extends Account2FA {
     async disableMultisig() {
         const contractBytes = new Uint8Array(await (await fetch('/main.wasm')).arrayBuffer());
         const stateCleanupContractBytes = new Uint8Array(await (await fetch('/state_cleanup.wasm')).arrayBuffer());
-        const result = await this.disable(contractBytes, stateCleanupContractBytes);
+        let result;
+        try {
+            result = await this.disable(contractBytes, stateCleanupContractBytes);
+        } catch (e) {
+            if (e.message.includes('too large to be viewed')) {
+                throw new Error('You must wait 15 minutes between each attempt to disable 2fa. Please try again in 15 minutes.');
+            }
+            if (e.message.includes('Request was cancelled.')) {
+                throw new Error('Request was cancelled. You must wait 15 minutes to attempt disabling 2fa again.');
+            }
+            throw new Error(e.message);
+        }
         await store.dispatch(refreshAccount());
         this.has2fa = false;
         return result;


### PR DESCRIPTION
This PR addresses Issue #2885

Adds better visibility into errors while disabling 2fa
- If the user tries to disable the 2fa within the 15 minute cooldown period, they are told to wait 15 minutes. 

| User Cancels disable 2fa request      | User attempts to disable 2fa during cooldown |
| ----------- | ----------- |
| <img width="820" alt="image" src="https://user-images.githubusercontent.com/25015977/188217064-70f28632-9885-49d9-8751-4b24349bed32.png">      | <img width="881" alt="image" src="https://user-images.githubusercontent.com/25015977/188217105-55d976bb-d546-4405-914f-b7dd3fd94687.png">       |



