### PR TITLE
Fix: filter out corrupted accounts and continue wallet-migration

### DIFF
--- a/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
+++ b/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
@@ -43,9 +43,8 @@ const WalletMigration = ({ open, onClose }) => {
     useEffect(() => {
         const importRotatableAccounts = async () => {
             const accounts = await wallet.keyStore.getAccounts(NETWORK_ID);
-            const details = await Promise.all(
-                accounts.map((accountId) => getAccountDetails({ accountId, wallet }))
-            );
+            const details = await Promise.allSettled(accounts.map((accountId) => getAccountDetails({ accountId, wallet })))
+                .then((results) => results.filter(({ status }) => status === 'fulfilled').map(({ value }) => value));
             setAccountWithDetails(details);
             setLoadingMultisigAccounts(false);
         };

--- a/packages/frontend/src/components/wallet-migration/utils.ts
+++ b/packages/frontend/src/components/wallet-migration/utils.ts
@@ -52,14 +52,19 @@ export const redirectLinkdropUser = ({
 };
 
 export async function getAccountDetails({ accountId, wallet }) {
-    const keyType = await wallet.getAccountKeyType(accountId);
-    const accountBalance = await wallet.getBalance(keyType.accountId);
+    try {
+        const keyType = await wallet.getAccountKeyType(accountId);
+        const accountBalance = await wallet.getBalance(keyType.accountId);
 
-    const account = await wallet.getAccount(accountId);
-    let isConversionRequired = false;
-    if (typeof account.isKeyConversionRequiredForDisable === 'function') {
-        isConversionRequired = await account.isKeyConversionRequiredForDisable();
+        const account = await wallet.getAccount(accountId);
+        let isConversionRequired = false;
+        if (typeof account.isKeyConversionRequiredForDisable === 'function') {
+            isConversionRequired = await account.isKeyConversionRequiredForDisable();
+        }
+
+        return { accountId, keyType, accountBalance, isConversionRequired };
+    } catch (e) {
+        console.log(`account ${accountId} error: ${e}`);
+        throw e;
     }
-
-    return { accountId, keyType, accountBalance, isConversionRequired };
 }


### PR DESCRIPTION
This PR contains fix/improvements for wallet-migration from having corrupted accounts included in the list. 

As part of wallet-migration, it attempts to fetch extra detail for each available accounts within the browser prior to start of the migration. Previously if any one of account is corrupted (invalid key pair), the process stuck on initial step and unable to proceed to next step.

To fix this bug, it uses `Promise.allSettled` to gracefully handle the failed accounts and filter them out so migration can continue proceed regardless of presence of corrupted account key pairs. 

`console.log` is left there in case to be used on debugging/helping purposes if end user encounters them.

![image](https://user-images.githubusercontent.com/6027014/222319685-d021f27b-4f0d-4372-8f9a-17a63bad5ac6.png)

