### PR TITLE
Added token cache reset interval of one week

### DIFF
--- a/packages/frontend/src/services/indexer/cache.js
+++ b/packages/frontend/src/services/indexer/cache.js
@@ -95,8 +95,8 @@ export class IndexerCache extends Cache {
         return timeNs - lastTimestampNs >= timeoutNs;
     }
 
-    _shouldReset(lastResetTimestamp, resetTimestamp) {
-        return new Date().getTime() - lastResetTimestamp >= resetTimestamp;
+    _shouldReset(lastResetIntervalNs, resetIntervalNs) {
+        return new Date().getTime() - lastResetIntervalNs >= resetIntervalNs;
     }
 
     /**

--- a/packages/frontend/src/services/indexer/cached-api.js
+++ b/packages/frontend/src/services/indexer/cached-api.js
@@ -14,6 +14,7 @@ export default {
             kind: LIKELY_NFT_KEY,
             updater: (timestamp) => api.listLikelyNfts(accountId, timestamp),
             timeoutNs: UPDATE_REQUEST_INTERVAL_NS,
+            resetMs: RESET_REQUEST_INTERVAL_MS,
         });
     },
     listLikelyTokens(accountId, timestamp) {


### PR DESCRIPTION
A large amount of users are raising an issue that they can't see fungible tokens in their near wallet. Indexer and RPC endpoints are returning the tokens correctly, but the issue is still there. There is a big chance that it the problem with the near wallet caching not updating properly.

I added a cache reset for every week so that the cache is synced with the blockchain.