### PR TITLE
Wallet Migration UI/flow enhancement [WEB-175]

### DIFF
--- a/features/flags.json
+++ b/features/flags.json
@@ -267,9 +267,9 @@
     "createdBy": "roshaans",
     "createdAt": "2022-09-29T12:47:40.121Z",
     "development": {
-      "enabled": false,
-      "lastEditedBy": "roshaans",
-      "lastEditedAt": "2022-09-29T12:47:40.119Z"
+      "enabled": true,
+      "lastEditedBy": "hcho112",
+      "lastEditedAt": "2022-11-10T19:42:24.864Z"
     },
     "testnet": {
       "enabled": false,

--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { Redirect, Switch } from 'react-router-dom';
 import styled, { ThemeProvider } from 'styled-components';
 
-import { SHOW_MIGRATION_BANNER, WEB3AUTH } from '../../../../features';
+import { SHOW_MIGRATION_BANNER, WEB3AUTH, WEP_PHASE_ONE } from '../../../../features';
 import favicon from '../../src/images/mynearwallet-cropped.svg';
 import TwoFactorVerifyModal from '../components/accounts/two_factor/TwoFactorVerifyModal';
 import {
@@ -373,7 +373,7 @@ class Routing extends Component {
                         }
                         {
                             
-                            SHOW_MIGRATION_BANNER && (
+                            WEP_PHASE_ONE && (
                                 <Switch>
                                     <Route
                                         path={['/', '/staking', '/profile']} render={() => (
@@ -386,10 +386,15 @@ class Routing extends Component {
                                 </Switch>
                             )
                         }
-                        <WalletMigration
-                            open={this.state.openTransferPopup}
-                            history={this.props.history}
-                            onClose={this.closeTransferPopup} />
+                        {
+                            WEP_PHASE_ONE && (
+                                <WalletMigration
+                                    open={this.state.openTransferPopup}
+                                    history={this.props.history}
+                                    onClose={this.closeTransferPopup}
+                                />
+                            )
+                        }
                         <LedgerConfirmActionModal />
                         <LedgerConnectModal />
                         {account.requestPending !== null && (

--- a/packages/frontend/src/components/svg/AlertRoundedIcon.js
+++ b/packages/frontend/src/components/svg/AlertRoundedIcon.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
-const AlertRoundedIcon = ({ color }) => {
+const AlertRoundedIcon = ({ color, className }) => {
     const stroke = color || '#EF860D';
     return (
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg className={className} width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M8 5.33333V7.99999M8 10.6667H8.00667M14.6667 8C14.6667 11.6819 11.6819 14.6667 8.00001 14.6667C4.31811 14.6667 1.33334 11.6819 1.33334 8C1.33334 4.3181 4.31811 1.33333 8.00001 1.33333C11.6819 1.33333 14.6667 4.3181 14.6667 8Z" stroke={stroke} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
         </svg>
     );

--- a/packages/frontend/src/components/wallet-migration/modals/MigrateAccountsModal/SelectDestinationWallet.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/MigrateAccountsModal/SelectDestinationWallet.jsx
@@ -145,6 +145,7 @@ const WalletOptionsListingItem = styled.div`
 
     &.disabled {
         opacity: 0.5;
+        background: #FAFAFA;
         &:hover {
             cursor: not-allowed;
         }

--- a/packages/frontend/src/components/wallet-migration/modals/MigrateAccountsModal/SelectDestinationWallet.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/MigrateAccountsModal/SelectDestinationWallet.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Translate } from 'react-localize-redux';
 import { useDispatch, } from 'react-redux';
 import styled from 'styled-components';
@@ -18,8 +18,11 @@ import {
 } from '../../../../utils/getWalletURL';
 import isMobile from '../../../../utils/isMobile';
 import { shuffle } from '../../../../utils/staking';
+import Tooltip from '../../../common/Tooltip';
+import AlertRoundedIcon from '../../../svg/AlertRoundedIcon.js';
 import { ButtonsContainer, StyledButton, MigrationModal } from '../../CommonComponents';
 import {WALLET_EXPORT_MODAL_VIEWS} from './MigrateAccountsModal';
+
 const Container = styled.div`
     padding: 15px 0;
     text-align: center;
@@ -51,12 +54,14 @@ export const WALLET_OPTIONS = shuffle([
         icon: <img src={ImgMyNearWallet} alt="MyNearWallet Logo" />,
         getUrl: ({ hash }) => `${getMyNearWalletUrlFromNEARORG()}/batch-import#${hash}`,
         checkAvailability: () => true,
+        ledgerSupport: true,
     },
     {
         id: 'ledger',
         name: 'Ledger',
         icon: <IconLedger />,
         checkAvailability: () => true,
+        ledgerSupport: true,
     },
     {
         id: 'sender',
@@ -64,6 +69,7 @@ export const WALLET_OPTIONS = shuffle([
         icon: <img src={SenderLogo} alt="Sender Wallet Logo"/>,
         getUrl: ({ hash, networkId }) => `https://sender.org/transfer?keystore=${hash}&network=${networkId}`,
         checkAvailability: () => true,
+        ledgerSupport: false,
     },
     {
         id: 'meteor-wallet',
@@ -71,6 +77,7 @@ export const WALLET_OPTIONS = shuffle([
         icon: <img src={ImgMeteorWallet} alt={'Meteor Wallet Logo'}/>,
         getUrl: ({ hash, networkId }) => `${getMeteorWalletUrl()}/batch-import?network=${networkId}#${hash}`,
         checkAvailability: () => true,
+        ledgerSupport: false,
     },
     {
         id: 'finer-wallet',
@@ -78,6 +85,7 @@ export const WALLET_OPTIONS = shuffle([
         icon: <img src={ImgFinerWallet} alt="Finer Wallet Logo" />,
         getUrl: ({ hash }) => `finer://wallet.near.org/batch-import#${hash}`,
         checkAvailability: () => isMobile('iOS'),
+        ledgerSupport: false,
     },
 ]);
 
@@ -135,6 +143,13 @@ const WalletOptionsListingItem = styled.div`
         }
     }
 
+    &.disabled {
+        opacity: 0.5;
+        &:hover {
+            cursor: not-allowed;
+        }
+    }
+
     .name {
         font-size: 16px;
         font-weight: 700;
@@ -154,7 +169,79 @@ const WalletOptionsListingItem = styled.div`
     }
 `;
 
-const SelectDestinationWallet = ({ handleSetActiveView, handleSetWallet, wallet, onClose }) => {
+const InfoIcon = styled(AlertRoundedIcon)`
+    &&& {
+        height: 20px;
+        width: 20px;
+        padding: 0;
+        margin-left: 5px;
+    }
+`;
+
+const LabelContainer = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+const WalletCategoryLabel = styled.h5`
+    text-align: left;
+    margin-top: 10px;
+`;
+
+const renderWalletOptions = ({ selectedId, handleSetWallet }) => {
+    const ledgerSupportedWallets = WALLET_OPTIONS.filter(({ ledgerSupport }) => ledgerSupport);
+    const ledgerUnsupportedWallets = WALLET_OPTIONS.filter(({ ledgerSupport }) => !ledgerSupport);
+
+    return (
+        <>
+            <WalletCategoryLabel><Translate id='walletMigration.selectWallet.ledgerSupported'/></WalletCategoryLabel>
+            {
+                ledgerSupportedWallets.map((wallet) => {
+                    const { id, name, icon, checkAvailability } = wallet;
+                    if (!checkAvailability() || id === 'ledger') {
+                        return null;
+                    }
+                    return (
+                        <WalletOptionsListingItem
+                            key={id}
+                            className={classNames({ active: id === selectedId })}
+                            onClick={() => handleSetWallet(wallet)}
+                        >
+                            <LabelContainer>
+                                <span className='name'>{name}</span>
+                            </LabelContainer>
+                            {icon}
+                        </WalletOptionsListingItem>
+                    );
+                })
+            }
+
+            <WalletCategoryLabel><Translate id='walletMigration.selectWallet.ledgerUnsupported'/></WalletCategoryLabel>
+            {
+                ledgerUnsupportedWallets.map((wallet) => {
+                    const { id, name, icon, checkAvailability } = wallet;
+                    if (!checkAvailability()) {
+                        return null;
+                    }
+                    return (
+                        <WalletOptionsListingItem
+                            className={classNames({ disabled: true })}
+                            key={id}
+                        >
+                            <LabelContainer>
+                                <h4 className='name'>{name}</h4>
+                            </LabelContainer>
+                            
+                            {icon}
+                        </WalletOptionsListingItem>
+                    );
+                })
+            }
+        </>
+    );
+};
+
+const SelectDestinationWallet = ({ handleSetActiveView, handleSetWallet, wallet, onClose, accountWithDetails }) => {
     const dispatch = useDispatch();
     
     const handleContinue = useCallback(() => {
@@ -167,6 +254,22 @@ const SelectDestinationWallet = ({ handleSetActiveView, handleSetWallet, wallet,
             return handleSetActiveView(WALLET_EXPORT_MODAL_VIEWS.MIGRATION_SECRET);
         }
     }, [wallet, handleSetActiveView, handleSetWallet]);
+
+    const hasLedgerAccount = useMemo(() => accountWithDetails.findIndex(({ keyType }) => keyType === 'ledger') > -1, [accountWithDetails.length]);
+    const hasFAKAccount = useMemo(() => accountWithDetails.findIndex(({ keyType }) => keyType === 'fullAccessKey') > -1, [accountWithDetails.length]);
+
+    // Use to show warning icon where accounts are both ledger + FAK
+    const showWarning = useCallback((ledgerSupport) => {
+        if (hasLedgerAccount && hasFAKAccount && !ledgerSupport) {
+            return true;
+        }
+        return false;
+    }, [hasLedgerAccount, hasFAKAccount]);
+
+    // Use to disable wallet options where account(s) is/are only ledger
+    const disableWalletOption = useCallback((ledgerSupport) => {
+        return hasLedgerAccount && !hasFAKAccount && !ledgerSupport;
+    }, [hasLedgerAccount, hasFAKAccount]);
     
     return (
         <MigrationModal>
@@ -174,22 +277,36 @@ const SelectDestinationWallet = ({ handleSetActiveView, handleSetWallet, wallet,
                 <IconWallet/>
                 <h4 className='title'><Translate id='walletMigration.selectWallet.title'/></h4>
                 <h5 className='description'><Translate id='walletMigration.selectWallet.descOne'/></h5>
+                
                 <WalletOptionsListing>
-                    {WALLET_OPTIONS.map((walletOption) => {
-                        if (!walletOption.checkAvailability()) {
-                            return null;
-                        }
-                        return (
-                            <WalletOptionsListingItem
-                                className={classNames([{ active: walletOption.id === wallet?.id }])}
-                                onClick={() => handleSetWallet(walletOption)}
-                                key={walletOption.name}
-                            >
-                                <h4 className='name'>{walletOption.name}</h4>
-                                {walletOption.icon}
-                            </WalletOptionsListingItem>
-                        );
-                    })}
+                    {
+                        hasLedgerAccount && !hasFAKAccount
+                            ? renderWalletOptions({ selectedId: wallet?.id, handleSetWallet })
+                            : WALLET_OPTIONS.map((walletOption) => {
+                                if (!walletOption.checkAvailability()) {
+                                    return null;
+                                }
+                                const disabled = disableWalletOption(walletOption.ledgerSupport);
+                                const warning = showWarning(walletOption.ledgerSupport);
+                                return (
+                                    <WalletOptionsListingItem
+                                        className={classNames({
+                                            active: walletOption.id === wallet?.id,
+                                            disabled,
+                                        })}
+                                        onClick={() => !disabled && handleSetWallet(walletOption)}
+                                        key={walletOption.name}
+                                    >
+                                        <LabelContainer>
+                                            <h4 className='name'>{walletOption.name}</h4>
+                                            {warning && <Tooltip translate='walletMigration.selectWallet.ledgerDisclaimer'><InfoIcon /></Tooltip>}
+                                        </LabelContainer>
+                                        
+                                        {walletOption.icon}
+                                    </WalletOptionsListingItem>
+                                );
+                            })
+                    }
                 </WalletOptionsListing>
                 <h6 className='description'><Translate id='walletMigration.selectWallet.descTwo'/></h6>
                 <ButtonsContainer>

--- a/packages/frontend/src/components/wallet-migration/modals/VerifyingModal/VerifyingModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/VerifyingModal/VerifyingModal.jsx
@@ -31,6 +31,7 @@ const DisclaimerLabel = styled.span`
 const VerifyingModal = ({
     onClose,
     onNext,
+    onStartOver,
 }) => {
     const [accessToMyAccount, setAccessToMyAccount] = useState(false);
 
@@ -55,13 +56,17 @@ const VerifyingModal = ({
                         <Translate id='walletMigration.verifying.disclaimer' />
                     </DisclaimerLabel>
                 </DisclaimerContainer>
-                <ButtonsContainer>
-                    <StyledButton className='gray-blue' onClick={onClose}>
+                <ButtonsContainer vertical>
+                    <StyledButton className='gray-blue' onClick={onClose} fullWidth>
                         <Translate id='button.cancel' />
+                    </StyledButton>
+                    <StyledButton className='white-blue' onClick={onStartOver} fullWidth>
+                        <Translate id='button.startOver' />
                     </StyledButton>
                     <StyledButton
                         onClick={onNext}
                         disabled={!accessToMyAccount}
+                        fullWidth
                     >
                         <Translate id='button.continue' />
                     </StyledButton>

--- a/packages/frontend/src/components/wallet-migration/utils.ts
+++ b/packages/frontend/src/components/wallet-migration/utils.ts
@@ -23,3 +23,11 @@ export const download = (filename, text) => {
   
     document.body.removeChild(element);
 };
+
+export const setMigrationStep = (step) => localStorage.setItem('walletMigrationStep', step);
+
+export const getMigrationStep = () => localStorage.getItem('walletMigrationStep');
+
+export const deleteMigrationStep = () => localStorage.removeItem('walletMigrationStep');
+
+

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1902,7 +1902,10 @@
         "selectWallet": {
             "descOne": "You’ll be automatically redirected in <b>10 seconds.</b> Once redirected, you’ll need to approve each account as it is added to your new wallet.",
             "descTwo": "These wallets support automatically transferring accounts. <br /><br /> You can manually import an existing account to any wallet using your 12-word recovery phrase.",
-            "title": "Select a wallet to transfer accounts"
+            "ledgerDisclaimer": "Transfer to this wallet will exclude any ledger account(s) due to incompetibility.",
+            "title": "Select a wallet to transfer accounts",
+            "ledgerSupported": "Ledger supported wallet(s)",
+            "ledgerUnsupported": "Ledger unsupported wallet(s)"
         },
         "redirect": {
             "title": "Redirecting to ${wallet}",
@@ -1920,7 +1923,7 @@
         "logout": {
             "title": "One last step",
             "desc": "As the last step, we are going clear out the keys stored on this browser for your security. You will be logged out of wallet.near.org and your keys will be removed. <br><br>Make sure you have access to your account in another wallet.",
-            "button": "Log Out of My Account(s)",
+            "button": "Log Out of My Account(s)"
         }
     },
     "warning": "Warning",


### PR DESCRIPTION
This PR contains improvements on wallet migration:

1. Ability to auto save on important steps during migration.
Save points are:
- when user reach to transfer step (moving to other wallet)
- when user completes key clean up step (at this point there is no turning back)
- when user click start over button on verify step (This will remove save point and start from beginning)

2. Show tailored UI/view on third party wallet selection upon transferring ledger account(s)
A. When there is no ledger account, show everything
B. When there is only ledger account, show categorized view, ledger support, unsupported group
![image](https://user-images.githubusercontent.com/6027014/200996823-f810f304-be2e-4655-8f5d-3d8c6732e154.png)

C. When there is mixture of ledger account(s) and FAK account(s), for the wallets that do not support ledger accounts, it will show info icon indicating that selecting unsupported wallet will exclude ledger accounts being transferred. (only FAK accounts will)
<img width="621" alt="image" src="https://user-images.githubusercontent.com/6027014/200996589-40533a26-4fbc-4cdc-8872-2fb53cb940ba.png">


