### PR TITLE
feat: batch key conversion in disable 2FA modal

### DIFF
--- a/packages/frontend/src/components/common/TwoFactorDisableBanner.js
+++ b/packages/frontend/src/components/common/TwoFactorDisableBanner.js
@@ -168,6 +168,8 @@ export default function TwoFactorDisableBanner() {
                     <Disable2FAModal
                         onClose={hideModal}
                         handleSetActiveView={hideModal}
+                        accountWithDetails={accounts}
+                        setAccountWithDetails={setAccounts}
                     />
                 )
             }

--- a/packages/frontend/src/components/common/TwoFactorDisableBanner.js
+++ b/packages/frontend/src/components/common/TwoFactorDisableBanner.js
@@ -122,9 +122,12 @@ export default function TwoFactorDisableBanner() {
                 accounts.map((accountId) => getAccountDetails({ accountId, wallet }))
             );
 
-            setAccounts(accountsKeyTypes.reduce(((acc, { accountId, keyType }) => keyType === WalletClass.KEY_TYPES.MULTISIG ? [...acc, accountId] : acc), []));
+            setAccounts(accountsKeyTypes.reduce(
+                (acc, account) => account.keyType === WalletClass.KEY_TYPES.MULTISIG ? [...acc, account] : acc,
+                []
+            ));
         };
-        if (loadedAccounts.length > 0 && accounts.sort() !== loadedAccounts.sort()) {
+        if (loadedAccounts.length > 0 && accounts.map(({ accountId }) => accountId).sort() !== loadedAccounts.sort()) {
             update2faAccounts();
         }
     }, [showDisable2FAModal, loadedAccounts.length]);

--- a/packages/frontend/src/components/common/TwoFactorDisableBanner.js
+++ b/packages/frontend/src/components/common/TwoFactorDisableBanner.js
@@ -9,6 +9,7 @@ import WalletClass, { wallet } from '../../utils/wallet';
 import AlertTriangleIcon from '../svg/AlertTriangleIcon';
 import LockIcon from '../svg/LockIcon';
 import Disable2FAModal from '../wallet-migration/modals/Disable2faModal/Disable2FA';
+import { getAccountDetails } from '../wallet-migration/utils';
 import FormButton from './FormButton';
 
 
