### PR TITLE
feat: Display NFTs from contracts with null base_uri

### DIFF
--- a/packages/frontend/src/services/NonFungibleTokens.js
+++ b/packages/frontend/src/services/NonFungibleTokens.js
@@ -61,7 +61,7 @@ export default class NonFungibleTokens {
             if (reference.startsWith('https')) {
                 referenceUrl = reference;
             } else if (reference.startsWith('ar://')) {
-                referenceUrl = `https://arweave.net/${reference}`;
+                referenceUrl = `https://arweave.net/${reference.split('//')[1]}`;
             } else {
                 referenceUrl = `${base_uri}/${reference}`;
             }

--- a/packages/frontend/src/services/NonFungibleTokens.js
+++ b/packages/frontend/src/services/NonFungibleTokens.js
@@ -56,7 +56,16 @@ export default class NonFungibleTokens {
             // TODO: Figure out ARWeave CORS issue
             // NOTE: For some reason raw fetch() doesn't have same issue as sendJson
             // tokenMetadata = sendJson('GET', `${base_uri}/${reference}`);
-            metadata = await (await fetch(`${base_uri}/${reference}`)).json();
+
+            let referenceUrl;
+            if (reference.startsWith('https')) {
+                referenceUrl = reference;
+            } else if (reference.startsWith('ar://')) {
+                referenceUrl = `https://arweave.net/${reference}`;
+            } else {
+                referenceUrl = `${base_uri}/${reference}`;
+            }
+            metadata = await (await fetch(referenceUrl)).json();
         }
 
         return metadata;
@@ -121,7 +130,7 @@ export default class NonFungibleTokens {
             receiverId: contractId,
             actions: [
                 functionCall(
-                    'nft_transfer', 
+                    'nft_transfer',
                     {
                         receiver_id: receiverId,
                         token_id: tokenId


### PR DESCRIPTION
# Handle contract tokens with null `base_uri`
This PR changes the logic responsible for resolving NFT reference material for display in the collectibles tab.

## Why the current implementation doesn't work 
A JS template literal will render `null` inside of the string if the value is null rather than empty string.  Even if used the `+` concatenation operator, `base_uri + '/' + reference` would also cause clients to attempt to load from the current host.  

## Motivation
While maintaining a shared `base_url` on the token contract can save storage and promote continuity between tokens, it is also advantageous allow a token to host its reference wherever it chooses.  

The [NEP 177 specification](https://nomicon.io/Standards/Tokens/NonFungibleToken/Metadata#interface) provides for this, and should be handled if a token contract prefers to behave this way. 

