### PR TITLE
feat: remove modal all together unless the user has 2fa enabled

### DIFF
--- a/packages/frontend/src/components/profile/Profile.js
+++ b/packages/frontend/src/components/profile/Profile.js
@@ -336,7 +336,7 @@ export function Profile({ match }) {
                         {(shouldShowEmail || shouldShowPhone) && <h4><Translate id='profile.security.lessSecure' /><Tooltip translate='profile.security.lessSecureDesc' icon='icon-lg' /></h4>}
                         {shouldShowEmail && <RecoveryContainer type='email' recoveryMethods={userRecoveryMethods} />}
                         {shouldShowPhone && <RecoveryContainer type='phone' recoveryMethods={userRecoveryMethods} />}
-                        {(twoFactor || !hasLedger) && (
+                        {twoFactor && (
                             <>
                                 <hr />
                                 <h2><LockIcon /><Translate id='profile.twoFactor' /></h2>

--- a/packages/frontend/src/components/profile/two_factor/TwoFactorAuth.js
+++ b/packages/frontend/src/components/profile/two_factor/TwoFactorAuth.js
@@ -1,27 +1,19 @@
-import { utils } from 'near-api-js';
 import React, { useState } from 'react';
 import { Translate } from 'react-localize-redux';
 import { useSelector, useDispatch } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { MULTISIG_MIN_AMOUNT } from '../../../config';
 import { disableMultisig } from '../../../redux/actions/account';
 import { selectAccountSlice } from '../../../redux/slices/account';
 import { actions as recoveryMethodsActions } from '../../../redux/slices/recoveryMethods';
 import { selectActionsPending } from '../../../redux/slices/status';
-import { selectNearTokenFiatValueUSD } from '../../../redux/slices/tokenFiatValues';
-import { getNearAndFiatValue } from '../../common/balance/helpers';
 import FormButton from '../../common/FormButton';
 import Card from '../../common/styled/Card.css';
-import SafeTranslate from '../../SafeTranslate';
 import AccountLockModal from '../../wallet-migration/AccountLock';
 import ConfirmDisable from '../hardware_devices/ConfirmDisable';
 const { fetchRecoveryMethods } = recoveryMethodsActions;
 
-const {
-    parseNearAmount
-} = utils.format;
 
 const Container = styled(Card)`
     margin-top: 30px;
@@ -68,7 +60,6 @@ const TwoFactorAuth = ({ twoFactor, history, isBrickedAccount, onDisableBrickedA
     const [confirmDisable, setConfirmDisable] = useState(false);
     const [showBrickedAccountModal, setShowBrickedAccountModal] = useState(false);
     const account = useSelector(selectAccountSlice);
-    const nearTokenFiatValueUSD = useSelector(selectNearTokenFiatValueUSD);
     const dispatch = useDispatch();
     const confirmDisabling = useSelector((state) => selectActionsPending(state, { types: ['DISABLE_MULTISIG'] }));
 
@@ -127,30 +118,6 @@ const TwoFactorAuth = ({ twoFactor, history, isBrickedAccount, onDisableBrickedA
             )}
             {twoFactor && isBrickedAccount && showBrickedAccountModal && (
                 <AccountLockModal accountId={account.accountId} onClose={onAccountLockClose} onComplete={onAccountLockComplete} onCancel={onAccountLockCancel} />
-            )}
-            {!twoFactor && (
-                <div className='method'>
-                    <div className='top'>
-                        <div className='title'><Translate id='twoFactor.notEnabled' /></div>
-                        <FormButton
-                            onClick={() => history.push('/enable-two-factor')}
-                            trackingId="2FA Click enable button"
-                            disabled={true}
-                        >
-                            <Translate id='button.enable' />
-                        </FormButton>
-                    </div>
-                    {!account.canEnableTwoFactor && (
-                        <div className='color-red'>
-                            <SafeTranslate
-                                id='twoFactor.notEnoughBalance'
-                                data={{
-                                    amount: getNearAndFiatValue(parseNearAmount(MULTISIG_MIN_AMOUNT), nearTokenFiatValueUSD)
-                                }}
-                            />
-                        </div>
-                    )}
-                </div>
             )}
         </Container>
     );


### PR DESCRIPTION
Instead of graying out the 2fa Enable button in the 2fa component, we will remove the 2fa component all together to not confuse the user. 

The change will also effect MNW. 

If the user has 2fa enabled, they will still be shown the 2fa disable component.  

**Switching between an account with and without 2fa enabled**
![2fa_account_vs_non_2fa_account](https://user-images.githubusercontent.com/25015977/193871357-5dc845d0-d83f-4de2-9a3e-7c2d5824e4e3.gif)


**Disabling 2fa on an account**
![remove_2fa](https://user-images.githubusercontent.com/25015977/193871468-08c98a1a-d8bd-407e-a21d-70aa07675875.gif)