@@ -117,12 +118,8 @@ export default function TwoFactorDisableBanner() {
     useEffect(() => {
         const update2faAccounts = async () => {
             const accounts = await wallet.keyStore.getAccounts(NETWORK_ID);
-            const getAccountWithAccessKeysAndType = async (accountId) => {
-                const keyType = await wallet.getAccountKeyType(accountId);
-                return { accountId, keyType };
-            };
             const accountsKeyTypes = await Promise.all(
-                accounts.map(getAccountWithAccessKeysAndType)
+                accounts.map((accountId) => getAccountDetails({ accountId, wallet }))
             );
 
             setAccounts(accountsKeyTypes.reduce(((acc, { accountId, keyType }) => keyType === WalletClass.KEY_TYPES.MULTISIG ? [...acc, accountId] : acc), []));

--- a/packages/frontend/src/components/profile/Profile.js
+++ b/packages/frontend/src/components/profile/Profile.js
@@ -157,6 +157,7 @@ export function Profile({ match }) {
     const accountId = accountIdFromUrl || loginAccountId;
     const isOwner = accountId && accountId === loginAccountId && accountExists;
     const [isBrickedAccount, setIsBrickedAccount] = useState(false);
+    const [isKeyConversionRequiredFor2faDisable, setIsKeyConversionRequiredFor2faDisable] = useState(false);
     const account = useAccount(accountId);
     const dispatch = useDispatch();
     const profileBalance = selectProfileBalance(account);
@@ -205,6 +206,7 @@ export function Profile({ match }) {
                 if (accountKeyType === WalletClass.KEY_TYPES.MULTISIG) {
                     let account = await wallet.getAccount(accountId);
                     setIsBrickedAccount(await isAccountBricked(account));
+                    setIsKeyConversionRequiredFor2faDisable(await account.isKeyConversionRequiredForDisable());
                 } else {
                     setIsBrickedAccount(false);
                 }
@@ -346,6 +348,7 @@ export function Profile({ match }) {
                                         <TwoFactorAuth
                                             twoFactor={twoFactor}
                                             isBrickedAccount={isBrickedAccount}
+                                            isKeyConversionRequiredFor2faDisable={isKeyConversionRequiredFor2faDisable}
                                             onDisableBrickedAccountComplete={onDisableBrickedAccountComplete}
                                         />
                                     </>

--- a/packages/frontend/src/components/profile/Profile.js
+++ b/packages/frontend/src/components/profile/Profile.js
@@ -206,7 +206,11 @@ export function Profile({ match }) {
                 if (accountKeyType === WalletClass.KEY_TYPES.MULTISIG) {
                     let account = await wallet.getAccount(accountId);
                     setIsBrickedAccount(await isAccountBricked(account));
-                    setIsKeyConversionRequiredFor2faDisable(await account.isKeyConversionRequiredForDisable());
+
+                    // sometimes `account` is not an instance of TwoFactor...
+                    if (typeof account.isKeyConversionRequiredForDisable === 'function') {
+                        setIsKeyConversionRequiredFor2faDisable(await account.isKeyConversionRequiredForDisable());
+                    }
                 } else {
                     setIsBrickedAccount(false);
                 }

--- a/packages/frontend/src/components/profile/hardware_devices/ConfirmDisable.js
+++ b/packages/frontend/src/components/profile/hardware_devices/ConfirmDisable.js
@@ -44,7 +44,7 @@ const Container = styled.form`
     }
 `;
 
-const ConfirmDisable = ({ onConfirmDisable, onKeepEnabled, accountId, disabling, component, twoFactorKind }) => {
+const ConfirmDisable = ({ onConfirmDisable, onKeepEnabled, accountId, disabling, component, twoFactorKind, isKeyConversionRequiredFor2faDisable }) => {
     const [username, setUsername] = useState('');
 
     const isTwoFactorPhone = component === 'twoFactor' && twoFactorKind === '2fa-phone';
@@ -56,6 +56,9 @@ const ConfirmDisable = ({ onConfirmDisable, onKeepEnabled, accountId, disabling,
         }}>
             <div><Translate id={`${component}.disable.title`}/></div>
             <div><Translate id={`${component}.disable.${isTwoFactorPhone ? 'phoneDesc' : 'desc'}`}/></div>
+            {isKeyConversionRequiredFor2faDisable && (
+                <div><Translate id={`${component}.disable.keyConversionRequired`}/></div>
+            )}
             <Translate>
                 {({ translate }) => (
                     <input

--- a/packages/frontend/src/components/profile/two_factor/TwoFactorAuth.js
+++ b/packages/frontend/src/components/profile/two_factor/TwoFactorAuth.js
@@ -56,7 +56,7 @@ const Container = styled(Card)`
     }
 `;
 
-const TwoFactorAuth = ({ twoFactor, history, isBrickedAccount, onDisableBrickedAccountComplete }) => {
+const TwoFactorAuth = ({ twoFactor, history, isBrickedAccount, isKeyConversionRequiredFor2faDisable, onDisableBrickedAccountComplete }) => {
     const [confirmDisable, setConfirmDisable] = useState(false);
     const [showBrickedAccountModal, setShowBrickedAccountModal] = useState(false);
     const account = useSelector(selectAccountSlice);
@@ -114,6 +114,7 @@ const TwoFactorAuth = ({ twoFactor, history, isBrickedAccount, onDisableBrickedA
                     disabling={confirmDisabling}
                     component='twoFactor'
                     twoFactorKind={twoFactor.kind}
+                    isKeyConversionRequiredFor2faDisable={isKeyConversionRequiredFor2faDisable}
                 />
             )}
             {twoFactor && isBrickedAccount && showBrickedAccountModal && (

--- a/packages/frontend/src/components/profile/two_factor/TwoFactorAuth.js
+++ b/packages/frontend/src/components/profile/two_factor/TwoFactorAuth.js
@@ -4,7 +4,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { disableMultisig } from '../../../redux/actions/account';
+import { disableMultisig, disableMultisigWithBatchKeyConversion } from '../../../redux/actions/account';
 import { selectAccountSlice } from '../../../redux/slices/account';
 import { actions as recoveryMethodsActions } from '../../../redux/slices/recoveryMethods';
 import { selectActionsPending } from '../../../redux/slices/status';
@@ -61,11 +61,15 @@ const TwoFactorAuth = ({ twoFactor, history, isBrickedAccount, isKeyConversionRe
     const [showBrickedAccountModal, setShowBrickedAccountModal] = useState(false);
     const account = useSelector(selectAccountSlice);
     const dispatch = useDispatch();
-    const confirmDisabling = useSelector((state) => selectActionsPending(state, { types: ['DISABLE_MULTISIG'] }));
+    const confirmDisabling = useSelector((state) => selectActionsPending(state, {
+        types: ['DISABLE_MULTISIG', 'DISABLE_MULTISIG_WITH_BATCH_KEY_CONVERSION']
+    }));
 
     const handleConfirmDisable = async () => {
         if (isBrickedAccount) {
             setShowBrickedAccountModal(true);
+        } else if (isKeyConversionRequiredFor2faDisable) {
+            await dispatch(disableMultisigWithBatchKeyConversion());
         } else {
             await dispatch(disableMultisig());
         }

--- a/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
+++ b/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
@@ -13,7 +13,7 @@ import MigrateAccountsModal from './modals/MigrateAccountsModal/MigrateAccountsM
 import RedirectingModal from './modals/RedirectingModal/RedirectingModal';
 import RotateKeysModal from './modals/RotateKeysModal/RotateKeysModal';
 import VerifyingModal from './modals/VerifyingModal/VerifyingModal';
-import { deleteMigrationStep, getMigrationStep, setMigrationStep } from './utils';
+import { deleteMigrationStep, getAccountDetails, getMigrationStep, setMigrationStep } from './utils';
 
 
 export const WALLET_MIGRATION_VIEWS = {
@@ -41,20 +41,8 @@ const WalletMigration = ({ open, onClose }) => {
     useEffect(() => {
         const importRotatableAccounts = async () => {
             const accounts = await wallet.keyStore.getAccounts(NETWORK_ID);
-            const getAccountDetails = async (accountId) => {
-                const keyType = await wallet.getAccountKeyType(accountId);
-                const accountBalance = await wallet.getBalance(keyType.accountId);
-
-                const account = await wallet.getAccount(accountId);
-                let isConversionRequired = false;
-                if (typeof account.isKeyConversionRequiredForDisable === 'function') {
-                    isConversionRequired = await account.isKeyConversionRequiredForDisable();
-                }
-
-                return { accountId, keyType, accountBalance, isConversionRequired };
-            };
             const details = await Promise.all(
-                accounts.map(getAccountDetails)
+                accounts.map((accountId) => getAccountDetails({ accountId, wallet }))
             );
             setAccountWithDetails(details);
             setLoadingMultisigAccounts(false);

--- a/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
+++ b/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
@@ -44,7 +44,14 @@ const WalletMigration = ({ open, onClose }) => {
             const getAccountDetails = async (accountId) => {
                 const keyType = await wallet.getAccountKeyType(accountId);
                 const accountBalance = await wallet.getBalance(keyType.accountId);
-                return { accountId, keyType, accountBalance };
+
+                const account = await wallet.getAccount(accountId);
+                let isConversionRequired = false;
+                if (typeof account.isKeyConversionRequiredForDisable === 'function') {
+                    isConversionRequired = await account.isKeyConversionRequiredForDisable();
+                }
+
+                return { accountId, keyType, accountBalance, isConversionRequired };
             };
             const details = await Promise.all(
                 accounts.map(getAccountDetails)

--- a/packages/frontend/src/components/wallet-migration/modals/Disable2faModal/Disable2FA.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/Disable2faModal/Disable2FA.jsx
@@ -53,7 +53,7 @@ const Disable2FAModal = ({ handleSetActiveView, onClose, accountWithDetails, set
     });
     const [loadingMultisigAccounts, setLoadingMultisigAccounts] = useState(true);
     const [currentBrickedAccount, setCurrentBrickedAccount] = useState(null);
-    
+
     const initialAccountIdOnStart = useSelector(selectAccountId);
     const initialAccountId = useRef(initialAccountIdOnStart);
     const dispatch = useDispatch();
@@ -80,6 +80,7 @@ const Disable2FAModal = ({ handleSetActiveView, onClose, accountWithDetails, set
     const currentAccount = useMemo(() => !failed && state.accounts.find((account) => account.status === IMPORT_STATUS.PENDING), [failed, state.accounts]);
     const batchDisableNotStarted = useMemo(() => state.accounts.every((account) => account.status === null), [state.accounts]);
     const completedWithSuccess = useMemo(() => !loadingMultisigAccounts && state.accounts.every((account) => account.status === IMPORT_STATUS.SUCCESS), [state.accounts, loadingMultisigAccounts]);
+    const someAccountsRequireKeyConversion = useMemo(() => !loadingMultisigAccounts && state.accounts.some((account) => account.isConversionRequired), [state.accounts, loadingMultisigAccounts]);
 
     useEffect(() => {
         if (batchDisableNotStarted) {
@@ -165,6 +166,9 @@ const Disable2FAModal = ({ handleSetActiveView, onClose, accountWithDetails, set
                 <IconSecurityLock />
                 <h4 className='title'><Translate id='walletMigration.disable2fa.title' /></h4>
                 <p><Translate id='walletMigration.disable2fa.desc' /></p>
+                {someAccountsRequireKeyConversion && (
+                    <p><Translate id='twoFactor.disable.keyConversionRequired' /></p>
+                )}
                 <div className="accountsTitle">
                     <Translate id='importAccountWithLink.accountsFound' data={{ count: state.accounts.length }} />
                 </div>

--- a/packages/frontend/src/components/wallet-migration/utils.ts
+++ b/packages/frontend/src/components/wallet-migration/utils.ts
@@ -51,4 +51,15 @@ export const redirectLinkdropUser = ({
     }
 };
 
+export async function getAccountDetails({ accountId, wallet }) {
+    const keyType = await wallet.getAccountKeyType(accountId);
+    const accountBalance = await wallet.getBalance(keyType.accountId);
 
+    const account = await wallet.getAccount(accountId);
+    let isConversionRequired = false;
+    if (typeof account.isKeyConversionRequiredForDisable === 'function') {
+        isConversionRequired = await account.isKeyConversionRequiredForDisable();
+    }
+
+    return { accountId, keyType, accountBalance, isConversionRequired };
+}

--- a/packages/frontend/src/redux/actions/account.js
+++ b/packages/frontend/src/redux/actions/account.js
@@ -243,6 +243,7 @@ export const {
     promptTwoFactor,
     deployMultisig,
     disableMultisig,
+    disableMultisigWithBatchKeyConversion,
     checkCanEnableTwoFactor,
     get2faMethod,
     getLedgerKey,
@@ -306,6 +307,10 @@ export const {
     ],
     DISABLE_MULTISIG: [
         (...args) => twoFactorMethod('disableMultisig', wallet, args),
+        () => showAlert()
+    ],
+    DISABLE_MULTISIG_WITH_BATCH_KEY_CONVERSION: [
+        () => twoFactorMethod('batchConvertKeysAndDisable', wallet, wallet.getPublicKey()),
         () => showAlert()
     ],
     CHECK_CAN_ENABLE_TWO_FACTOR: [

--- a/packages/frontend/src/redux/actions/account.js
+++ b/packages/frontend/src/redux/actions/account.js
@@ -310,7 +310,7 @@ export const {
         () => showAlert()
     ],
     DISABLE_MULTISIG_WITH_BATCH_KEY_CONVERSION: [
-        () => twoFactorMethod('batchConvertKeysAndDisable', wallet, wallet.getPublicKey()),
+        () => twoFactorMethod('batchConvertKeysAndDisable', wallet, [wallet.getPublicKey()]),
         () => showAlert()
     ],
     CHECK_CAN_ENABLE_TWO_FACTOR: [

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1678,6 +1678,7 @@
             "desc": "Keep in mind that transactions won't have to be confirmed with 2FA once it's disabled.",
             "disable": "Disable 2FA",
             "keep": "No, keep 2FA",
+            "keyConversionRequired": "Due to the number of 2FA access keys on this account, some access keys will need to be converted to full access keys before 2FA can be disabled. The converted keys can sign transactions without a 2FA prompt, so it is important to complete the 2FA disable process once begun. You will receive one or more additional 2FA prompts to perform this key conversion when disabling 2FA.",
             "phoneDesc": "The SMS option for two-factor authentication is being deprecated, and cannot be re-enbaled.",
             "title": "Are you sure you want to disable 2FA?"
         },

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1678,7 +1678,7 @@
             "desc": "Keep in mind that transactions won't have to be confirmed with 2FA once it's disabled.",
             "disable": "Disable 2FA",
             "keep": "No, keep 2FA",
-            "keyConversionRequired": "Due to the number of 2FA access keys on this account, some access keys will need to be converted to full access keys before 2FA can be disabled. The converted keys can sign transactions without a 2FA prompt, so it is important to complete the 2FA disable process once begun. You will receive one or more additional 2FA prompts to perform this key conversion when disabling 2FA.",
+            "keyConversionRequired": "<br />Due to the number of 2FA access keys on this account, some access keys will need to be converted to full access keys before 2FA can be disabled. The converted keys can sign transactions without a 2FA prompt, so it is important to complete the 2FA disable process once begun. You will receive one or more additional 2FA prompts to perform this key conversion when disabling 2FA.",
             "phoneDesc": "The SMS option for two-factor authentication is being deprecated, and cannot be re-enbaled.",
             "title": "Are you sure you want to disable 2FA?"
         },

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1678,7 +1678,7 @@
             "desc": "Keep in mind that transactions won't have to be confirmed with 2FA once it's disabled.",
             "disable": "Disable 2FA",
             "keep": "No, keep 2FA",
-            "keyConversionRequired": "<br />Due to the number of 2FA access keys on this account, some access keys will need to be converted to full access keys before 2FA can be disabled. The converted keys can sign transactions without a 2FA prompt, so it is important to complete the 2FA disable process once begun. You will receive one or more additional 2FA prompts to perform this key conversion when disabling 2FA.",
+            "keyConversionRequired": "<br />Due to the number of 2FA access keys on this account, some access keys will need to be converted to full access keys before 2FA can be disabled. The converted keys can sign transactions without a 2FA prompt, so it is important to complete the 2FA disable process once begun.<br/><br/><b>You will receive one or more additional 2FA prompts to perform this key conversion when disabling 2FA.</b>",
             "phoneDesc": "The SMS option for two-factor authentication is being deprecated, and cannot be re-enbaled.",
             "title": "Are you sure you want to disable 2FA?"
         },


### PR DESCRIPTION
This PR changes the components currently responsible for disabling 2FA so that they have awareness around whether a 2FA-enabled account requires that its keys are converted prior to attempting to disable 2FA. I'm not aware of a design for this so the exact wording and specifics on how the user is informed of this conversion (i.e. that they'll need to confirm multiple 2FA modals) is subject to change.

Disabling from `Disable 2FA` button:
![2022-11-07 13 35 42](https://user-images.githubusercontent.com/36863574/200421881-0a369b61-3bf6-4386-a8b3-de6cbeaf7778.gif)

