### PR TITLE
feat: enable WEP_PHASE_ONE in testnet

### DIFF
--- a/features/flags.json
+++ b/features/flags.json
@@ -336,9 +336,9 @@
       "lastEditedAt": "2022-09-29T12:47:40.121Z"
     },
     "testnet_NEARORG": {
-      "enabled": false,
-      "lastEditedBy": "roshaans",
-      "lastEditedAt": "2022-09-29T12:47:40.121Z"
+      "enabled": true,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2023-02-09T22:30:08.582Z"
     },
     "mainnet_NEARORG": {
       "enabled": false,


### PR DESCRIPTION
Enables recovery method/key cleanup and account export on wallet.testnet.near.org.