### PR TITLE
fix: use accountWithDetails in CleanKeysModal

### DIFF
--- a/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
+++ b/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
@@ -161,7 +161,7 @@ const WalletMigration = ({ open, onClose }) => {
             )}
             {state.activeView === WALLET_MIGRATION_VIEWS.CLEAN_KEYS && (
                 <CleanKeysModal
-                    accounts={availableAccounts}
+                    accounts={accountWithDetails}
                     handleSetActiveView={handleSetActiveView}
                     onClose={onClose}
                     onNext={navigateToMigrateAccounts}

--- a/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/CleanKeysModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/CleanKeysModal.jsx
@@ -104,7 +104,7 @@ const CleanKeysModal = ({ accounts, handleSetActiveView, onNext, onClose, rotate
     useEffect(() => {
         const importAccounts = async () => {
             const accountDetails = await Promise.all(
-                accounts.map((accountId) => getAccountDetails({
+                accounts.map(({ accountId }) => getAccountDetails({
                     accountId,
                     publicKeyBlacklist: rotatedPublicKeys,
                     wallet,

--- a/packages/frontend/src/config/environmentDefaults/mainnet.js
+++ b/packages/frontend/src/config/environmentDefaults/mainnet.js
@@ -41,7 +41,7 @@ export default {
     ],
     MULTISIG_MIN_AMOUNT: '4',
     MULTISIG_MIN_PROMPT_AMOUNT: '200',
-    NETWORK_ID: 'default',
+    NETWORK_ID: 'mainnet',
     NODE_URL: 'https://rpc.mainnet.near.org',
     REACT_APP_USE_TESTINGLOCKUP: false,
     RECAPTCHA_CHALLENGE_API_KEY: '6LeRzswaAAAAAGeS7mSasZ1wDcGnMcH3D7W1gy1b',

--- a/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.js
+++ b/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.js
@@ -41,7 +41,7 @@ export default {
     ],
     MULTISIG_MIN_AMOUNT: '4',
     MULTISIG_MIN_PROMPT_AMOUNT: '200',
-    NETWORK_ID: 'default',
+    NETWORK_ID: 'mainnet',
     NODE_URL: 'https://rpc.mainnet.near.org',
     REACT_APP_USE_TESTINGLOCKUP: false,
     RECAPTCHA_CHALLENGE_API_KEY: '6LeRzswaAAAAAGeS7mSasZ1wDcGnMcH3D7W1gy1b',

--- a/packages/frontend/src/config/environmentDefaults/testnet.js
+++ b/packages/frontend/src/config/environmentDefaults/testnet.js
@@ -41,7 +41,7 @@ export default {
     ],
     MULTISIG_MIN_AMOUNT: '4',
     MULTISIG_MIN_PROMPT_AMOUNT: '200',
-    NETWORK_ID: 'default',
+    NETWORK_ID: 'testnet',
     NODE_URL: 'https://rpc.testnet.near.org',
     REACT_APP_USE_TESTINGLOCKUP: false,
     SENTRY_DSN: 'https://75d1dabd0ab646329fad8a3e7d6c761d@o398573.ingest.sentry.io/5254526',

--- a/packages/frontend/src/config/environmentDefaults/testnet_STAGING.js
+++ b/packages/frontend/src/config/environmentDefaults/testnet_STAGING.js
@@ -41,7 +41,7 @@ export default {
     ],
     MULTISIG_MIN_AMOUNT: '4',
     MULTISIG_MIN_PROMPT_AMOUNT: '200',
-    NETWORK_ID: 'default',
+    NETWORK_ID: 'testnet',
     NODE_URL: 'https://rpc.testnet.near.org',
     REACT_APP_USE_TESTINGLOCKUP: false,
     SENTRY_DSN: 'https://75d1dabd0ab646329fad8a3e7d6c761d@o398573.ingest.sentry.io/5254526',


### PR DESCRIPTION
Update `CleanKeysModal` to use the sanitized output of `accountWithDetails`. Currently, deleted accounts in your set of available accounts will break during key rotation.