### PR TITLE
feat: batch key conversion when disabling 2FA

### DIFF
--- a/packages/frontend/jest.config.js
+++ b/packages/frontend/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
     setupFilesAfterEnv: ['./jest.setup.js'],
     setupFiles: ['dotenv/config'],
-    testEnvironment: 'jsdom',
+    testEnvironment: 'node',
     moduleNameMapper: {
         '^.+\\.svg$': 'jest-svg-transformer'
     }

--- a/packages/frontend/src/utils/twoFactor/index.js
+++ b/packages/frontend/src/utils/twoFactor/index.js
@@ -1,0 +1,1 @@
+export { TwoFactor } from './twoFactorBase';

--- a/packages/frontend/src/utils/twoFactor/index.js
+++ b/packages/frontend/src/utils/twoFactor/index.js
@@ -1,1 +1,21 @@
-export { TwoFactor } from './twoFactorBase';
+import { store } from '../..';
+import { promptTwoFactor, refreshAccount } from '../../redux/actions/account';
+import { TwoFactorBase } from './twoFactorBase';
+
+export class TwoFactor extends TwoFactorBase {
+    constructor(wallet, accountId, has2fa = false) {
+        super({
+            connection: wallet.connection,
+            accountId,
+            getCode: () => store.dispatch(promptTwoFactor(true)).payload.promise,
+            init2fa: ({ accountId, method }) => wallet.postSignedJson('/2fa/init', {
+                accountId,
+                method
+            }),
+            isLedgerEnabled: () => wallet.isLedgerEnabled(),
+            localStorage,
+            refreshAccount: () => store.dispatch(refreshAccount()),
+            has2fa,
+        });
+    }
+}

--- a/packages/frontend/src/utils/twoFactor/twoFactorBase.js
+++ b/packages/frontend/src/utils/twoFactor/twoFactorBase.js
@@ -2,10 +2,10 @@ import { BN } from 'bn.js';
 import * as nearApiJs from 'near-api-js';
 import { parseSeedPhrase } from 'near-seed-phrase';
 
