### PR TITLE
fix: remove outer FunctionCallError in NFT metadata error matching

### DIFF
--- a/packages/frontend/src/services/NonFungibleTokens.js
+++ b/packages/frontend/src/services/NonFungibleTokens.js
@@ -75,7 +75,7 @@ export default class NonFungibleTokens {
                     }))
             );
         } catch (e) {
-            if (!e.toString().includes('FunctionCallError(MethodResolveError(MethodNotFound))')) {
+            if (!e.toString().includes('MethodResolveError(MethodNotFound)')) {
                 throw e;
             }
 


### PR DESCRIPTION
This PR removes the outer `FunctionCallError(...)` string used to match error "missing method" responses from RPC. Currently mainnet errors do include this value but testnet RPC error responses do not, preventing NFTs from rendering.