### PR TITLE
[WEP-161 ]fix: error handling

### DIFF
--- a/packages/frontend/netlify.toml
+++ b/packages/frontend/netlify.toml
@@ -3,6 +3,9 @@
     command = "yarn build"
     ignore = "/bin/false"
 
+[build.environment]
+    NETLIFY_USE_YARN = "true"
+
 [[headers]]
     for = "/*"
     [headers.values]

--- a/packages/frontend/src/components/wallet-migration/AccountLock.jsx
+++ b/packages/frontend/src/components/wallet-migration/AccountLock.jsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import { Translate } from 'react-localize-redux';
+import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 
 import IconSecurityLock from '../../images/wallet-migration/IconSecurityLock';
+import { showCustomAlert } from '../../redux/actions/status';
 import { TwoFactor } from '../../utils/twoFactor';
 import FormButton from '../common/FormButton';
 import Modal from '../common/modal/Modal';
@@ -61,6 +63,7 @@ const AccountLockModal = ({ accountId, onClose, onComplete, onCancel }) => {
     const [isContinue, setIsContinue] = useState(false);
     const [passphrase, setPassphrase] = useState('');
     const [isLoading, setLoading] = useState(false);
+    const dispatch = useDispatch();
 
     const onContinue = () => setIsContinue(true);
     const onBack = () => setIsContinue(false);
@@ -81,6 +84,19 @@ const AccountLockModal = ({ accountId, onClose, onComplete, onCancel }) => {
                 onClose();
             }).catch((e) => {
                 setLoading(false);
+                let err;
+                if (e.message.includes('did not match a signature of')) {
+                    err = 'The passphrase you entered does not match this account. Please try again with another key.';
+                }
+
+                if (err) {
+                    dispatch(showCustomAlert({
+                        errorMessage: err,
+                        success: false,
+                        messageCodeHeader: 'error'
+                    }));
+                }
+                
                 throw new Error(e.message);
             });
     };

--- a/packages/frontend/src/components/wallet-migration/Disable2FA.jsx
+++ b/packages/frontend/src/components/wallet-migration/Disable2FA.jsx
@@ -7,6 +7,7 @@ import { useImmerReducer } from 'use-immer';
 import { NETWORK_ID } from '../../config';
 import IconSecurityLock from '../../images/wallet-migration/IconSecurityLock';
 import { switchAccount } from '../../redux/actions/account';
+import { showCustomAlert } from '../../redux/actions/status';
 import { selectAccountId } from '../../redux/slices/account';
 import WalletClass, { wallet } from '../../utils/wallet';
 import AccountListImport from '../accounts/AccountListImport';
@@ -132,6 +133,12 @@ const Disable2FAModal = ({ handleSetActiveView, onClose }) => {
                     localDispatch({ type: ACTIONS.SET_CURRENT_DONE });
                 }
             } catch (e) {
+                dispatch(showCustomAlert({
+                    errorMessage: e.message,
+                    success: false,
+                    messageCodeHeader: 'error'
+                }));
+                await new Promise((r) => setTimeout(r, 3000));
                 localDispatch({ type: ACTIONS.SET_CURRENT_FAILED_AND_END_PROCESS });
             } finally {
                 await dispatch(switchAccount({accountId: initialAccountId.current}));


### PR DESCRIPTION
The batch disable 2fa flow fails without any errors to the users. There are a few errors and hints we want to give the user:

- If the user tries to disable 2fa within 15 mins of each other for the same account
- The user hits cancel on the input 2fa code screen(let user know to wait 15 mins if they want to try again)
- When the user has a bricked account and enters the wrong key phrase into the modal. 

<img width="966" alt="image" src="https://user-images.githubusercontent.com/25015977/193162978-faacf067-ae69-421c-9a81-9b072f587c5c.png">


<img width="337" alt="image" src="https://user-images.githubusercontent.com/25015977/193163010-3e508da6-f34b-4a1b-9dc6-ff2d5095bc88.png">
