### PR TITLE
fix: reset to default

### DIFF
--- a/packages/frontend/src/config/environmentDefaults/mainnet.js
+++ b/packages/frontend/src/config/environmentDefaults/mainnet.js
@@ -41,7 +41,7 @@ export default {
     ],
     MULTISIG_MIN_AMOUNT: '4',
     MULTISIG_MIN_PROMPT_AMOUNT: '200',
-    NETWORK_ID: 'mainnet',
+    NETWORK_ID: 'default',
     NODE_URL: 'https://rpc.mainnet.near.org',
     REACT_APP_USE_TESTINGLOCKUP: false,
     RECAPTCHA_CHALLENGE_API_KEY: '6LeRzswaAAAAAGeS7mSasZ1wDcGnMcH3D7W1gy1b',

--- a/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.js
+++ b/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.js
@@ -41,7 +41,7 @@ export default {
     ],
     MULTISIG_MIN_AMOUNT: '4',
     MULTISIG_MIN_PROMPT_AMOUNT: '200',
-    NETWORK_ID: 'mainnet',
+    NETWORK_ID: 'default',
     NODE_URL: 'https://rpc.mainnet.near.org',
     REACT_APP_USE_TESTINGLOCKUP: false,
     RECAPTCHA_CHALLENGE_API_KEY: '6LeRzswaAAAAAGeS7mSasZ1wDcGnMcH3D7W1gy1b',

--- a/packages/frontend/src/config/environmentDefaults/testnet.js
+++ b/packages/frontend/src/config/environmentDefaults/testnet.js
@@ -41,7 +41,7 @@ export default {
     ],
     MULTISIG_MIN_AMOUNT: '4',
     MULTISIG_MIN_PROMPT_AMOUNT: '200',
-    NETWORK_ID: 'testnet',
+    NETWORK_ID: 'default',
     NODE_URL: 'https://rpc.testnet.near.org',
     REACT_APP_USE_TESTINGLOCKUP: false,
     SENTRY_DSN: 'https://75d1dabd0ab646329fad8a3e7d6c761d@o398573.ingest.sentry.io/5254526',

--- a/packages/frontend/src/config/environmentDefaults/testnet_STAGING.js
+++ b/packages/frontend/src/config/environmentDefaults/testnet_STAGING.js
@@ -41,7 +41,7 @@ export default {
     ],
     MULTISIG_MIN_AMOUNT: '4',
     MULTISIG_MIN_PROMPT_AMOUNT: '200',
-    NETWORK_ID: 'testnet',
+    NETWORK_ID: 'default',
     NODE_URL: 'https://rpc.testnet.near.org',
     REACT_APP_USE_TESTINGLOCKUP: false,
     SENTRY_DSN: 'https://75d1dabd0ab646329fad8a3e7d6c761d@o398573.ingest.sentry.io/5254526',


### PR DESCRIPTION
Partial revert of #3017 to remove debugging configuration that breaks only on wallet.near.org (staging unaffected).