-import { store } from '..';
-import { ACCOUNT_HELPER_URL, MULTISIG_CONTRACT_HASHES, MULTISIG_MIN_AMOUNT, NETWORK_ID, NODE_URL } from '../config';
-import { promptTwoFactor, refreshAccount } from '../redux/actions/account';
-import { WalletError } from './walletError';
+import { store } from '../..';
+import { ACCOUNT_HELPER_URL, MULTISIG_CONTRACT_HASHES, MULTISIG_MIN_AMOUNT, NETWORK_ID, NODE_URL } from '../../config';
+import { promptTwoFactor, refreshAccount } from '../../redux/actions/account';
+import { WalletError } from '../walletError';
 
 const {
     multisig: { Account2FA },

--- a/packages/frontend/test/twoFactorBase.test.js
+++ b/packages/frontend/test/twoFactorBase.test.js
@@ -1,0 +1,123 @@
+const nearApiJs = require('near-api-js');
+
+const { TwoFactorBase } = require('../src/utils/twoFactor/twoFactorBase');
+
+const {
+    KeyPair,
+    multisig: { MULTISIG_CHANGE_METHODS }
+} = nearApiJs;
+
+function mock2faLimitedAccessKeys(keysToReturn) {
+    return new Array(keysToReturn)
+        .fill()
+        .map(() => ({
+            public_key: KeyPair.fromRandom('ed25519').publicKey.toString(),
+        }));
+}
+
+describe('2fa batch key conversion', () => {
+    let sender;
+    beforeEach(async () => {
+        sender = new TwoFactorBase({ connection: {} });
+        sender.disable = async () => {};
+    });
+
+    test('get2faLimitedAccessKeys filters out full access keys', async() => {
+        sender.getAccessKeys = async () => [{
+            access_key: { permission: 'FullAccess' },
+            public_key: KeyPair.fromRandom('ed25519').publicKey.toString(),
+        }];
+
+        expect(await sender.get2faLimitedAccessKeys()).toHaveLength(0);
+    });
+
+    test('get2faLimitedAccessKeys filters out LAKs with only the `confirm` method', async() => {
+        sender.getAccessKeys = async () => [{
+            access_key: {
+                permission: {
+                    FunctionCall: {
+                        method_names: ['confirm'],
+                        receiver_id: sender.accountId,
+                    },
+                },
+            },
+            public_key: KeyPair.fromRandom('ed25519').publicKey.toString(),
+        }];
+
+        expect(await sender.get2faLimitedAccessKeys()).toHaveLength(0);
+    });
+
+    test('get2faLimitedAccessKeys includes LAKs for requesting multisig signing', async() => {
+        sender.getAccessKeys = async () => [{
+            access_key: {
+                permission: {
+                    FunctionCall: {
+                        method_names: MULTISIG_CHANGE_METHODS,
+                        receiver_id: sender.accountId,
+                    },
+                },
+            },
+            public_key: KeyPair.fromRandom('ed25519').publicKey.toString(),
+        }];
+
+        expect(await sender.get2faLimitedAccessKeys()).toHaveLength(1);
+    });
+
+    test('isConversionRequiredForDisable returns false for accounts with fewer than 48 LAKs to convert', async() => {
+        await Promise.all([0, 1, 2, 48].map(async (n) => {
+            sender.get2faLimitedAccessKeys = async () => mock2faLimitedAccessKeys(n);
+            expect(await sender.isKeyConversionRequiredForDisable()).toEqual(false);
+        }));
+    });
+
+    test('isConversionRequiredForDisable returns true for accounts with 48 or more LAKs to convert', async() => {
+        await Promise.all([49, 100].map(async (n) => {
+            sender.get2faLimitedAccessKeys = async () => mock2faLimitedAccessKeys(n);
+            expect(await sender.isKeyConversionRequiredForDisable()).toEqual(true);
+        }));
+    });
+
+    test('batchConvertKeysAndDisable throws an exception for empty signing keys', async() => {
+        await expect(async () => {
+            await sender.batchConvertKeysAndDisable({});
+        }).rejects.toBeTruthy();
+
+        await expect(async () => {
+            await sender.batchConvertKeysAndDisable({ signingPublicKey: '' });
+        }).rejects.toBeTruthy();
+    });
+
+    test('batchConvertKeysAndDisable signs the expected number of transactions', async() => {
+        const batches = [
+            // no batches for cardinality <= 48 since these can be disabled directly
+            { numberOfLaks: 1, numberOfBatches: 0 },
+            { numberOfLaks: 48, numberOfBatches: 0 },
+            { numberOfLaks: 49, numberOfBatches: 1 },
+            { numberOfLaks: 98, numberOfBatches: 1 },
+            { numberOfLaks: 99, numberOfBatches: 2 },
+        ];
+
+        await Promise.all(batches.map(async ({ numberOfLaks, numberOfBatches }) => {
+            let batchesSigned = 0;
+            let disableMultisigCalled = false;
+            const laks = mock2faLimitedAccessKeys(numberOfLaks);
+            const account = {
+                ...sender,
+                checkMultisigCodeAndStateStatus: async () => ({ stateStatus: 1 }),
+                get2faLimitedAccessKeys: async () => laks,
+                signAndSendTransaction: async () => batchesSigned++,
+                disableMultisig: async () => disableMultisigCalled = true,
+            };
+            account.batchConvertKeysAndDisable = sender.batchConvertKeysAndDisable.bind(account);
+
+            const signingPublicKey = (await account.get2faLimitedAccessKeys())[0];
+            await account.batchConvertKeysAndDisable({
+                signingPublicKey: signingPublicKey.public_key,
+                contractBytes: [],
+                cleanupContractBytes: [],
+            });
+            expect(batchesSigned).toEqual(numberOfBatches);
+            expect(disableMultisigCalled).toBe(true);
+        }));
+    });
+});


### PR DESCRIPTION
Users attempting to disable 2FA with > 48 function call access keys for multisig require multiple transactions to convert these keys to FAKs. This PR adds batch conversion logic to convert keys prior to attempting to disable 2FA to facilitate a seamless disable workflow for the handful (95 at time of writing) of accounts impacted by this. Users going through the batch conversion flow will need to approve one 2FA transaction for each batch of 50 keys to be converted, e.g. 49-99 keys requires one prompt for key conversion, 100-149 requires two, etc. The 2FA prompt will still be required for the final disable as usual.

Once the design is finalized, additional code will be added to the `Disable2FA` component to indicate to affected users that multiple prompts will be required to disable.

Note that this implementation was originally written for `near-api-js`, which has better support for the tests included in this PR. To port them over it was necessary to separate out the `TwoFactor` class to decouple the dependencies (yes, plural) with circular references. If this is too much for this PR I am open to leaving it for a different piece of work.