### PR TITLE
fix: Hide migration banner on testnet

### DIFF
--- a/features/flags.json
+++ b/features/flags.json
@@ -292,7 +292,7 @@
       "lastEditedAt": "2022-09-29T12:47:40.121Z"
     },
     "testnet_NEARORG": {
-      "enabled": true,
+      "enabled": false,
       "lastEditedBy": "roshaans",
       "lastEditedAt": "2022-09-29T12:47:40.121Z"
     },


### PR DESCRIPTION
Disabling the migration feature on testnet since the flow is still being actively worked on.