### PR TITLE
feat: change the steps order on wallet migration

### DIFF
--- a/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
+++ b/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
@@ -1,3 +1,4 @@
+import * as nearApi from 'near-api-js';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -37,7 +38,7 @@ const WalletMigration = ({ open, onClose }) => {
     const availableAccounts = useSelector(selectAvailableAccounts);
     const [loadingMultisigAccounts, setLoadingMultisigAccounts] = useState(true);
     const [accountWithDetails, setAccountWithDetails] = useState([]);
-
+    const [isLoggingOut, setIsLoggingOut] = useState(false);
     useEffect(() => {
         const importRotatableAccounts = async () => {
             const accounts = await wallet.keyStore.getAccounts(NETWORK_ID);
@@ -101,12 +102,20 @@ const WalletMigration = ({ open, onClose }) => {
     };
 
     const onLogout = () => {
-        // TODO: Add logic to remove FAK(s) here so everything gets cleared together
-        return Promise.all(availableAccounts.map((accountId) => wallet.removeWalletAccount(accountId)))
+        setIsLoggingOut(true);
+        return Promise.all(availableAccounts.map(async (accountId) => {
+            const account = await wallet.getAccount(accountId);
+            const keyPair = await wallet.keyStore.getKey(wallet.connection.networkId, accountId);
+            await account.signAndSendTransaction({
+                actions: [nearApi.transactions.deleteKey(keyPair.publicKey)],
+                receiverId: accountId,
+            });
+            return wallet.removeWalletAccount(accountId);
+        }))
             .then(() => {
-                location.reload();
+                setIsLoggingOut(false);
                 deleteMigrationStep();
-                onClose();
+                location.reload();
             });
     };
 
@@ -171,7 +180,7 @@ const WalletMigration = ({ open, onClose }) => {
                 <VerifyingModal onClose={onClose} onNext={navigateToLogOut} onStartOver={onStartOver} />
             )}
             {state.activeView === WALLET_MIGRATION_VIEWS.LOG_OUT && (
-                <LogoutModal onClose={onClose} onLogout={onLogout}/>
+                <LogoutModal onClose={onClose} onLogout={onLogout} isLoggingOut={isLoggingOut} />
             )}
         </div>
     );

--- a/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
+++ b/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
@@ -91,13 +91,13 @@ const WalletMigration = ({ open, onClose }) => {
         handleSetActiveView(WALLET_MIGRATION_VIEWS.VERIFYING);
     };
 
-    const navigateToCleanKeys = () => {
-        handleSetActiveView(WALLET_MIGRATION_VIEWS.CLEAN_KEYS);
-    };
-
     const navigateToLogOut = () => {
         setMigrationStep(WALLET_MIGRATION_VIEWS.LOG_OUT);
         handleSetActiveView(WALLET_MIGRATION_VIEWS.LOG_OUT);
+    };
+
+    const navigateToMigrateAccounts = () => {
+        handleSetActiveView(WALLET_MIGRATION_VIEWS.MIGRATE_ACCOUNTS);
     };
 
     const onLogout = () => {
@@ -143,6 +143,15 @@ const WalletMigration = ({ open, onClose }) => {
                     accountWithDetails={accountWithDetails}
                 />
             )}
+            {state.activeView === WALLET_MIGRATION_VIEWS.CLEAN_KEYS && (
+                <CleanKeysModal
+                    accounts={availableAccounts}
+                    handleSetActiveView={handleSetActiveView}
+                    onClose={onClose}
+                    onNext={navigateToMigrateAccounts}
+                    rotatedKeys={rotatedKeys}
+                />
+            )}
             {state.activeView === WALLET_MIGRATION_VIEWS.MIGRATE_ACCOUNTS && (
                 <MigrateAccountsModal
                     onClose={onClose}
@@ -159,21 +168,11 @@ const WalletMigration = ({ open, onClose }) => {
                 <RedirectingModal wallet={state?.wallet?.name} onNext={navigateToVerifying} />
             )}
             {state.activeView === WALLET_MIGRATION_VIEWS.VERIFYING && (
-                <VerifyingModal onClose={onClose} onNext={navigateToCleanKeys} onStartOver={onStartOver} />
-            )}
-            {state.activeView === WALLET_MIGRATION_VIEWS.CLEAN_KEYS && (
-                <CleanKeysModal
-                    accounts={availableAccounts}
-                    handleSetActiveView={handleSetActiveView}
-                    onClose={onClose}
-                    onNext={navigateToLogOut}
-                    rotatedKeys={rotatedKeys}
-                />
+                <VerifyingModal onClose={onClose} onNext={navigateToLogOut} onStartOver={onStartOver} />
             )}
             {state.activeView === WALLET_MIGRATION_VIEWS.LOG_OUT && (
                 <LogoutModal onClose={onClose} onLogout={onLogout}/>
             )}
-            
         </div>
     );
 };

--- a/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/CleanKeysModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/CleanKeysModal.jsx
@@ -33,9 +33,11 @@ async function getAccountDetails({ accountId, publicKeyBlacklist, wallet }) {
         }, {});
 
     const allAccessKeys = await wallet.getAccessKeys(accountId);
