### PR TITLE
feat: migration banner URL

### DIFF
--- a/features/features.d.ts
+++ b/features/features.d.ts
@@ -9,5 +9,6 @@ export type Features = {
 	RENDER_MIGRATION: boolean;
 	SHOW_MIGRATION_BANNER: boolean;
 	WEB3AUTH: boolean;
+	WEP_DISABLE_ACCOUNT_CREATION: boolean;
 	WEP_PHASE_ONE: boolean;
 };

--- a/features/flags.json
+++ b/features/flags.json
@@ -380,9 +380,9 @@
       "lastEditedAt": "2022-09-29T12:47:40.121Z"
     },
     "testnet_NEARORG": {
-      "enabled": false,
-      "lastEditedBy": "roshaans",
-      "lastEditedAt": "2022-09-29T12:47:40.121Z"
+      "enabled": true,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2023-02-13T22:23:12.644Z"
     },
     "mainnet_NEARORG": {
       "enabled": false,

--- a/features/flags.json
+++ b/features/flags.json
@@ -307,6 +307,50 @@
       "lastEditedAt": "2022-07-19T05:34:11.690Z"
     }
   },
+  "WEP_DISABLE_ACCOUNT_CREATION": {
+    "createdBy": "Andy Haynes",
+    "createdAt": "2023-02-13T18:46:04.151Z",
+    "development": {
+      "enabled": true,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2023-02-13T18:46:04.150Z"
+    },
+    "testnet": {
+      "enabled": false,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2023-02-13T18:46:04.151Z"
+    },
+    "mainnet": {
+      "enabled": false,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2023-02-13T18:46:04.151Z"
+    },
+    "mainnet_STAGING": {
+      "enabled": false,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2023-02-13T18:46:04.151Z"
+    },
+    "testnet_STAGING": {
+      "enabled": false,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2023-02-13T18:46:04.151Z"
+    },
+    "testnet_NEARORG": {
+      "enabled": false,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2023-02-13T18:46:04.151Z"
+    },
+    "mainnet_NEARORG": {
+      "enabled": false,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2023-02-13T18:46:04.151Z"
+    },
+    "mainnet_STAGING_NEARORG": {
+      "enabled": false,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2023-02-13T18:46:04.151Z"
+    }
+  },
   "WEP_PHASE_ONE": {
     "createdBy": "roshaans",
     "createdAt": "2022-09-29T12:47:40.121Z",
@@ -316,9 +360,9 @@
       "lastEditedAt": "2022-11-10T19:42:24.864Z"
     },
     "testnet": {
-      "enabled": true,
-      "lastEditedBy": "Andy Haynes",
-      "lastEditedAt": "2023-02-13T20:13:01.110Z"
+      "enabled": false,
+      "lastEditedBy": "roshaans",
+      "lastEditedAt": "2022-09-29T12:47:40.121Z"
     },
     "mainnet": {
       "enabled": false,

--- a/features/flags.json
+++ b/features/flags.json
@@ -316,9 +316,9 @@
       "lastEditedAt": "2022-11-10T19:42:24.864Z"
     },
     "testnet": {
-      "enabled": false,
-      "lastEditedBy": "roshaans",
-      "lastEditedAt": "2022-09-29T12:47:40.121Z"
+      "enabled": true,
+      "lastEditedBy": "Andy Haynes",
+      "lastEditedAt": "2023-02-13T20:13:01.110Z"
     },
     "mainnet": {
       "enabled": false,

--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { Redirect, Switch } from 'react-router-dom';
 import styled, { ThemeProvider } from 'styled-components';
 
-import { SHOW_MIGRATION_BANNER, WEB3AUTH, WEP_PHASE_ONE } from '../../../../features';
+import { SHOW_MIGRATION_BANNER, WEB3AUTH, WEP_DISABLE_ACCOUNT_CREATION, WEP_PHASE_ONE } from '../../../../features';
 import favicon from '../../src/images/mynearwallet-cropped.svg';
 import TwoFactorVerifyModal from '../components/accounts/two_factor/TwoFactorVerifyModal';
 import {
@@ -457,7 +457,7 @@ class Routing extends Component {
                                 exact
                                 path="/create"
                                 render={(props) => {
-                                    if (WEP_PHASE_ONE) {
+                                    if (WEP_DISABLE_ACCOUNT_CREATION) {
                                         return this.props.history.push('/');
                                     } else {
                                         if (accountFound || !DISABLE_CREATE_ACCOUNT) {

--- a/packages/frontend/src/components/common/MigrationBanner.js
+++ b/packages/frontend/src/components/common/MigrationBanner.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import IconOffload from '../../images/IconOffload';
 import { selectAvailableAccounts, selectAvailableAccountsIsLoading } from '../../redux/slices/availableAccounts';
-import { getMyNearWalletUrl } from '../../utils/getWalletURL';
+import { getNearOrgWalletUrl } from '../../utils/getWalletURL';
 import AlertTriangleIcon from '../svg/AlertTriangleIcon';
 import InfoIcon from '../svg/InfoIcon';
 import FormButton from './FormButton';
@@ -113,6 +113,8 @@ const MigrationBanner = ({ account, onTransfer }) => {
     const availableAccounts = useSelector(selectAvailableAccounts);
     const availableAccountsIsLoading = useSelector(selectAvailableAccountsIsLoading);
 
+    const walletUrl = getNearOrgWalletUrl().replace('https://', '');
+
     const onTransferClick = useCallback(() => {
         if (availableAccounts.length) {
             onTransfer();
@@ -136,8 +138,8 @@ const MigrationBanner = ({ account, onTransfer }) => {
                     </div>
                     {
                         availableAccounts.length
-                            ? <Translate id='migration.message'/>
-                            : <Translate id='migration.redirect' data={{ url: getMyNearWalletUrl() }}/>
+                            ? <Translate id='migration.message' data={{ walletUrl }}/>
+                            : <Translate id='migration.redirect' data={{ walletUrl }}/>
                     }
                 </div>
                 

--- a/packages/frontend/src/components/common/MigrationBanner.js
+++ b/packages/frontend/src/components/common/MigrationBanner.js
@@ -80,7 +80,7 @@ const ContentWrapper =  styled(Container)`
         flex-wrap: none;
         color: #CD2B31;
 
-        > span > a {
+        > div > span > a {
             color: #CD2B31;
             text-decoration: underline;
         }
@@ -136,11 +136,17 @@ const MigrationBanner = ({ account, onTransfer }) => {
                     <div className='alert-container'>
                         <AlertTriangleIcon color={'#E5484D'} />
                     </div>
-                    {
-                        availableAccounts.length
-                            ? <Translate id='migration.message' data={{ walletUrl }}/>
-                            : <Translate id='migration.redirect' data={{ walletUrl }}/>
-                    }
+                    <div>
+                        {
+                            availableAccounts.length
+                                ? <Translate id='migration.message' data={{ walletUrl }}/>
+                                : <Translate id='migration.redirect' data={{ walletUrl }}/>
+                        }
+                        <br />
+                        <br />
+                        {availableAccounts.length > 0 && <Translate id='migration.readMore' />}
+
+                    </div>
                 </div>
                 
                 <CustomButton onClick={onTransferClick}>

--- a/packages/frontend/src/components/landing/GuestLanding.js
+++ b/packages/frontend/src/components/landing/GuestLanding.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Translate } from 'react-localize-redux';
 import styled from 'styled-components';
 
-import { WEP_PHASE_ONE } from '../../../../../features';
+import { WEP_DISABLE_ACCOUNT_CREATION, WEP_PHASE_ONE } from '../../../../../features';
 import iPhoneMockup from '../../images/iphone-mockup.png';
 import FormButton from '../common/FormButton';
 import Container from '../common/styled/Container.css';
@@ -164,7 +164,7 @@ export function GuestLanding({ history }) {
                 <div className='buttons'>
                     <FormButton
                         onClick={() => {
-                            if (WEP_PHASE_ONE) {
+                            if (WEP_DISABLE_ACCOUNT_CREATION) {
                                 setShowModal('more-near-wallets');
                             } else {
                                 history.push('/create');

--- a/packages/frontend/src/components/navigation/Navigation.js
+++ b/packages/frontend/src/components/navigation/Navigation.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
 
-import { WEP_PHASE_ONE } from '../../../../../features';
+import { WEP_DISABLE_ACCOUNT_CREATION } from '../../../../../features';
 import { WalletSelectorGetAWallet } from '../common/wallet_selector/WalletSelectorGetAWallet';
 import DesktopContainer from './DesktopContainer';
 import MobileContainer from './MobileContainer';
@@ -89,7 +89,7 @@ export default ({
     }, []);
 
     const handleOnClickCreateNewAccount = () => {
-        if (WEP_PHASE_ONE) {
+        if (WEP_DISABLE_ACCOUNT_CREATION) {
             setShowModal('more-near-wallets');
         } else {
             history.push('/create');

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -791,6 +791,7 @@
     },
     "migration": {
         "message": "Soon NEAR wallet (${walletUrl}) will no longer be supported. Transfer your accounts to a different wallet or export your private keys from <a href='/profile'>account settings.</a>",
+        "readMore": "Please see our <a href='https://near.org/blog/near-opens-the-door-to-more-wallets/' target='_blank' rel='noopener noreferrer'>blog post</a> for more details on this upcoming transition.",
         "redirect": "Soon NEAR wallet (${walletUrl}) will no longer be supported. Use your 12-word recovery phrase to import your account(s) to a different wallet or <a href='/recover-account'>recover and export your account(s).</a>",
         "redirectCaption": "Learn More",
         "transferCaption": "Transfer My Accounts"

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -790,8 +790,8 @@
         }
     },
     "migration": {
-        "message": "Soon NEAR wallet (wallet.near.org) will no longer be supported. Transfer your accounts to a different wallet or export your private keys from <a href='/profile'>account settings.</a>",
-        "redirect": "Soon NEAR wallet (wallet.near.org) will no longer be supported. Use your 12-word recovery phrase to import your account(s) to a different wallet or <a href='/recover-account'>recover and export your account(s).</a>",
+        "message": "Soon NEAR wallet (${walletUrl}) will no longer be supported. Transfer your accounts to a different wallet or export your private keys from <a href='/profile'>account settings.</a>",
+        "redirect": "Soon NEAR wallet (${walletUrl}) will no longer be supported. Use your 12-word recovery phrase to import your account(s) to a different wallet or <a href='/recover-account'>recover and export your account(s).</a>",
         "redirectCaption": "Learn More",
         "transferCaption": "Transfer My Accounts"
     },


### PR DESCRIPTION
This PR updates the migration banner to include the current URL and keep account creation guarded behind a new flag (to be kept enabled on testnet for ease of testing). It also re-enables `WEP_PHASE_ONE` on testnet, allowing users to export accounts to available wallets.