### PR TITLE
fix: only show Finer Wallet if device is iOS

### DIFF
--- a/packages/frontend/src/components/wallet-migration/SelectDestinationWallet.jsx
+++ b/packages/frontend/src/components/wallet-migration/SelectDestinationWallet.jsx
@@ -74,7 +74,7 @@ const WALLET_OPTIONS = [
         name: 'FiNER Wallet',
         icon: <img src={ImgFinerWallet} alt="Finer Wallet Logo" />,
         getUrl: ({ hash }) => `finer://wallet.near.org/batch-import#${hash}`,
-        checkAvailability: () => isMobile(),
+        checkAvailability: () => isMobile('iOS'),
     },
 ];
 

--- a/packages/frontend/src/utils/isMobile.js
+++ b/packages/frontend/src/utils/isMobile.js
@@ -1,9 +1,13 @@
-const isMobile = () => {
+const isMobile = (target) => {
     let userAgent = navigator.userAgent || navigator.vendor || window.opera;
 
     const windows = /windows phone/i.test(userAgent);
     const android = /android/i.test(userAgent);
     const iOs = /iPad|iPhone|iPod/.test(userAgent) && !window.MSStream;
+
+    if (target === 'iOS') {
+        return iOs;
+    }
 
     return windows || android || iOs;
 };


### PR DESCRIPTION
During wallet migration, only show `Finer Wallet` from migration list if the device is iOS.
[They](https://finerwallet.io/) only support iOS apps at the moment.

This is to avoid any android (and window 😄 ) phone users accidentally selecting  Finer Wallet. 

