### PR TITLE
fix: redact sensitive data in URLs reported via Sentry

### DIFF
--- a/packages/frontend/src/utils/sentry.js
+++ b/packages/frontend/src/utils/sentry.js
@@ -2,6 +2,17 @@ const Sentry = require('@sentry/browser');
 
 const { SENTRY_DSN, SENTRY_RELEASE } = require('../config');
 
+function sanitizeUrl(url) {
+    if (!url) {
+        return url;
+    }
+
+    return encodeURI(decodeURI(url)
+        .split('#')[0]
+        .replace(/(?:\w{3,12} ){11}(?:\w{3,12})/gi, 'REDACTED')
+        .replace(/(ed25519:)?[\w\d]{65,}/gi, 'REDACTED'));
+}
+
 const initSentry = () => {
     if (!SENTRY_DSN) {
         return;
@@ -14,13 +25,33 @@ const initSentry = () => {
             if (event.request.url.includes('recover-with-link')) {
                 delete event.request.url;
             }
+
+            event.request.url = sanitizeUrl(event.request.url);
+            if (event.request.headers?.Referer) {
+                event.request.headers.Referer = sanitizeUrl(event.request.headers.Referer);
+            }
+            event.breadcrumbs = event.breadcrumbs && event.breadcrumbs.map((breadcrumb) => ({
+                ...breadcrumb,
+                ...(breadcrumb.data && {
+                    data: {
+                        ...breadcrumb.data,
+                        url: sanitizeUrl(breadcrumb.data?.url),
+                    }
+                }),
+            }));
+
             return event;
         },
         beforeBreadcrumb(breadcrumb) {
-            if (breadcrumb.category === 'navigation' &&
-                (breadcrumb.data.from.includes('recover-with-link') ||
-                    breadcrumb.data.to.includes('recover-with-link'))) {
-                delete breadcrumb.data;
+            if (breadcrumb.category === 'navigation') {
+                let { from, to } = breadcrumb.data;
+                if (from.includes('recover-with-link') || to.includes('recover-with-link')) {
+                    delete breadcrumb.data;
+                }
+
+                ([from, to] = [from, to].map(sanitizeUrl));
+                breadcrumb.data.from = from;
+                breadcrumb.data.to = to;
             }
             return breadcrumb;
         }


### PR DESCRIPTION
This PR adds client-side filtering to Sentry reporting to redact sensitive information embedded within the URL, specifically by:
- removing the URL fragment component (only takes what comes before `#`)
- redacting strings with 12 space-delimited words
- redacting strings that could potentially be private keys

This change is to provide an extra assurance that private data is never reported to Sentry. The server-side Sentry integration for wallet.near.org already [strips all URLs which would contain sensitive information](https://docs.sentry.io/product/data-management-settings/scrubbing/server-side-scrubbing/).

![Uploading image.png…]()


See Telegram post for more details: https://t.me/openvpn/190