### PR TITLE
Minor UI update on wallet migration [WEB-188]

### DIFF
--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -362,7 +362,8 @@ class Routing extends Component {
                         <NavigationWrapper />
                         <GlobalAlert />
                         {
-                            !isWhitelabel && (
+                            // TODO: Remove TwoFactorDisableBanner when we push MigrationBanner to mainnet
+                            !isWhitelabel && !SHOW_MIGRATION_BANNER && (
                                 <Switch>
                                     <Route
                                         path={['/', '/staking', '/profile']} component={TwoFactorDisableBanner}

--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -358,13 +358,6 @@ class Routing extends Component {
                 >
                     <ThemeProvider theme={theme}>
                         <ScrollToTop />
-                        {
-                            SHOW_MIGRATION_BANNER && (
-                                <MigrationBanner
-                                    account={account}
-                                    onTransfer={this.handleTransferClick} />
-                            )}
-
                         <NetworkBanner account={account} />
                         <NavigationWrapper />
                         <GlobalAlert />
@@ -373,6 +366,21 @@ class Routing extends Component {
                                 <Switch>
                                     <Route
                                         path={['/', '/staking', '/profile']} component={TwoFactorDisableBanner}
+                                    />
+                                </Switch>
+                            )
+                        }
+                        {
+                            
+                            SHOW_MIGRATION_BANNER && (
+                                <Switch>
+                                    <Route
+                                        path={['/', '/staking', '/profile']} render={() => (
+                                            <MigrationBanner
+                                                account={account}
+                                                onTransfer={this.handleTransferClick} 
+                                            />
+                                        )}
                                     />
                                 </Switch>
                             )

--- a/packages/frontend/src/components/accounts/recovery_setup/new_account/ConfirmPassphrase.js
+++ b/packages/frontend/src/components/accounts/recovery_setup/new_account/ConfirmPassphrase.js
@@ -7,6 +7,11 @@ import Container from '../../../common/styled/Container.css';
 import SafeTranslate from '../../../SafeTranslate';
 
 const StyledContainer = styled(Container)`
+    ${({ flat }) => flat && `
+        margin: 0px !important;
+        max-width: fit-content !important;
+    `} 
+
     h4 {
         margin-top: 20px;
     }
@@ -40,10 +45,12 @@ export default ({
     handleChangeWord,
     handleStartOver,
     userInputValueWrongWord,
-    finishingSetup
+    finishingSetup,
+    flat,
 }) => {
+
     return (
-        <StyledContainer className='small-centered border'>
+        <StyledContainer className='small-centered border' flat={flat}>
             <form
                 onSubmit={(e) => {
                     handleConfirmPassphrase();

--- a/packages/frontend/src/components/accounts/recovery_setup/new_account/SavePassphrase.js
+++ b/packages/frontend/src/components/accounts/recovery_setup/new_account/SavePassphrase.js
@@ -9,14 +9,14 @@ export default ({
     refreshPhrase,
     onClickContinue,
     onClickCancel,
-    accountId
+    accountId,
+    style,
 }) => {
     return (
-        <Container className='small-centered border'>
-            {accountId ?
-                <h1><Translate id='setupSeedPhrase.pageTitleWithAccountId' data={{ accountId }} /></h1>
-                :
-                <h1><Translate id='setupSeedPhrase.pageTitle' /></h1>
+        <Container className='small-centered border' style={style}>
+            <h1><Translate id='setupSeedPhrase.pageTitle' /></h1>
+            {
+                accountId && (<h2><b>{accountId}</b></h2>)
             }
             <h2><Translate id='setupSeedPhrase.pageText' /></h2>
             <SetupSeedPhraseForm

--- a/packages/frontend/src/components/common/MigrationBanner.js
+++ b/packages/frontend/src/components/common/MigrationBanner.js
@@ -1,36 +1,55 @@
-import React, {useCallback, useEffect} from 'react';
+import React, {useCallback} from 'react';
 import { Translate } from 'react-localize-redux';
 import {useSelector} from 'react-redux';
 import styled from 'styled-components';
 
-import { MIGRATION_START_DATE } from '../../config';
-import IconAlertTriangle from '../../images/IconAlertTriangle';
 import IconOffload from '../../images/IconOffload';
-import {selectAvailableAccounts} from '../../redux/slices/availableAccounts';
+import { selectAvailableAccounts, selectAvailableAccountsIsLoading } from '../../redux/slices/availableAccounts';
 import { getMyNearWalletUrl } from '../../utils/getWalletURL';
+import AlertTriangleIcon from '../svg/AlertTriangleIcon';
+import InfoIcon from '../svg/InfoIcon';
 import FormButton from './FormButton';
 import Container from './styled/Container.css';
 
 const StyledContainer = styled.div`
-    color: #995200;
-    background-color: #FFECD6;
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
+    border: 2px solid #DC1F26;
+    border-radius: 16px;
+    background-color: #FFFCFC;
+    
     display: flex;
-    align-items: center;
-    justify-content: center;
+    align-items: flex-start;
+    flex-direction: row;
+    padding: 25px;
+    margin: 25px auto;
+    line-height: 1.5;
 
-    a {
-        color: #995200;
-        text-decoration: underline;
-        cursor: pointer;
+    @media (min-width: 768px) {
+        width: 720px;
+    }
 
-        :hover {
-            color: #995200;
+    @media (min-width: 992px) {
+        width: 920px;
+    }
+
+    @media (min-width: 1200px) {
+        width: 1000px;
+    }
+
+    .alert-container {
+        background-color: #FFEFEF;
+        border-radius: 50%;
+        padding: 9px;
+        margin-right: 16px;
+        display: flex;
+        justify-content: center;
+        @media (max-width: 768px) {
+            margin: 0 auto 15px;
         }
+        .alert-triangle-icon {
+            width: 25px;
+            height: 25px;
+        }
+     
     }
 `;
 
@@ -58,22 +77,22 @@ const ContentWrapper =  styled(Container)`
         display: flex;
         align-items: flex-start;
         flex-wrap: none;
+        color: #CD2B31;
 
-        svg {
-            margin-right: 18px;
-            min-width: 24px;
+        > span > a {
+            color: #CD2B31;
+            text-decoration: underline;
         }
     }
 `;
 
 const CustomButton = styled(FormButton)`
-    color: #452500 !important;
-    background-color: #FFB259 !important;
+    color: #FEF2F2 !important;
+    background: #FC5B5B !important;
     border: none !important;
     white-space: nowrap;
     padding: 11px 16px;
     margin: 0 !important;
-    height: 40px;
 
     @media (max-width: 768px) {
         margin-top: 16px !important;
@@ -87,20 +106,7 @@ const IconWrapper = styled.div`
 
 const MigrationBanner = ({ account, onTransfer }) => {
     const availableAccounts = useSelector(selectAvailableAccounts);
-
-    const setBannerHeight = () => {
-        const migrationBanner = document.getElementById('migration-banner');
-        const bannerHeight = migrationBanner ? migrationBanner.offsetHeight : 0;
-        const networkBanner = document.getElementById('top-banner');
-        if (networkBanner) {
-            networkBanner.style.top = bannerHeight ? `${bannerHeight}px` : 0;
-        } else {
-            const app = document.getElementById('app-container');
-            const navContainer = document.getElementById('nav-container');
-            navContainer.style.top = bannerHeight ? `${bannerHeight}px` : 0;
-            app.style.paddingTop = bannerHeight ? `${bannerHeight + 85}px` : '75px';
-        }
-    };
+    const availableAccountsIsLoading = useSelector(selectAvailableAccountsIsLoading);
 
     const onTransferClick = useCallback(() => {
         if (availableAccounts.length) {
@@ -108,48 +114,42 @@ const MigrationBanner = ({ account, onTransfer }) => {
             return;
         }
 
-        window.open(getMyNearWalletUrl(), '_blank');
+        window.open('https://near.org/blog/near-opens-the-door-to-more-wallets/', '_blank');
     }, [availableAccounts]);
 
-
-    useEffect(() => {
-        setBannerHeight();
-        window.addEventListener('resize', setBannerHeight);
-        return () => {
-            window.removeEventListener('resize', setBannerHeight);
-        };
-    }, [account]);
+    // If accounts area loading, don't show the banner
+    if (availableAccountsIsLoading) {
+        return null;
+    }
 
     return (
         <StyledContainer id='migration-banner'>
             <ContentWrapper>
                 <div className='content'>
-                    <IconAlertTriangle/>
+                    <div className='alert-container'>
+                        <AlertTriangleIcon color={'#E5484D'} />
+                    </div>
                     {
-                        availableAccounts.length ? (
-                            <Translate id='migration.message' data={{
-                                startDate: MIGRATION_START_DATE.toLocaleDateString(),
-                                url: 'https://near.org/blog/near-opens-the-door-to-more-wallets/'
-                            }}/>
-                        ) :
-                            <Translate id='migration.redirect' data={{ url: getMyNearWalletUrl() }}/>
+                        availableAccounts.length
+                            ? <Translate id='migration.message'/>
+                            : <Translate id='migration.redirect' data={{ url: getMyNearWalletUrl() }}/>
                     }
                 </div>
-                <Translate>
-                    {({ translate }) =>
-                        (<CustomButton onClick={onTransferClick}>
-                            <IconWrapper>
-                                <IconOffload/>
-                            </IconWrapper>
-                            {
-                                availableAccounts.length ?
-                                    <Translate id='migration.transferCaption' /> :
-                                    <Translate id='migration.redirectCaption' />
-                            }
-
-                        </CustomButton>)
+                
+                <CustomButton onClick={onTransferClick}>
+                    <IconWrapper>
+                        {
+                            availableAccounts.length
+                                ? <IconOffload stroke="#fff" />
+                                : <InfoIcon color="#fff" />
+                        }    
+                    </IconWrapper>
+                    {
+                        availableAccounts.length
+                            ? <Translate id='migration.transferCaption' />
+                            : <Translate id='migration.redirectCaption' />
                     }
-                </Translate>
+                </CustomButton>
             </ContentWrapper>
         </StyledContainer>
     );

--- a/packages/frontend/src/components/common/MigrationBanner.js
+++ b/packages/frontend/src/components/common/MigrationBanner.js
@@ -58,6 +58,7 @@ const ContentWrapper =  styled(Container)`
     align-items: center;
     justify-content: space-between;
     margin-top: 0;
+    padding: 0;
 
     &>*:first-child{
         margin-right: 10px;
@@ -83,6 +84,10 @@ const ContentWrapper =  styled(Container)`
             color: #CD2B31;
             text-decoration: underline;
         }
+
+        @media (max-width: 767px) {
+            flex-direction: column;
+        }
     }
 `;
 
@@ -91,9 +96,9 @@ const CustomButton = styled(FormButton)`
     background: #FC5B5B !important;
     border: none !important;
     white-space: nowrap;
-    padding: 11px 16px;
+    padding: 9.5px 16px;
     margin: 0 !important;
-
+    height: 40px !important;
     @media (max-width: 768px) {
         margin-top: 16px !important;
     }

--- a/packages/frontend/src/components/wallet-migration/CommonComponents.jsx
+++ b/packages/frontend/src/components/wallet-migration/CommonComponents.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import FormButton from '../common/FormButton';
+import Modal from '../common/modal/Modal';
+
+export const ButtonsContainer = styled.div`
+  text-align: center;
+  width: 100% !important;
+  display: flex;
+  ${(props) => (props.vertical && 'flex-direction: column;')}
+  @media (max-width: 650px) {
+    flex-direction: column;
+  }
+  padding-top: 48px;
+`;
+
+export const StyledButton = styled(FormButton)`
+  flex: 1;
+  ${(props) => (props.fullWidth ? 'width: 100%': '' )}
+  margin: 0 5px !important;
+  @media (max-width: 650px) {
+    flex-direction: column;
+    padding: 18px;
+	align-items: center;
+    &:last-child{
+      	margin-top: 16px !important;
+    }
+  }
+`;
+
+export const MigrationModal = ({ children, isOpen = true, onClose = () => {}, disableClose = true }) => {
+    return (
+        <Modal
+            modalClass="slim"
+            id='migration-modal'
+            isOpen={isOpen}
+            disableClose={disableClose}
+            modalSize='md'
+            style={{ maxWidth: '435px' }}
+            onClose={onClose}
+        >
+            {children}
+        </Modal>
+    );
+};

--- a/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
+++ b/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
@@ -34,7 +34,7 @@ const WalletMigration = ({ open, onClose }) => {
   
     useEffect(() => {
         if (open) {
-            handleSetActiveView(WALLET_MIGRATION_VIEWS.ROTATE_KEYS);
+            handleSetActiveView(WALLET_MIGRATION_VIEWS.DISABLE_2FA);
         } else {
             handleSetActiveView(null);
         }

--- a/packages/frontend/src/components/wallet-migration/modals/Disable2faModal/AccountLock.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/Disable2faModal/AccountLock.jsx
@@ -6,8 +6,7 @@ import styled from 'styled-components';
 import IconSecurityLock from '../../../../images/wallet-migration/IconSecurityLock';
 import { showCustomAlert } from '../../../../redux/actions/status';
 import { TwoFactor } from '../../../../utils/twoFactor';
-import FormButton from '../../../common/FormButton';
-import Modal from '../../../common/modal/Modal';
+import { ButtonsContainer, StyledButton, MigrationModal } from '../../CommonComponents';
 
 const Container = styled.div`
     padding: 15px 0;
@@ -33,22 +32,6 @@ const Container = styled.div`
         font-weight: 800;
         font-size: 20px;
         margin-top: 40px;
-    }
-`;
-
-const ButtonsContainer = styled.div`
-    text-align: center;
-    width: 100% !important;
-    display: flex;
-    ${(props) => (props.vertical && 'flex-direction: column;')}
-`;
-
-const StyledButton = styled(FormButton)`
-    width: ${(props) => (props.fullWidth ? '100%': 'calc((100% - 16px) / 2);' )}
-    margin: 48px 0 0 !important;
-
-    &:last-child {
-        ${(props) => (!props.fullWidth && 'margin-left: 16px !important;')}
     }
 `;
 
@@ -102,14 +85,7 @@ const AccountLockModal = ({ accountId, onClose, onComplete, onCancel }) => {
     };
 
     return (
-        <Modal
-            modalClass="slim"
-            id='migration-modal'
-            isOpen={true}
-            disableClose={true}
-            modalSize='md'
-            style={{ maxWidth: '435px' }}
-        >
+        <MigrationModal>
             <Container>
                 {
                     !isContinue ? (
@@ -152,7 +128,7 @@ const AccountLockModal = ({ accountId, onClose, onComplete, onCancel }) => {
                     )
                 }
             </Container>
-        </Modal>
+        </MigrationModal>
     );
 };
 

--- a/packages/frontend/src/components/wallet-migration/modals/Disable2faModal/Disable2FA.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/Disable2faModal/Disable2FA.jsx
@@ -14,10 +14,9 @@ import AccountListImport from '../../../accounts/AccountListImport';
 import { IMPORT_STATUS } from '../../../accounts/batch_import_accounts';
 import sequentialAccountImportReducer, { ACTIONS } from '../../../accounts/batch_import_accounts/sequentialAccountImportReducer';
 import LoadingDots from '../../../common/loader/LoadingDots';
-import Modal from '../../../common/modal/Modal';
 import { isAccountBricked } from '../..//utils';
+import { ButtonsContainer, StyledButton, MigrationModal } from '../../CommonComponents';
 import { WALLET_MIGRATION_VIEWS } from '../../WalletMigration';
-import FormButton from './../../../common/FormButton';
 import AccountLockModal from './AccountLock';
 
 
@@ -46,21 +45,6 @@ const Container = styled.div`
         font-weight: 800;
         font-size: 20px;
         margin-top: 40px;
-    }
-`;
-
-const ButtonsContainer = styled.div`
-    text-align: center;
-    width: 100% !important;
-    display: flex;
-`;
-
-const StyledButton = styled(FormButton)`
-    width: calc((100% - 16px) / 2);
-    margin: 48px 0 0 !important;
-
-    &:last-child{
-        margin-left: 16px !important;
     }
 `;
 
@@ -140,7 +124,7 @@ const Disable2FAModal = ({ handleSetActiveView, onClose }) => {
 
     useEffect(() => {
         if (completedWithSuccess) {
-            handleSetActiveView(WALLET_MIGRATION_VIEWS.SELECT_DESTINATION_WALLET);
+            handleSetActiveView(WALLET_MIGRATION_VIEWS.ROTATE_KEYS);
         }
     }, [completedWithSuccess]);
 
@@ -158,14 +142,10 @@ const Disable2FAModal = ({ handleSetActiveView, onClose }) => {
 
     return (
         <>
-        <Modal
-            modalClass="slim"
-            id='migration-modal'
+        <MigrationModal
             isOpen={!currentBrickedAccount}
             disableClose={!currentBrickedAccount}
             onClose={onClose}
-            modalSize='md'
-            style={{ maxWidth: '435px' }}
         >
             <Container>
                 {loadingMultisigAccounts ? <LoadingDots /> :
@@ -192,7 +172,7 @@ const Disable2FAModal = ({ handleSetActiveView, onClose }) => {
                     )
                 }
             </Container>
-        </Modal>
+        </MigrationModal>
         { currentBrickedAccount && <AccountLockModal accountId={currentBrickedAccount} onClose={onAccountLockClose} onComplete={onAccountLockComplete} onCancel={onAccountLockCancel} /> }
         </>
     );

--- a/packages/frontend/src/components/wallet-migration/modals/MigrateAccountsModal/MigrationSecret.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/MigrateAccountsModal/MigrationSecret.jsx
@@ -4,8 +4,7 @@ import styled from 'styled-components';
 
 import IconSecurityLock from '../../../../images/wallet-migration/IconSecurityLock';
 import ClickToCopy from '../../../common/ClickToCopy';
-import FormButton from '../../../common/FormButton';
-import Modal from '../../../common/modal/Modal';
+import { ButtonsContainer, StyledButton, MigrationModal } from '../../CommonComponents';
 
 
 const Container = styled.div`
@@ -39,22 +38,6 @@ const TextSelectDisplay = styled.div`
     text-align: center;
 `;
 
-const ButtonsContainer = styled.div`
-    text-align: center;
-    width: 100% !important;
-    display: flex;
-`;
-
-const StyledButton = styled(FormButton)`
-    width: calc((100% - 16px) / 2);
-    margin: 48px 0 0 !important;
-
-    &:last-child{
-        margin-left: 16px !important;
-    }
-`;
-
-
 const MigrationSecret = ({
     showMigrationPrompt,
     showMigrateAccount,
@@ -67,14 +50,7 @@ const MigrationSecret = ({
     }, []);
 
     return (
-        <Modal
-            modalClass='slim'
-            id='migration-modal'
-            isOpen={true}
-            disableClose={true}
-            modalSize='md'
-            style={{ maxWidth: '431px' }}
-        >
+        <MigrationModal>
             <Container>
                 <IconSecurityLock/>
                 <h3 className='title'>
@@ -102,7 +78,7 @@ const MigrationSecret = ({
                     </StyledButton>
                 </ButtonsContainer>
             </Container>
-        </Modal>
+        </MigrationModal>
     );
 };
 

--- a/packages/frontend/src/components/wallet-migration/modals/MigrateAccountsModal/SelectDestinationWallet.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/MigrateAccountsModal/SelectDestinationWallet.jsx
@@ -17,8 +17,7 @@ import {
     getMyNearWalletUrlFromNEARORG
 } from '../../../../utils/getWalletURL';
 import isMobile from '../../../../utils/isMobile';
-import FormButton from '../../../common/FormButton';
-import Modal from '../../../common/modal/Modal';
+import { ButtonsContainer, StyledButton, MigrationModal } from '../../CommonComponents';
 import {WALLET_EXPORT_MODAL_VIEWS} from './MigrateAccountsModal';
 const Container = styled.div`
     padding: 15px 0;
@@ -154,22 +153,6 @@ const WalletOptionsListingItem = styled.div`
     }
 `;
 
-const ButtonsContainer = styled.div`
-    text-align: center;
-    width: 100% !important;
-    display: flex;
-`;
-
-const StyledButton = styled(FormButton)`
-    width: calc((100% - 16px) / 2);
-    margin: 48px 0 0 !important;
-
-    &:last-child {
-        margin-left: 16px !important;
-    }
-`;
-
-
 const SelectDestinationWallet = ({ handleSetActiveView, handleSetWallet, wallet, onClose }) => {
     const dispatch = useDispatch();
     
@@ -185,14 +168,7 @@ const SelectDestinationWallet = ({ handleSetActiveView, handleSetWallet, wallet,
     }, [wallet, handleSetActiveView, handleSetWallet]);
     
     return (
-        <Modal
-            modalClass="slim"
-            id='migration-modal'
-            isOpen={true}
-            disableClose={true}
-            modalSize='md'
-            style={{ maxWidth: '435px' }}
-        >
+        <MigrationModal>
             <Container>
                 <IconWallet/>
                 <h4 className='title'><Translate id='walletMigration.selectWallet.title'/></h4>
@@ -224,7 +200,7 @@ const SelectDestinationWallet = ({ handleSetActiveView, handleSetWallet, wallet,
                     </StyledButton>
                 </ButtonsContainer>
             </Container>
-        </Modal>
+        </MigrationModal>
     );
 };
 

--- a/packages/frontend/src/components/wallet-migration/modals/MigrateAccountsModal/SelectDestinationWallet.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/MigrateAccountsModal/SelectDestinationWallet.jsx
@@ -38,6 +38,10 @@ const Container = styled.div`
         font-size: 20px;
         margin-top: 40px;
     }
+
+    .description {
+        margin-top: 25px;
+    }
 `;
 
 export const WALLET_OPTIONS = [
@@ -192,6 +196,7 @@ const SelectDestinationWallet = ({ handleSetActiveView, handleSetWallet, wallet,
             <Container>
                 <IconWallet/>
                 <h4 className='title'><Translate id='walletMigration.selectWallet.title'/></h4>
+                <h5 className='description'><Translate id='walletMigration.selectWallet.descOne'/></h5>
                 <WalletOptionsListing>
                     {WALLET_OPTIONS.map((walletOption) => {
                         if (!walletOption.checkAvailability()) {
@@ -209,6 +214,7 @@ const SelectDestinationWallet = ({ handleSetActiveView, handleSetWallet, wallet,
                         );
                     })}
                 </WalletOptionsListing>
+                <h6 className='description'><Translate id='walletMigration.selectWallet.descTwo'/></h6>
                 <ButtonsContainer>
                     <StyledButton className="gray-blue" onClick={onClose}>
                         <Translate id='button.cancel'/>

--- a/packages/frontend/src/components/wallet-migration/modals/RotateKeysModal/RotateKeysModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/RotateKeysModal/RotateKeysModal.jsx
@@ -16,25 +16,10 @@ import { IMPORT_STATUS } from '../../../accounts/batch_import_accounts';
 import sequentialAccountImportReducer, { ACTIONS } from '../../../accounts/batch_import_accounts/sequentialAccountImportReducer';
 import ConfirmPassphrase from '../../../accounts/recovery_setup/new_account/ConfirmPassphrase';
 import SavePassphrase from '../../../accounts/recovery_setup/new_account/SavePassphrase';
-import FormButton from '../../../common/FormButton';
 import LoadingDots from '../../../common/loader/LoadingDots';
 import Modal from '../../../common/modal/Modal';
+import { ButtonsContainer, StyledButton } from '../../CommonComponents';
 import { WALLET_MIGRATION_VIEWS } from '../../WalletMigration';
-
-const ButtonsContainer = styled.div`
-    text-align: center;
-    width: 100% !important;
-    display: flex;
-`;
-
-const StyledButton = styled(FormButton)`
-    width: calc((100% - 16px) / 2);
-    margin: 48px 0 0 !important;
-
-    &:last-child{
-        margin-left: 16px !important;
-    }
-`;
 
 const Container = styled.div`
     padding: 15px 0;
@@ -179,10 +164,11 @@ const RotateKeysModal = ({handleSetActiveView, onClose}) => {
     if (confirmPassphrase) {
         return (
             <Modal
-                modalClass="fullscreen"
+                modalClass="slim"
                 id='migration-modal'
                 onClose={onClose}
                 modalSize='md'
+                style={{ padding: '0px' }}
             >
                 <ConfirmPassphrase
                     wordIndex={wordIndex}
@@ -215,6 +201,7 @@ const RotateKeysModal = ({handleSetActiveView, onClose}) => {
                             setFinishingSetupForCurrentAccount(false);
                         }
                     }}
+                    flat
                 />
         
             </Modal>
@@ -228,6 +215,7 @@ const RotateKeysModal = ({handleSetActiveView, onClose}) => {
                    id='migration-modal'
                    onClose={onClose}
                    modalSize='lg'
+                   style={{ maxWidth: '528px' }}
                >
                    <SavePassphrase
                        passPhrase={currentPassphrase}
@@ -242,6 +230,7 @@ const RotateKeysModal = ({handleSetActiveView, onClose}) => {
                            setShowConfirmSeedphraseModal(() => false);
                        }}
                        accountId={currentAccount.accountId}
+                       style={{ marginTop: '0px' }}
                    />
                </Modal>
            )

--- a/packages/frontend/src/hooks/getCurrentLanguage.js
+++ b/packages/frontend/src/hooks/getCurrentLanguage.js
@@ -10,7 +10,7 @@ function getCurrentLanguage() {
     );
     const currentLanguage = useSelector(getlanguage);
 
-    return currentLanguage.code;
+    return currentLanguage?.code || 'en';
 }
 
 export default getCurrentLanguage;

--- a/packages/frontend/src/images/IconOffload.js
+++ b/packages/frontend/src/images/IconOffload.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
-export default ({ stroke = '#ccc' }) => (
+export default ({ stroke = '#995200' }) => (
     <svg width="14" height="16" viewBox="0 0 14 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M1.66666 8V13.3333C1.66666 13.687 1.80713 14.0261 2.05718 14.2761C2.30723 14.5262 2.64637 14.6667 2.99999 14.6667H11C11.3536 14.6667 11.6927 14.5262 11.9428 14.2761C12.1928 14.0261 12.3333 13.687 12.3333 13.3333V8" stroke="#995200" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-        <path d="M9.66668 4.00004L7.00001 1.33337L4.33334 4.00004" stroke="#995200" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-        <path d="M7 1.33337V10" stroke="#995200" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+        <path d="M1.66666 8V13.3333C1.66666 13.687 1.80713 14.0261 2.05718 14.2761C2.30723 14.5262 2.64637 14.6667 2.99999 14.6667H11C11.3536 14.6667 11.6927 14.5262 11.9428 14.2761C12.1928 14.0261 12.3333 13.687 12.3333 13.3333V8" stroke={stroke} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+        <path d="M9.66668 4.00004L7.00001 1.33337L4.33334 4.00004" stroke={stroke} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+        <path d="M7 1.33337V10" stroke={stroke} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
     </svg>
 
 );

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -291,7 +291,6 @@
         "goToDashboard": "Go To Dashboard",
         "importAccount": "Import Account",
         "importExistingAccount": "Import Existing Account",
-        "recoverExistingAccount": "Recover Existing Account",
         "learnMore": "Learn More",
         "learnMoreAboutNear": "Learn more about NEAR",
         "loading": "Loading",
@@ -303,6 +302,7 @@
         "receive": "Receive",
         "reconnect": "Reconnect",
         "recoverAccount": "Recover Account",
+        "recoverExistingAccount": "Recover Existing Account",
         "recovering": "Finding Account",
         "recoverYourAccount": "Recover your Account",
         "removeAccount": "Remove Account",
@@ -1334,7 +1334,6 @@
     "setupSeedPhrase": {
         "pageText": "Write down the following words in order and keep them somewhere safe. <b>Anyone with access to it will also have access to your account!</b> You’ll be asked to verify your passphrase next.",
         "pageTitle": "Setup Your Secure Passphrase",
-        "pageTitleWithAccountId": "Setup Your Secure Passphrase\n For ${accountId}",
         "snackbarCopyImplicitAddress": "Funding Address Copied!",
         "snackbarCopySuccess": "Passphrase copied!"
     },
@@ -1702,21 +1701,21 @@
             "title": "Enter Two-Factor Verification Code"
         }
     },
-    "twoFactorDisbleBanner": {
-        "desc": "NEAR wallet (wallet.near.org) will soon remove support for two-factor authentication, please disable 2FA for your connected accounts.",
-        "titleSingular": "Account Needs Your Attention",
-        "titlePlural": "Accounts Need Your Attention",
-        "button": "Disable 2FA"
-    },
     "twoFactorDisableLocked": {
-        "title": "Is your account locked?",
         "descOne": "We couldn’t verify your 2FA method for ",
-        "descTwo": "If you can no longer access your account, you can rotate your keys and recover it. You will need your secure passphrase to unlock your account."
+        "descTwo": "If you can no longer access your account, you can rotate your keys and recover it. You will need your secure passphrase to unlock your account.",
+        "title": "Is your account locked?"
+    },
+    "twoFactorDisbleBanner": {
+        "button": "Disable 2FA",
+        "desc": "NEAR wallet (wallet.near.org) will soon remove support for two-factor authentication, please disable 2FA for your connected accounts.",
+        "titlePlural": "Accounts Need Your Attention",
+        "titleSingular": "Account Needs Your Attention"
     },
     "twoFactorRemoveAuth": {
-        "title": "Remove Two-Factor Authentication?",
+        "button": "Remove 2FA",
         "desc": "Enter your secure passphrase to remove 2FA from the account:",
-        "button": "Remove 2FA"
+        "title": "Remove Two-Factor Authentication?"
     },
     "unlockedAvailTransfer": "This NEAR is unlocked, and can be transferred out of your lockup contract.",
     "unlockedBalance": "This NEAR is still in a lockup contract, but unlocked.",
@@ -1883,10 +1882,6 @@
             "desc": "2FA must be disabled before you can transfer an account to a new wallet.",
             "title": "Disable two-factor authentication"
         },
-        "rotateKeys": {
-            "desc": "Before we can transfer your accounts, we’ll rotate the keys for your named accounts for additional security. Next, we’ll transfer your named and implicit acconuts to the wallet of your choosing. Ledger accounts don’t need to be tranferred, and you can go ahead and import them to any hardware-supported wallet.",
-            "title": "Let’s transfer your accounts"
-        },
         "migrateAccounts": {
             "desc": "The following accounts will be transferred:",
             "title": "We found ${count} active accounts"
@@ -1895,10 +1890,14 @@
             "desc": "You'll need this <strong>password</strong> to securely import your accounts. Copy or write it down until you've completed transferring your accounts.",
             "title": "Password required to import accounts"
         },
+        "rotateKeys": {
+            "desc": "For your security, we are going to generate a new passphrase and full access key for the below accounts. <br /><br /> Rotating your key will help protect your wallet and allow you to clean up your old full access keys after you transfer your accounts.",
+            "title": "Let’s secure your accounts"
+        },
         "selectWallet": {
-            "title": "Select a wallet to transfer accounts",
             "descOne": "You’ll be automatically redirected in <b>10 seconds.</b> Once redirected, you’ll need to approve each account as it is added to your new wallet.",
-            "descTwo": "These wallets support automatically transferring accounts. <br /><br /> You can manually import an existing account to any wallet using your 12-word recovery phrase."
+            "descTwo": "These wallets support automatically transferring accounts. <br /><br /> You can manually import an existing account to any wallet using your 12-word recovery phrase.",
+            "title": "Select a wallet to transfer accounts"
         }
     },
     "warning": "Warning",

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -789,8 +789,8 @@
         }
     },
     "migration": {
-        "message": "NEAR Wallet is being sunsetted, find more info in our <a href='${url}' target='_blank'>blog</a>.<br/>You have until ${startDate} to transfer your accounts, or export your keys from your account settings.",
-        "redirect": "NEAR Wallet is being sunsetted.<br/>Click the button to learn more.",
+        "message": "Soon NEAR wallet (wallet.near.org) will no longer be supported. Transfer your accounts to a different wallet or export your private keys from <a href='/profile'>account settings.</a>",
+        "redirect": "Soon NEAR wallet (wallet.near.org) will no longer be supported. Use your 12-word recovery phrase to import your account(s) to a different wallet or <a href='/recover-account'>recover and export your account(s).</a>",
         "redirectCaption": "Learn More",
         "transferCaption": "Transfer My Accounts"
     },
@@ -1896,7 +1896,9 @@
             "title": "Password required to import accounts"
         },
         "selectWallet": {
-            "title": "Select a wallet to transfer accounts"
+            "title": "Select a wallet to transfer accounts",
+            "descOne": "You’ll be automatically redirected in <b>10 seconds.</b> Once redirected, you’ll need to approve each account as it is added to your new wallet.",
+            "descTwo": "These wallets support automatically transferring accounts. <br /><br /> You can manually import an existing account to any wallet using your 12-word recovery phrase."
         }
     },
     "warning": "Warning",


### PR DESCRIPTION
This PR contains minor UI updates on wallet migration:
([Design Reference](https://www.figma.com/file/FNtU2zIXEaMPuXaZDvK3IT/Wallet-Transition?node-id=701%3A28209))

this PR resolves #2959 

1. logged off state banner + label:
<img width="1097" alt="image" src="https://user-images.githubusercontent.com/6027014/198927954-1e6f818f-62c6-4165-a5d4-25acaa98aefa.png">
<img width="622" alt="image" src="https://user-images.githubusercontent.com/6027014/198927981-bcbd1419-2f5a-4c23-b959-9bd7408bd195.png">

2. logged in state banner + label:
<img width="1115" alt="image" src="https://user-images.githubusercontent.com/6027014/198928053-1a2a8ba5-b922-4155-b754-ab7f26f91cc6.png">
<img width="621" alt="image" src="https://user-images.githubusercontent.com/6027014/198928065-83c91259-94a8-4978-8643-1b8b9d1f06e5.png">

3. Wallet migration list:
<img width="437" alt="image" src="https://user-images.githubusercontent.com/6027014/198928097-73e33c68-52cd-4174-8a86-fb74d87789d2.png">

4. Rotate Key Modal UI:
<img width="543" alt="image" src="https://user-images.githubusercontent.com/6027014/199399975-464d6cee-0746-4f54-8886-2b9469a27910.png">

5. Rotate Key Modal Passphrase UI:
<img width="575" alt="image" src="https://user-images.githubusercontent.com/6027014/199400031-4223e405-9116-4a50-b54d-f15a245b29eb.png">


