### PR TITLE
Bugfix: Account Transfer Wizard clean key bug fix on multiple accounts

### DIFF
--- a/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/CleanKeysModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/CleanKeysModal.jsx
@@ -34,8 +34,7 @@ async function getAccountDetails({ accountId, publicKeyBlacklist, wallet }) {
         }, {});
 
     const allAccessKeys = await wallet.getAccessKeys(accountId);
-    const signingPublicKey = await wallet.getLocalKeyPair(accountId)
-        .then(({ publicKey }) => publicKey.toString());
+    const signingPublicKey = (await wallet.getLocalKeyPair(accountId))?.publicKey.toString();
 
     const accessKeys = allAccessKeys
         .filter(({ public_key }) =>

--- a/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/CleanKeysModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/CleanKeysModal.jsx
@@ -34,12 +34,12 @@ async function getAccountDetails({ accountId, publicKeyBlacklist, wallet }) {
         }, {});
 
     const allAccessKeys = await wallet.getAccessKeys(accountId);
-    const signingPublicKey = (await wallet.getLocalKeyPair(accountId))?.publicKey.toString();
-
+    const signingPublicKey = await wallet.getPublicKey(accountId);
+    
     const accessKeys = allAccessKeys
         .filter(({ public_key }) =>
             !publicKeyBlacklist.some((key) => key === public_key)
-            && public_key !== signingPublicKey
+            && public_key !== signingPublicKey.toString()
             && recoveryMethods[public_key] !== 'ledger'
         )
         .map(({ public_key }) => ({
@@ -58,7 +58,7 @@ async function getAccountDetails({ accountId, publicKeyBlacklist, wallet }) {
 
 async function deleteKeys({ accountId, publicKeysToDelete, wallet }) {
     const account = await wallet.getAccount(accountId);
-    const signingPublicKey = await wallet.getPublicKey();
+    const signingPublicKey = await wallet.getPublicKey(accountId);
     const deleteSigningKey = publicKeysToDelete.some((publicKey) => publicKey === signingPublicKey);
     const keysForBatchDeletion = publicKeysToDelete.length - (deleteSigningKey ? 1 : 0);
 

--- a/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/CleanKeysModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/CleanKeysModal.jsx
@@ -34,11 +34,13 @@ async function getAccountDetails({ accountId, publicKeyBlacklist, wallet }) {
         }, {});
 
     const allAccessKeys = await wallet.getAccessKeys(accountId);
-    const signingPublicKey = await wallet.getPublicKey();
+    const signingPublicKey = await wallet.getLocalKeyPair(accountId)
+        .then(({ publicKey }) => publicKey.toString());
+
     const accessKeys = allAccessKeys
         .filter(({ public_key }) =>
             !publicKeyBlacklist.some((key) => key === public_key)
-            && public_key !== signingPublicKey.toString()
+            && public_key !== signingPublicKey
             && recoveryMethods[public_key] !== 'ledger'
         )
         .map(({ public_key }) => ({


### PR DESCRIPTION
This PR contains bug fix on `Clean Keys` step of wallet migration. 

Previous implementation had a bug where if there are two or more accounts being transferred, it was deleting FAK that is stored in localStorage. (Which it shouldn't be deleted) After investigation, the issue was using public key of first account. So the fix was made by selecting correct public key on each `accountId` given. 