### PR TITLE
fix: verify actions exist

### DIFF
--- a/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
+++ b/packages/frontend/src/components/accounts/two_factor/TwoFactorVerifyModal.js
@@ -139,7 +139,7 @@ const TwoFactorVerifyModal = ({ open, onClose }) => {
             <h2 className='title'><Translate id='twoFactor.verify.title'/></h2>
             <p className='font-bw'><Translate id='twoFactor.verify.desc'/></p>
             <p className='color-black font-bw' style={{ marginTop: '-10px', fontWeight: '500', height: '19px'}}>{method && method.detail}</p>
-            {multisigRequest && <ActionDetailsBanner multisigRequest={multisigRequest} />}
+            {multisigRequest?.actions && <ActionDetailsBanner multisigRequest={multisigRequest} />}
             <Form onSubmit={(e) => {
                 handleVerifyCode();
                 e.preventDefault();


### PR DESCRIPTION
This PR updates the code guard in the 2FA modal to match the expression being evaluated. This prevents the UI from breaking when the call to `get_request` fails.