### PR TITLE
fix: removed NETLIFY_USE_YARN from Netlify.toml

### DIFF
--- a/packages/frontend/netlify.toml
+++ b/packages/frontend/netlify.toml
@@ -2,6 +2,7 @@
     publish = "./dist"
     command = "yarn build"
     ignore = "/bin/false"
+
 [[headers]]
     for = "/*"
     [headers.values]

--- a/packages/frontend/netlify.toml
+++ b/packages/frontend/netlify.toml
@@ -2,10 +2,6 @@
     publish = "./dist"
     command = "yarn build"
     ignore = "/bin/false"
-
-[build.environment]
-    NETLIFY_USE_YARN = "true"
-
 [[headers]]
     for = "/*"
     [headers.values]


### PR DESCRIPTION
removed NETLIFY_USE_YARN var as it is set in Netlify UI now. This will let forks build previews after this release. 