### PR TITLE
Changed Meteor batch import to use URI hash

### DIFF
--- a/packages/frontend/src/components/wallet-migration/modals/MigrateAccountsModal/SelectDestinationWallet.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/MigrateAccountsModal/SelectDestinationWallet.jsx
@@ -65,7 +65,7 @@ export const WALLET_OPTIONS = [
         id: 'meteor-wallet',
         name: 'Meteor Wallet',
         icon: <img src={ImgMeteorWallet} alt={'Meteor Wallet Logo'}/>,
-        getUrl: ({ hash, networkId }) => `${getMeteorWalletUrl()}/batch-import?hash=${hash}&network=${networkId}`,
+        getUrl: ({ hash, networkId }) => `${getMeteorWalletUrl()}/batch-import?network=${networkId}#${hash}`,
         checkAvailability: () => true,
     },
     {


### PR DESCRIPTION
As requested for security reasons- this changes Meteor Wallet's batch import url to place the sensitive hashed data at the end of the URL as a URI parameter.