### PR TITLE
feat: add My Near Wallet to mainnet export list

### DIFF
--- a/packages/frontend/src/components/wallet-migration/modals/WalletSelectorModal/WalletSelectorExportContext.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/WalletSelectorModal/WalletSelectorExportContext.jsx
@@ -24,6 +24,7 @@ const MAINNET_MODULES = [
     setupMeteorWallet,
     setupWelldoneWallet,
     setupHereWallet,
+    setupMyNearWallet,
 ];
 
 const TESTNET_MODULES = [


### PR DESCRIPTION
This PR contains implementation to include `My Near Wallet` back to mainnet supported wallet transfer list. 