+    const currentAccount = await wallet.getLocalAccessKey(accountId, allAccessKeys);
     const accessKeys = allAccessKeys
         .filter(({ public_key }) =>
             !publicKeyBlacklist.some((key) => key === public_key)
+            && public_key !== currentAccount.public_key
             && recoveryMethods[public_key] !== 'ledger'
         )
         .map(({ public_key }) => ({

--- a/packages/frontend/src/components/wallet-migration/modals/LogoutModal/LogoutModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/LogoutModal/LogoutModal.jsx
@@ -7,6 +7,7 @@ import { ButtonsContainer, StyledButton, MigrationModal, Container, IconBackgrou
 const LogoutModal = ({
     onLogout,
     onClose,
+    isLoggingOut,
 }) => {
 
     return (
@@ -23,13 +24,15 @@ const LogoutModal = ({
                     <StyledButton
                         onClick={onLogout}
                         fullWidth
+                        disabled={isLoggingOut}
+                        sending={isLoggingOut}
+                        sendingString="walletMigration.logout.button"
                     >
                         <Translate id='walletMigration.logout.button' />
                     </StyledButton>
                     <StyledButton className='gray-blue' onClick={onClose} fullWidth>
                         <Translate id='button.cancel' />
                     </StyledButton>
-                    
                 </ButtonsContainer>
             </Container>
         </MigrationModal>

--- a/packages/frontend/src/components/wallet-migration/modals/RedirectingModal/RedirectingModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/RedirectingModal/RedirectingModal.jsx
@@ -8,8 +8,8 @@ const RedirectingModal = ({
     wallet,
     onNext,
 }) => {
-    // move to next modal after 10 seconds
-    setTimeout(() => onNext(), 10000);
+    // move to next modal after 5 seconds
+    setTimeout(() => onNext(), 5000);
 
     return (
         <MigrationModal>

--- a/packages/frontend/src/components/wallet-migration/modals/RotateKeysModal/RotateKeysModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/RotateKeysModal/RotateKeysModal.jsx
@@ -107,7 +107,7 @@ const RotateKeysModal = ({handleSetActiveView, onClose, onRotateKeySuccess, acco
 
     useEffect(() => {
         if (completedWithSuccess) {
-            handleSetActiveView(WALLET_MIGRATION_VIEWS.MIGRATE_ACCOUNTS);
+            handleSetActiveView(WALLET_MIGRATION_VIEWS.CLEAN_KEYS);
         }
     }, [completedWithSuccess]);
 

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1934,7 +1934,7 @@
             "title": "Password required to import accounts"
         },
         "redirect": {
-            "desc": "You’ll be automatically redirected in <b>10 seconds.</b> Once redirected, you’ll need to approve each account as it is added to your new wallet.",
+            "desc": "You’ll be automatically redirected in <b>5 seconds.</b> Once redirected, you’ll need to approve each account as it is added to your new wallet.",
             "title": "Redirecting to ${wallet}"
         },
         "rotateKeys": {


### PR DESCRIPTION
This PR contains changes for wallet migration. 

A. Change the order of wallet migration steps to following:

1. Disable 2FA (if any)
2. Rotate Key
3. Delete FAKs
4. Export Account(s) to third party wallet (To be replaced with wallet-selector)
5. Logout

Intention of this change is to make sure we clean up FAKs before moving to third party wallet. (Also this is only way to make sure we don't accidentally delete any FAK(s) created by third party wallet)

B. Ability to come back and continue where user left

This is achieved by leaving current user's FAK that is used to log in on browser wallet from delete FAK(s) step. This key will be deleted on the final step `Logout`.

