### PR TITLE
fix: fixes for mobile light sidebar

### DIFF
--- a/packages/frontend/src/components/wallet/CreateCustomNameLightBanner.js
+++ b/packages/frontend/src/components/wallet/CreateCustomNameLightBanner.js
@@ -15,10 +15,6 @@ const Container = styled.div`
         font-size: 14px;
         padding-top: 8px;
 
-        @media (max-width: 992px) {
-            padding-top: 72px;
-        }
-
         h2 {
             color: #25272A;
             align-self: center;

--- a/packages/frontend/src/components/wallet/SidebarLight.js
+++ b/packages/frontend/src/components/wallet/SidebarLight.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import CreateCustomNameLightBanner from './CreateCustomNameLightBanner';
@@ -43,13 +43,6 @@ const StyledBanner = styled.div`
 
 export default ({ availableAccounts }) => {
     const [activeComponent, setActiveComponent] = useState('ExploreApps');
-
-    useEffect(() => {
-        if (availableAccounts?.length > 0) {
-            const numNonImplicitAccounts = availableAccounts.filter((a) => a.length < 64).length;
-            setActiveComponent(numNonImplicitAccounts === 0 ? 'CreateCustomName' : 'ExploreApps');
-        }
-    }, [availableAccounts]);
 
     return (
         <StyledContainer>


### PR DESCRIPTION
* Made Explore Near banner always be the first in light Sidebar
* Fixed paddings for Custom Address banner on mobile light Sidebar

<img width="254" alt="Screenshot 2022-09-09 at 00 45 34" src="https://user-images.githubusercontent.com/7001916/189231573-32dbb877-4b8c-4905-a654-91a316514f37.png">
<img width="255" alt="Screenshot 2022-09-09 at 00 45 15" src="https://user-images.githubusercontent.com/7001916/189231582-875b0c9e-26da-4caa-a260-c566af29f8c4.png">
