### PR TITLE
WEP-99: Unbrick 2FA process to UI

### DIFF
--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -84,6 +84,7 @@ import NetworkBanner from './common/NetworkBanner';
 import PrivateRoute from './common/routing/PrivateRoute';
 import PublicRoute from './common/routing/PublicRoute';
 import Route from './common/routing/Route';
+import TwoFactorDisableBanner from './common/TwoFactorDisableBanner';
 import { ExploreContainer } from './explore/ExploreContainer';
 import GlobalStyle from './GlobalStyle';
 import { LoginCliLoginSuccess } from './login/LoginCliLoginSuccess';
@@ -366,6 +367,7 @@ class Routing extends Component {
 
                         <NetworkBanner account={account} />
                         <NavigationWrapper />
+                        { !isWhitelabel() && <TwoFactorDisableBanner />}
                         <GlobalAlert />
                         <WalletMigration
                             open={this.state.openTransferPopup}

--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -367,7 +367,15 @@ class Routing extends Component {
 
                         <NetworkBanner account={account} />
                         <NavigationWrapper />
-                        { !isWhitelabel && <TwoFactorDisableBanner />}
+                        {
+                            !isWhitelabel && (
+                                <Switch>
+                                    <Route
+                                        path={['/', '/staking', '/profile']} component={TwoFactorDisableBanner}
+                                    />
+                                </Switch>
+                            )
+                        }
                         <GlobalAlert />
                         <WalletMigration
                             open={this.state.openTransferPopup}

--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -367,7 +367,7 @@ class Routing extends Component {
 
                         <NetworkBanner account={account} />
                         <NavigationWrapper />
-                        { !isWhitelabel() && <TwoFactorDisableBanner />}
+                        { !isWhitelabel && <TwoFactorDisableBanner />}
                         <GlobalAlert />
                         <WalletMigration
                             open={this.state.openTransferPopup}

--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -367,6 +367,7 @@ class Routing extends Component {
 
                         <NetworkBanner account={account} />
                         <NavigationWrapper />
+                        <GlobalAlert />
                         {
                             !isWhitelabel && (
                                 <Switch>
@@ -376,7 +377,6 @@ class Routing extends Component {
                                 </Switch>
                             )
                         }
-                        <GlobalAlert />
                         <WalletMigration
                             open={this.state.openTransferPopup}
                             history={this.props.history}

--- a/packages/frontend/src/components/common/TwoFactorDisableBanner.js
+++ b/packages/frontend/src/components/common/TwoFactorDisableBanner.js
@@ -37,14 +37,20 @@ const Container = styled.div`
 
 
     .alert-container {
-      background-color: #FFEFEF;
-      border-radius: 50%;
-      padding: 9px;
-      margin-right: 16px;
-      .alert-triangle-icon {
-        width: 25px;
-        height: 25px;
-      }
+        background-color: #FFEFEF;
+        border-radius: 50%;
+        padding: 9px;
+        margin-right: 16px;
+        display: flex;
+        justify-content: center;
+        @media (max-width: 768px) {
+            margin: 0 auto 15px;
+        }
+        .alert-triangle-icon {
+            width: 25px;
+            height: 25px;
+        }
+     
     }
     
     .content {
@@ -66,15 +72,15 @@ const Container = styled.div`
             display: flex;
             align-items: center;
             justify-content: center;
-            margin: 0;
+            margin: 0 !important;
             height: 40px;
             padding: 8px 16px;
             white-space: nowrap;
             border-radius: 50px;
             font-weight: 600;
             .lock-icon {
-              margin: 0;
-              margin-right: 10px;
+                margin: 0;
+                margin-right: 10px;
             }
             :hover {
                 > svg {
@@ -88,7 +94,7 @@ const Container = styled.div`
         @media (max-width: 767px) {
             button {
                 width: 100%;
-                margin-top: 25px;
+                margin-top: 25px !important;
             }
         }
     }
@@ -138,7 +144,7 @@ export default function TwoFactorDisableBanner() {
             </div>
             <div className='content'>
                 <h4 className='title'>
-                    <Translate id='twoFactorDisbleBanner.title' data={{ accountsCount, plural: accountsCount > 1 ? 's' : '' }} />
+                    <Translate id='twoFactorDisbleBanner.title' data={{ accountsCount, context: accountsCount === 1 ? 'Account Needs' : 'Accounts Need'}} />
                 </h4>
                 <div className='desc'>
                     <Translate id='twoFactorDisbleBanner.desc' />

--- a/packages/frontend/src/components/common/TwoFactorDisableBanner.js
+++ b/packages/frontend/src/components/common/TwoFactorDisableBanner.js
@@ -1,8 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { Translate } from 'react-localize-redux';
+import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
 import { NETWORK_ID } from '../../config';
+import { selectAccountSlice } from '../../redux/slices/account';
 import WalletClass, { wallet } from '../../utils/wallet';
 import AlertTriangleIcon from '../svg/AlertTriangleIcon';
 import LockIcon from '../svg/LockIcon';
@@ -100,6 +102,9 @@ export default function TwoFactorDisableBanner() {
     const [accounts, setAccounts] = useState([]);
     const [showDisable2FAModal, setShowDisable2FAModal] = useState(false);
 
+    const account = useSelector(selectAccountSlice);
+    const loadedAccounts = useMemo(() => Object.keys(account.accounts ?? {}), [account.accounts]);
+
     const showModal = () => setShowDisable2FAModal(true);
     const hideModal = () => setShowDisable2FAModal(false);
 
@@ -116,8 +121,10 @@ export default function TwoFactorDisableBanner() {
     
             setAccounts(accountsKeyTypes.reduce(((acc, { accountId, keyType }) => keyType === WalletClass.KEY_TYPES.MULTISIG ? [...acc, accountId] : acc), []));
         };
-        update2faAccounts();
-    }, [showDisable2FAModal]);
+        if (loadedAccounts.length > 0 && accounts.sort() !== loadedAccounts.sort()) {
+            update2faAccounts();
+        }
+    }, [showDisable2FAModal, loadedAccounts.length]);
 
     const accountsCount = accounts.length;
     if (accounts.length === 0) {

--- a/packages/frontend/src/components/common/TwoFactorDisableBanner.js
+++ b/packages/frontend/src/components/common/TwoFactorDisableBanner.js
@@ -1,0 +1,157 @@
+import React, { useEffect, useState } from 'react';
+import { Translate } from 'react-localize-redux';
+import styled from 'styled-components';
+
+import { NETWORK_ID } from '../../config';
+import WalletClass, { wallet } from '../../utils/wallet';
+import AlertTriangleIcon from '../svg/AlertTriangleIcon';
+import LockIcon from '../svg/LockIcon';
+import Disable2FAModal from '../wallet-migration/Disable2FA';
+import FormButton from './FormButton';
+
+
+const Container = styled.div`
+    border: 2px solid #DC1F26;
+    border-radius: 16px;
+    background-color: #FFFCFC;
+    display: flex;
+    align-items: flex-start;
+    flex-direction: row;
+    padding: 25px;
+    margin: 25px auto;
+    line-height: 1.5;
+
+    @media (min-width: 768px) {
+        width: 720px;
+    }
+
+    @media (min-width: 992px) {
+        width: 920px;
+    }
+
+    @media (min-width: 1200px) {
+        width: 1000px;
+    }
+
+
+    .alert-container {
+      background-color: #FFEFEF;
+      border-radius: 50%;
+      padding: 9px;
+      margin-right: 16px;
+      .alert-triangle-icon {
+        width: 25px;
+        height: 25px;
+      }
+    }
+    
+    .content {
+        margin-right: 20px;
+    }
+
+    .title {
+        font-weight: 700;
+        color: #DC1F25;
+    }
+
+    .desc {
+        margin-top: 10px;
+        color: #DC1F25;
+    }
+
+    && {
+        button {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 0;
+            height: 40px;
+            padding: 8px 16px;
+            white-space: nowrap;
+            border-radius: 50px;
+            font-weight: 600;
+            .lock-icon {
+              margin: 0;
+              margin-right: 10px;
+            }
+            :hover {
+                > svg {
+                    path {
+                        stroke: #E5484D;
+                    }
+                }
+            }
+        }
+
+        @media (max-width: 767px) {
+            button {
+                width: 100%;
+                margin-top: 25px;
+            }
+        }
+    }
+
+    @media (max-width: 767px) {
+        flex-direction: column;
+    }
+`;
+
+export default function TwoFactorDisableBanner() {
+    const [accounts, setAccounts] = useState([]);
+    const [showDisable2FAModal, setShowDisable2FAModal] = useState(false);
+
+    const showModal = () => setShowDisable2FAModal(true);
+    const hideModal = () => setShowDisable2FAModal(false);
+
+    useEffect(() => {
+        const update2faAccounts = async () => {
+            const accounts = await wallet.keyStore.getAccounts(NETWORK_ID);
+            const getAccountWithAccessKeysAndType = async (accountId) => {
+                const keyType = await wallet.getAccountKeyType(accountId);
+                return { accountId, keyType };
+            };
+            const accountsKeyTypes = await Promise.all(
+                accounts.map(getAccountWithAccessKeysAndType)
+            );
+    
+            setAccounts(accountsKeyTypes.reduce(((acc, { accountId, keyType }) => keyType === WalletClass.KEY_TYPES.MULTISIG ? [...acc, accountId] : acc), []));
+        };
+        update2faAccounts();
+    }, [showDisable2FAModal]);
+
+    const accountsCount = accounts.length;
+    if (accounts.length === 0) {
+        return null;
+    }
+
+    return (
+        <Container className='banner-container'>
+            <div className='alert-container'>
+                <AlertTriangleIcon color={'#DC1F25'} />
+            </div>
+            <div className='content'>
+                <h4 className='title'>
+                    <Translate id='twoFactorDisbleBanner.title' data={{ accountsCount, plural: accountsCount > 1 ? 's' : '' }} />
+                </h4>
+                <div className='desc'>
+                    <Translate id='twoFactorDisbleBanner.desc' />
+                </div>
+            </div>
+            <FormButton
+                onClick={showModal}
+                color='red'
+            >
+                <LockIcon color='#FEF2F2' /> 
+                <Translate id='twoFactorDisbleBanner.button' />
+            </FormButton>
+            {
+                showDisable2FAModal && (
+                    <Disable2FAModal
+                        onClose={hideModal}
+                        handleSetActiveView={hideModal}
+                    />
+                )
+            }
+        </Container>
+    );
+};

--- a/packages/frontend/src/components/wallet-migration/AccountLock.jsx
+++ b/packages/frontend/src/components/wallet-migration/AccountLock.jsx
@@ -57,13 +57,18 @@ const Textarea = styled.textarea`
 `;
 
 
-const AccountLockModal = ({ accountId, onClose, onComplete }) => {
+const AccountLockModal = ({ accountId, onClose, onComplete, onCancel }) => {
     const [isContinue, setIsContinue] = useState(false);
     const [passphrase, setPassphrase] = useState('');
     const [isLoading, setLoading] = useState(false);
 
     const onContinue = () => setIsContinue(true);
     const onBack = () => setIsContinue(false);
+
+    const onModalCancel = () => {
+        onCancel();
+        onClose();
+    };
     
     const onSetPassphrase = (e) => setPassphrase(e.target.value);
 
@@ -95,10 +100,10 @@ const AccountLockModal = ({ accountId, onClose, onComplete }) => {
                     <>
                             <IconSecurityLock />
                             <h4 className='title'><Translate id='twoFactorDisableLocked.title' /></h4>
-                            <p><Translate id='twoFactorDisableLocked.descOne' /></p>
+                            <p><Translate id='twoFactorDisableLocked.descOne' /><b>{accountId}</b></p>
                             <p><Translate id='twoFactorDisableLocked.descTwo' /></p>
                             <ButtonsContainer>
-                                <StyledButton className="gray-blue" onClick={onClose}>
+                                <StyledButton className="gray-blue" onClick={onModalCancel}>
                                     <Translate id='button.cancel' />
                                 </StyledButton>
                                 <StyledButton onClick={onContinue}>

--- a/packages/frontend/src/components/wallet-migration/AccountLock.jsx
+++ b/packages/frontend/src/components/wallet-migration/AccountLock.jsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import { Translate } from 'react-localize-redux';
+import styled from 'styled-components';
+
+import IconSecurityLock from '../../images/wallet-migration/IconSecurityLock';
+import { TwoFactor } from '../../utils/twoFactor';
+import FormButton from '../common/FormButton';
+import Modal from '../common/modal/Modal';
+
+const Container = styled.div`
+    padding: 15px 0;
+    text-align: center;
+    margin: 0 auto;
+
+    @media (max-width: 360px) {
+        padding: 0;
+    }
+
+    @media (min-width: 500px) {
+        padding: 48px 28px 12px;
+    }
+
+    .accountsTitle {
+        text-align: left;
+        font-size: 12px;
+        padding-top: 72px;
+        padding-bottom: 6px;
+    }
+
+    .title{
+        font-weight: 800;
+        font-size: 20px;
+        margin-top: 40px;
+    }
+`;
+
+const ButtonsContainer = styled.div`
+    text-align: center;
+    width: 100% !important;
+    display: flex;
+    ${(props) => (props.vertical && 'flex-direction: column;')}
+`;
+
+const StyledButton = styled(FormButton)`
+    width: ${(props) => (props.fullWidth ? '100%': 'calc((100% - 16px) / 2);' )}
+    margin: 48px 0 0 !important;
+
+    &:last-child {
+        ${(props) => (!props.fullWidth && 'margin-left: 16px !important;')}
+    }
+`;
+
+const Textarea = styled.textarea`
+    resize: none;
+    margin-top: 50px;
+    height: 130px;
+`;
+
+
+const AccountLockModal = ({ accountId, onClose, onComplete }) => {
+    const [isContinue, setIsContinue] = useState(false);
+    const [passphrase, setPassphrase] = useState('');
+    const [isLoading, setLoading] = useState(false);
+
+    const onContinue = () => setIsContinue(true);
+    const onBack = () => setIsContinue(false);
+    
+    const onSetPassphrase = (e) => setPassphrase(e.target.value);
+
+    const onButtonClick = () => {
+        setLoading(true);
+        TwoFactor.disableMultisigWithFAK({ accountId, seedPhrase: passphrase.trim(), cleanupState: false })
+            .then(() => {
+                setLoading(false);
+                onComplete();
+                onClose();
+            }).catch((e) => {
+                setLoading(false);
+                throw new Error(e.message);
+            });
+    };
+
+    return (
+        <Modal
+            modalClass="slim"
+            id='migration-modal'
+            isOpen={true}
+            disableClose={true}
+            modalSize='md'
+            style={{ maxWidth: '435px' }}
+        >
+            <Container>
+                {
+                    !isContinue ? (
+                    <>
+                            <IconSecurityLock />
+                            <h4 className='title'><Translate id='twoFactorDisableLocked.title' /></h4>
+                            <p><Translate id='twoFactorDisableLocked.descOne' /></p>
+                            <p><Translate id='twoFactorDisableLocked.descTwo' /></p>
+                            <ButtonsContainer>
+                                <StyledButton className="gray-blue" onClick={onClose}>
+                                    <Translate id='button.cancel' />
+                                </StyledButton>
+                                <StyledButton onClick={onContinue}>
+                                    <Translate id={'button.continue'} />
+                                </StyledButton>
+                            </ButtonsContainer>
+                        </>
+                    ) : (
+                        <>
+                            <h4 className='title'><Translate id='twoFactorRemoveAuth.title' /></h4>
+                            <p><Translate id='twoFactorRemoveAuth.desc' /></p>
+                            <h4>{accountId}</h4>
+                            <Textarea value={passphrase} onChange={onSetPassphrase} disabled={isLoading} />
+                            <ButtonsContainer vertical>
+                                <StyledButton
+                                    className="blue"
+                                    onClick={onButtonClick}
+                                    disabled={!passphrase}
+                                    sending={isLoading}
+                                    sendingString='twoFactorRemoveAuth.button'
+                                    fullWidth
+                                >
+                                    <Translate id='twoFactorRemoveAuth.button' />
+                                </StyledButton>
+                                <StyledButton className="white-blue" onClick={onBack} fullWidth>
+                                    <Translate id='button.cancel' />
+                                </StyledButton>
+                            </ButtonsContainer>
+                        </>
+                    )
+                }
+            </Container>
+        </Modal>
+    );
+};
+
+export default AccountLockModal;

--- a/packages/frontend/src/components/wallet-migration/Disable2FA.jsx
+++ b/packages/frontend/src/components/wallet-migration/Disable2FA.jsx
@@ -150,11 +150,14 @@ const Disable2FAModal = ({ handleSetActiveView, onClose }) => {
 
     const onAccountLockClose = () => { 
         setCurrentBrickedAccount(null);
-        localDispatch({ type: ACTIONS.SET_CURRENT_FAILED_AND_END_PROCESS });
     };
 
     const onAccountLockComplete = () => {
         localDispatch({ type: ACTIONS.SET_CURRENT_DONE });
+    };
+
+    const onAccountLockCancel = () => {
+        localDispatch({ type: ACTIONS.SET_CURRENT_FAILED_AND_END_PROCESS });
     };
 
     return (
@@ -162,8 +165,9 @@ const Disable2FAModal = ({ handleSetActiveView, onClose }) => {
         <Modal
             modalClass="slim"
             id='migration-modal'
-            isOpen={true}
-            disableClose={true}
+            isOpen={!currentBrickedAccount}
+            disableClose={!currentBrickedAccount}
+            onClose={() => {}}
             modalSize='md'
             style={{ maxWidth: '435px' }}
         >
@@ -193,7 +197,7 @@ const Disable2FAModal = ({ handleSetActiveView, onClose }) => {
                 }
             </Container>
         </Modal>
-        { currentBrickedAccount && <AccountLockModal accountId={currentBrickedAccount} onClose={onAccountLockClose} onComplete={onAccountLockComplete} /> }
+        { currentBrickedAccount && <AccountLockModal accountId={currentBrickedAccount} onClose={onAccountLockClose} onComplete={onAccountLockComplete} onCancel={onAccountLockCancel} /> }
         </>
     );
 };

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1701,8 +1701,8 @@
         }
     },
     "twoFactorDisbleBanner": {
-        "desc": "NEAR wallet will soon remove support for two-factor authentication, please disable 2FA for your connected accounts.",
-        "title": "${accountsCount} Account${Plural} Need Your Attention",
+        "desc": "NEAR wallet (wallet.near.org) will soon remove support for two-factor authentication, please disable 2FA for your connected accounts.",
+        "title": "${accountsCount} ${context} Your Attention",
         "button": "Disable 2FA"
     },
     "twoFactorDisableLocked": {

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1700,6 +1700,11 @@
             "title": "Enter Two-Factor Verification Code"
         }
     },
+    "twoFactorDisbleBanner": {
+        "desc": "NEAR wallet will soon be remove support for two-factor authentication, please disable 2FA for your connected accounts.",
+        "title": "${accountsCount} Account${Plural} Need Your Attention",
+        "button": "Disable 2FA"
+    },
     "unlockedAvailTransfer": "This NEAR is unlocked, and can be transferred out of your lockup contract.",
     "unlockedBalance": "This NEAR is still in a lockup contract, but unlocked.",
     "unvestedBalance": "Unvested NEAR is earmarked to you, but not yet under your ownership. You can still delegate or stake this NEAR, and the rewards will be entirely yours. As your NEAR is vested, it will appear in either your Locked or Unlocked balance.",

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1707,7 +1707,7 @@
     },
     "twoFactorDisableLocked": {
         "title": "Is your account locked?",
-        "descOne": "We couldn’t verify your 2FA method.",
+        "descOne": "We couldn’t verify your 2FA method for ",
         "descTwo": "If you can no longer access your account, you can rotate your keys and recover it. You will need your secure passphrase to unlock your account."
     },
     "twoFactorRemoveAuth": {

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1657,7 +1657,7 @@
     "twoFactor": {
         "action": {
             "addKey": {
-                "full": "WARNING: Entering the code below will authorize full access to your NEAR account: ${accountId}. If you did not initiate this action, please DO NOT continue.<br /><br />This should only be done if you are adding a new full access key to your account. In all other cases, this is very dangerous.<br /><br /> The public key you are adding is: ${publicKey} ",
+                "full": "Entering the code below will authorize full access to your NEAR account: ${accountId} If you did not initiate this action, please DO NOT continue.",
                 "limited": "Adding key ${publicKey} limited to call ${methodNames} on ${receiverId} and spend up to ${allowance} NEAR on gas"
             },
             "deleteKey": "Deleting key ${publicKey}",
@@ -1701,9 +1701,19 @@
         }
     },
     "twoFactorDisbleBanner": {
-        "desc": "NEAR wallet will soon be remove support for two-factor authentication, please disable 2FA for your connected accounts.",
+        "desc": "NEAR wallet will soon remove support for two-factor authentication, please disable 2FA for your connected accounts.",
         "title": "${accountsCount} Account${Plural} Need Your Attention",
         "button": "Disable 2FA"
+    },
+    "twoFactorDisableLocked": {
+        "title": "Is your account locked?",
+        "descOne": "We couldn’t verify your 2FA method.",
+        "descTwo": "If you can no longer access your account, you can rotate your keys and recover it. You will need your secure passphrase to unlock your account."
+    },
+    "twoFactorRemoveAuth": {
+        "title": "Remove Two-Factor Authentication?",
+        "desc": "Enter your secure passphrase to remove 2FA from the account:",
+        "button": "Remove 2FA"
     },
     "unlockedAvailTransfer": "This NEAR is unlocked, and can be transferred out of your lockup contract.",
     "unlockedBalance": "This NEAR is still in a lockup contract, but unlocked.",


### PR DESCRIPTION
This PR contains implementation for showing Disable 2FA banner for near wallet.
(Please check [ticket](https://nearinc.atlassian.net/browse/WEP-99) for further details)

Banner
![image](https://user-images.githubusercontent.com/6027014/192761984-b35e4bfc-d489-4f9f-8310-0c0351f5e0e9.png)

Modal
<img width="445" alt="image" src="https://user-images.githubusercontent.com/6027014/192762089-c09bfd5b-cd71-4a3f-b2f1-4ad451745c4f.png">

Account lock Modal (only show if target account is bricked)
<img width="580" alt="image" src="https://user-images.githubusercontent.com/6027014/192763689-d4358f95-bf23-45d0-9b2c-0ba583d27866.png">

Reset via passphrase
<img width="543" alt="image" src="https://user-images.githubusercontent.com/6027014/192763752-0599d876-21e8-4589-8313-f6fd6054d3b5.png">

If anyone need help with manually creating bricked account, please let me know.