### PR TITLE
feat: storing rotated keys in memory and use them on creating hash

### DIFF
--- a/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
+++ b/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
@@ -15,9 +15,9 @@ const initialState = {
     wallet: null,
 };
 
-
 const WalletMigration = ({ open, onClose }) => {
     const [state, setState] = React.useState(initialState);
+    const [rotatedKeys, setRotatedKeys] = React.useState({});
 
     const handleStateUpdate = (newState) => {
         setState({...state, ...newState});
@@ -40,6 +40,13 @@ const WalletMigration = ({ open, onClose }) => {
         }
     }, [open]);
 
+    const onRotateKeySuccess = useCallback(({ accountId, key }) => {
+        setRotatedKeys({
+            ...rotatedKeys,
+            [accountId]: key,
+        });
+    }, [Object.keys(rotatedKeys).length]);
+
     return (
         <div>
             {state.activeView === WALLET_MIGRATION_VIEWS.DISABLE_2FA && (
@@ -54,6 +61,7 @@ const WalletMigration = ({ open, onClose }) => {
                     onClose={onClose}
                     handleSetActiveView={handleSetActiveView}
                     data-test-id="rotateKeysModal"
+                    onRotateKeySuccess={onRotateKeySuccess}
                 />
             )}
             {state.activeView === WALLET_MIGRATION_VIEWS.MIGRATE_ACCOUNTS && (
@@ -63,6 +71,7 @@ const WalletMigration = ({ open, onClose }) => {
                     handleSetWallet={handleSetWallet}
                     state={state}
                     data-test-id="migrateAccountsModal"
+                    rotatedKeys={rotatedKeys}
                 />
             )}
             

--- a/packages/frontend/src/components/wallet-migration/modals/MigrateAccountsModal/MigrateAccountsModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/MigrateAccountsModal/MigrateAccountsModal.jsx
@@ -16,7 +16,7 @@ export const WALLET_EXPORT_MODAL_VIEWS = {
     MIGRATE_ACCOUNTS: 'MIGRATE_ACCOUNTS',    
 };
 
-const MigrateAccountsModal = ({ onClose, handleSetActiveView,  handleSetWallet, state }) => {
+const MigrateAccountsModal = ({ onClose, handleSetActiveView,  handleSetWallet, state, rotatedKeys }) => {
     const [activeModalView, setActiveModalView] = useState('SELECT_DESTINATION_WALLET');
     const availableAccounts = useSelector(selectAvailableAccounts);
     const [migrationKey, setMigrationKey] = useState(generatePublicKey());
@@ -25,10 +25,11 @@ const MigrateAccountsModal = ({ onClose, handleSetActiveView,  handleSetWallet, 
         const accountsData = [];
         for (let i = 0; i < accounts.length; i++) {
             const accountId = accounts[i];
+            const rotateKey = rotatedKeys[accountId];
             const keyPair = await wallet.getLocalKeyPair(accountId);
             accountsData.push([
                 accountId,
-                keyPair?.secretKey || '',
+                rotateKey || keyPair?.secretKey || '',
                 getLedgerHDPath(accountId),
             ]);
         }

--- a/packages/frontend/src/components/wallet-migration/modals/RotateKeysModal/RotateKeysModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/RotateKeysModal/RotateKeysModal.jsx
@@ -49,7 +49,7 @@ const Container = styled.div`
 `;
 const MINIMIM_ACCOUNT_BALANCE  = 0.00005;
 
-const RotateKeysModal = ({handleSetActiveView, onClose}) => {
+const RotateKeysModal = ({handleSetActiveView, onClose, onRotateKeySuccess}) => {
     const [state, localDispatch] = useImmerReducer(sequentialAccountImportReducer, {
         accounts: []
     });
@@ -123,9 +123,10 @@ const RotateKeysModal = ({handleSetActiveView, onClose}) => {
         try {
             const account = await wallet.getAccount(currentAccount.accountId);
             await account.addKey(currentRecoveryKeyPair.getPublicKey());
-            await wallet.saveAccount(currentAccount.accountId, currentRecoveryKeyPair);
+            onRotateKeySuccess({ accountId: currentAccount.accountId,  key: currentRecoveryKeyPair.secretKey});
+
             localDispatch({ type: ACTIONS.SET_CURRENT_DONE });
-            setShowConfirmSeedphraseModal(() => false);            
+            setShowConfirmSeedphraseModal(false);            
         } catch (e) {
             localDispatch({ type: ACTIONS.SET_CURRENT_FAILED_AND_END_PROCESS });
             dispatch(showCustomAlert({
@@ -145,7 +146,7 @@ const RotateKeysModal = ({handleSetActiveView, onClose}) => {
         dispatch(switchAccount({accountId: currentAccount.accountId}));
         generateAndSetPhrase();
         await new Promise((r) => setTimeout(r, 1500));
-        setShowConfirmSeedphraseModal(() => true);
+        setShowConfirmSeedphraseModal(true);
     };
 
     useEffect(() => {
@@ -196,7 +197,7 @@ const RotateKeysModal = ({handleSetActiveView, onClose}) => {
                             }
                             await handleConfirmPassphrase();
                             setConfirmPassphrase(false);
-                            setShowConfirmSeedphraseModal(() => false);
+                            setShowConfirmSeedphraseModal(false);
                         } finally {
                             setFinishingSetupForCurrentAccount(false);
                         }
@@ -227,7 +228,7 @@ const RotateKeysModal = ({handleSetActiveView, onClose}) => {
                        }}
                        onClickCancel = { async () => {
                            localDispatch({ type: ACTIONS.SET_CURRENT_FAILED_AND_END_PROCESS });
-                           setShowConfirmSeedphraseModal(() => false);
+                           setShowConfirmSeedphraseModal(false);
                        }}
                        accountId={currentAccount.accountId}
                        style={{ marginTop: '0px' }}


### PR DESCRIPTION
This PR contains implementation for security enhancement on wallet migration. Based on our team discussion, we decided to avoid storing newly created FAK from rotate keys in localStorage. Instead we keep them in memory and use them upon migrating to third party wallet. 

(it will be stored inside `rotatedKeys` variable on `WalletMigration` component. This should also be used on key clean up step, cc @andy-haynes )

