### PR TITLE
fix: update translation on TwoFactorDisableBanner

### DIFF
--- a/packages/frontend/src/components/common/TwoFactorDisableBanner.js
+++ b/packages/frontend/src/components/common/TwoFactorDisableBanner.js
@@ -144,7 +144,13 @@ export default function TwoFactorDisableBanner() {
             </div>
             <div className='content'>
                 <h4 className='title'>
-                    <Translate id='twoFactorDisbleBanner.title' data={{ accountsCount, context: accountsCount === 1 ? 'Account Needs' : 'Accounts Need'}} />
+                    { accountsCount }
+                    {' '}
+                    {
+                        accountsCount > 1
+                            ? <Translate id='twoFactorDisbleBanner.titlePlural' />
+                            : <Translate id='twoFactorDisbleBanner.titleSingular' />
+                    }
                 </h4>
                 <div className='desc'>
                     <Translate id='twoFactorDisbleBanner.desc' />

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1702,7 +1702,8 @@
     },
     "twoFactorDisbleBanner": {
         "desc": "NEAR wallet (wallet.near.org) will soon remove support for two-factor authentication, please disable 2FA for your connected accounts.",
-        "title": "${accountsCount} ${context} Your Attention",
+        "titleSingular": "Account Needs Your Attention",
+        "titlePlural": "Accounts Need Your Attention",
         "button": "Disable 2FA"
     },
     "twoFactorDisableLocked": {


### PR DESCRIPTION
This PR contains minor fix on TwoFactorDisableBanner component to allow foreign language translation.

Closes #2935 

Singular:
<img width="1126" alt="image" src="https://user-images.githubusercontent.com/6027014/193670072-57ad599a-0e74-454d-877a-5bb143c79d69.png">

Plural:
<img width="1060" alt="image" src="https://user-images.githubusercontent.com/6027014/193670601-2387d078-d0fa-4475-bd78-44cd7782ff44.png">
