### PR TITLE
fix: avoid relying on NETWORK_ID to reference correct network

### DIFF
--- a/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
+++ b/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
@@ -2,9 +2,10 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { Translate } from 'react-localize-redux';
 import { useSelector, useDispatch } from 'react-redux';
 
-import { NETWORK_ID } from '../../config';
+import { NETWORK_ID, IS_MAINNET } from '../../config';
 import { showCustomAlert } from '../../redux/actions/status';
 import { selectAvailableAccounts } from '../../redux/slices/availableAccounts';
+import { MAINNET, TESTNET } from '../../utils/constants';
 import { wallet } from '../../utils/wallet';
 import LoadingDots from '../common/loader/LoadingDots';
 import { MigrationModal, ButtonsContainer, StyledButton, Container } from './CommonComponents';
@@ -224,7 +225,7 @@ const WalletMigration = ({ open, onClose }) => {
                 <WalletSelectorModal
                     onComplete={navigateToRedirect}
                     migrationAccounts={accountWithDetails}
-                    network={NETWORK_ID === 'default' ? 'testnet': NETWORK_ID}
+                    network={IS_MAINNET ? MAINNET : TESTNET}
                     rotatedKeys={rotatedKeys}
                 />
             )}


### PR DESCRIPTION
This PR contains implementation for fixing the wallet migration wizard error. 

After reverting [this PR](https://github.com/near/near-wallet/pull/3036) , wallet migration wizard fail to operate properly as it was replying on `NETWORK_ID` to reflect the correct network. (eg. `testnet` or `mainnet`)

But revert needed to happen to fix another bug on wallet so wallet wizard also needed to make corresponding change in order to work properly.

