### PR TITLE
Bug fix on account export sending wrong private key

### DIFF
--- a/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
+++ b/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
@@ -95,7 +95,6 @@ const WalletMigration = ({ open, onClose }) => {
     };
 
     const navigateToMigrateAccounts = () => {
-        setMigrationStep(WALLET_MIGRATION_VIEWS.MIGRATE_ACCOUNTS);
         handleSetActiveView(WALLET_MIGRATION_VIEWS.MIGRATE_ACCOUNTS);
     };
 
@@ -173,6 +172,7 @@ const WalletMigration = ({ open, onClose }) => {
                     onComplete={navigateToRedirect}
                     migrationAccounts={accountWithDetails}
                     network={NETWORK_ID === 'default' ? 'testnet': NETWORK_ID}
+                    rotatedKeys={rotatedKeys}
                 />
             )}
             {state.activeView === WALLET_MIGRATION_VIEWS.REDIRECTING && (

--- a/packages/frontend/src/components/wallet-migration/modals/WalletSelectorModal/WalletSelectorModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/WalletSelectorModal/WalletSelectorModal.jsx
@@ -8,14 +8,15 @@ export const WalletSelectorModal = ({ onComplete, migrationAccounts, network, ro
     useEffect(() => {
         const init = async () => {
             const accountsWithKey = await Promise.all(migrationAccounts.map(async (account) => {
-                const privateKey = rotatedKeys[account.accountId];
+                const accountId = account.accountId;
+                const privateKey = rotatedKeys[accountId];
                 if (!privateKey) {
                     throw new Error('Unable to find a private key from the rotated keys');
                 }
 
                 return {
-                    accountId: account.accountId,
-                    privateKey: rotatedKeys[account.accountId],
+                    accountId,
+                    privateKey,
                 };
             }));
             setAccounts(accountsWithKey);

--- a/packages/frontend/src/components/wallet-migration/modals/WalletSelectorModal/WalletSelectorModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/WalletSelectorModal/WalletSelectorModal.jsx
@@ -1,18 +1,21 @@
 import React, { useEffect, useState } from 'react';
 
-import { wallet } from '../../../../utils/wallet';
 import { WalletSelectorContent } from './WalletSelectorContent';
 import { ExportAccountSelectorContextProvider } from './WalletSelectorExportContext';
 
-export const WalletSelectorModal = ({ onComplete, migrationAccounts, network }) => {
+export const WalletSelectorModal = ({ onComplete, migrationAccounts, network, rotatedKeys }) => {
     const [accounts, setAccounts] = useState([]);
     useEffect(() => {
         const init = async () => {
             const accountsWithKey = await Promise.all(migrationAccounts.map(async (account) => {
-                const localKey = await wallet.getLocalSecretKey(account.accountId);
+                const privateKey = rotatedKeys[account.accountId];
+                if (!privateKey) {
+                    throw new Error('Unable to find a private key from the rotated keys');
+                }
+
                 return {
                     accountId: account.accountId,
-                    privateKey: localKey,
+                    privateKey: rotatedKeys[account.accountId],
                 };
             }));
             setAccounts(accountsWithKey);


### PR DESCRIPTION
This PR contains a bug fix for account export where it was sending a private key from localStorage instead of newly created private key from key rotation step. 

Bug is fixed by sending a correct private key from `rotatedKeys` object. 

Conducted full end to end test to make sure that:
1. Correct private key is passed to other wallet
2. Upon logout, private key from localStorage gets deleted and rotated private key is still exist
3. After logout, attempt to transfer token from third party wallet that uses rotated private key to make sure it is available