### PR TITLE
Minor UI update on handling implicit account character ellipsis

### DIFF
--- a/packages/frontend/src/components/accounts/recovery_setup/new_account/SavePassphrase.js
+++ b/packages/frontend/src/components/accounts/recovery_setup/new_account/SavePassphrase.js
@@ -1,8 +1,15 @@
 import React from 'react';
 import { Translate } from 'react-localize-redux';
+import styled from 'styled-components';
 
 import Container from '../../../common/styled/Container.css';
 import SetupSeedPhraseForm from '../../SetupSeedPhraseForm';
+
+const AccountIdContainer = styled.div`
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-weight: 800;
+`;
 
 export default ({
     passPhrase,
@@ -16,7 +23,7 @@ export default ({
         <Container className='small-centered border' style={style}>
             <h1><Translate id='setupSeedPhrase.pageTitle' /></h1>
             {
-                accountId && (<h2><b>{accountId}</b></h2>)
+                accountId && (<h2><AccountIdContainer>{accountId}</AccountIdContainer></h2>)
             }
             <h2><Translate id='setupSeedPhrase.pageText' /></h2>
             <SetupSeedPhraseForm

--- a/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/AccessKeyList.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/AccessKeyList.jsx
@@ -42,11 +42,12 @@ const AccessKeyListContainer = styled.div`
         width: 100%;
 
         .account-detail {
-            flex: 7;
+            width: 100%;
 
             .account-id {
                 font-weight: bold;
                 text-overflow: ellipsis;
+                overflow: hidden;
             }
 
             .keys-to-remove {


### PR DESCRIPTION
This PR contains minor UI update related to seed phrase modal with implicit account.

If fixes the UI by applying simple ellipsis:
<img width="544" alt="Greenshot 2023-03-28 11 27 09" src="https://user-images.githubusercontent.com/6027014/228081962-f41599b5-2e6f-43cb-8b68-68431480b244.png">

<img width="479" alt="image" src="https://user-images.githubusercontent.com/6027014/228358523-0970f3f5-5679-4d90-bfba-d5908caa1f43.png">

<img width="494" alt="image" src="https://user-images.githubusercontent.com/6027014/228361805-e8e7b329-90d4-4996-b5d3-42e67c0fe373.png">
