### PR TITLE
UI/UX improvements on clean key step (transfer wizard)

### DIFF
--- a/packages/frontend/src/components/accounts/AccountListImport.js
+++ b/packages/frontend/src/components/accounts/AccountListImport.js
@@ -212,12 +212,13 @@ const AccountListImport = ({ accounts = [], animationScope = 0, onClickAccount }
                     <div className='status'>
                         <StatusIcon status={account.status}/>
                     </div>
-                ) : null}
-                {account.accessKeys && account.accessKeys.length ? (
-                    <div className='access-keys access-keys-to-remove'>
-                        {account.accessKeys.length} {account.accessKeys.length === 1 ? 'key' : 'keys'}
-                    </div>
-                ) : null}
+                ) : (
+                    account.accessKeys && account.accessKeys.length ? (
+                        <div className='access-keys access-keys-to-remove'>
+                            {account?.accessKeys?.length || 'no \n'} {account?.accessKeys?.length === 1 ? 'key' : 'keys'}
+                        </div>
+                    ) : null
+                )}
             </div>
         ))}
     </AnimateList>

--- a/packages/frontend/src/components/common/Checkbox.js
+++ b/packages/frontend/src/components/common/Checkbox.js
@@ -1,9 +1,13 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 const CheckboxContainer = styled.div`
     display: inline-block;
     vertical-align: middle;
+    cursor: pointer;
+    ${(props) => (props.disabled && css`
+        cursor: not-allowed;
+    `)};
 `;
 
 const Icon = styled.svg`
@@ -41,12 +45,25 @@ const StyledCheckbox = styled.div`
     ${Icon} {
         visibility: ${(props) => (props.checked ? 'visible' : 'hidden')};
     }
+
+    ${(props) => (props.red && css`
+        background: ${(props) => (props.checked ? '#FCECEC' : 'white')};
+        border: 2px solid ${(props) => (props.checked ? '#FFBDBE' : '#E6E5E3')};
+        ${Icon} {
+            stroke: #FC5B5B;
+        }
+    `)};
+
+    ${(props) => (props.disabled && css`
+        background: rgba(0,0,0,0.2);
+        border: 2px solid #111618;
+    `)};
 `;
 
-const Checkbox = ({ className, checked, ...props }) => (
-    <CheckboxContainer className={className}>
+const Checkbox = ({ className, checked, red, ...props }) => (
+    <CheckboxContainer className={className} disabled={props.disabled}>
         <HiddenCheckbox checked={checked} {...props} />
-        <StyledCheckbox checked={checked}>
+        <StyledCheckbox checked={checked} red={red} disabled={props.disabled}>
             <Icon viewBox="0 0 24 24">
                 <polyline points="20 6 9 17 4 12" />
             </Icon>

--- a/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/AccessKeyList.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/AccessKeyList.jsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 import { Translate } from 'react-localize-redux';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import classNames from '../../../../utils/classNames';
 import Accordion from '../../../common/Accordion';
 import Checkbox from '../../../common/Checkbox';
+import Tooltip from '../../../common/Tooltip';
 import ChevronIcon from '../../../svg/ChevronIcon';
 import { ButtonsContainer, StyledButton } from '../../CommonComponents';
 
@@ -12,6 +13,16 @@ const AccessKeyListContainer = styled.div`
     display: flex;
     flex-direction: column;
     text-align: left;
+
+    .title {
+        text-align: center;
+    }
+
+    > .desc {
+        text-align: center;
+        font-weight: 12px;
+        margin: 24px 0;
+    }
 
     .access-key {
         display: flex;
@@ -22,7 +33,8 @@ const AccessKeyListContainer = styled.div`
 
         .public-key {
             flex: 7;
-
+            margin-left: 8px;
+            display: flex;
             .key-prefix {
                 font-family: monospace;
             }
@@ -43,7 +55,7 @@ const AccessKeyListContainer = styled.div`
 
         .account-detail {
             width: 100%;
-
+            margin-left: 8px;
             .account-id {
                 font-weight: bold;
                 text-overflow: ellipsis;
@@ -57,9 +69,17 @@ const AccessKeyListContainer = styled.div`
 
         .expand-keys {
             flex: 1;
-            padding: 16px 0 0 0;
+            padding: 16px 16px 0 0;
+            cursor: pointer;
         }
     }
+`;
+
+const IconContainer = styled.div`
+    transform: rotate(90deg);
+    ${({ expanded }) => (expanded && css`
+        transform: rotate(270deg);
+    `)}
 `;
 
 const AccessKeyList = ({ account, onClose, onNext, selectKey, selectedKeys }) => {
@@ -75,6 +95,9 @@ const AccessKeyList = ({ account, onClose, onNext, selectKey, selectedKeys }) =>
             <h3 className='title'>
                 <Translate id='walletMigration.cleanKeys.accountTitle' />
             </h3>
+            <div className="desc">
+                <Translate id='walletMigration.cleanKeys.accountDesc' />
+            </div>
             <div
                 className={classNames(['account', expanded ? 'open' : ''])}
                 id='full-access-keys'
@@ -89,7 +112,9 @@ const AccessKeyList = ({ account, onClose, onNext, selectKey, selectedKeys }) =>
                     </p>
                 </div>
                 <div className='expand-keys'>
-                    <ChevronIcon color='#0072ce' />
+                    <IconContainer expanded={expanded}>
+                        <ChevronIcon color='#0072ce' />
+                    </IconContainer>
                 </div>
             </div>
             <Accordion
@@ -106,11 +131,40 @@ const AccessKeyList = ({ account, onClose, onNext, selectKey, selectedKeys }) =>
                             (<Translate id={`walletMigration.cleanKeys.keyTypes.${kind}`} />)
                         </div>
                         <div className='remove-checkbox' onClick={() => selectKey(publicKey, !checked)}>
-                            <Checkbox checked={checked} />
+                            <Checkbox checked={checked} red />
                         </div>
                     </div>
                 ))}
+                <div className='access-key'>
+                    <div className='public-key'>
+                        <span className='key-prefix'>
+                            Private Key
+                        </span>
+                        &nbsp;
+                        (<Translate id='walletMigration.cleanKeys.keyTypes.rotatedKey' />)
+                        <Tooltip translate="walletMigration.cleanKeys.rotatedKeyTooltip" />
+                    </div>
+                    <div className='remove-checkbox'>
+                        <Checkbox disabled />
+                    </div>
+                </div>
+                <div className='access-key'>
+                    <div className='public-key'>
+                        <span className='key-prefix'>
+                            Private Key
+                        </span>
+                        &nbsp;
+                        (<Translate id='walletMigration.cleanKeys.keyTypes.currentAccessKey' />)
+                        <Tooltip translate="walletMigration.cleanKeys.currentAccessKeyTooltip" />
+                    </div>
+                    <div className='remove-checkbox'>
+                        <Checkbox disabled />
+                    </div>
+                </div>
             </Accordion>
+            <div className="desc">
+                <Translate id='walletMigration.cleanKeys.accountDescTwo' />
+            </div>
             <ButtonsContainer vertical>
                 <StyledButton
                     onClick={onNext}
@@ -121,7 +175,7 @@ const AccessKeyList = ({ account, onClose, onNext, selectKey, selectedKeys }) =>
                     <Translate id='walletMigration.cleanKeys.removeKeys' />
                 </StyledButton>
                 <StyledButton
-                    className='gray-blue'
+                    className='white-blue'
                     onClick={onClose}
                     fullWidth
                 >

--- a/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/CleanKeysModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/CleanKeysModal.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useImmerReducer } from 'use-immer';
 
-import IconSecurityLock from '../../../../images/wallet-migration/IconSecurityLock';
+import IconKey from '../../../../images/wallet-migration/IconKey';
 import { switchAccount } from '../../../../redux/actions/account';
 import { selectAccountId } from '../../../../redux/slices/account';
 import WalletClass, { wallet } from '../../../../utils/wallet';
@@ -185,7 +185,7 @@ const CleanKeysModal = ({ accounts, handleSetActiveView, onNext, onClose, rotate
         <MigrationModal>
             <Container>
                 <IconBackground>
-                    <IconSecurityLock />
+                    <IconKey />
                 </IconBackground>
 
                 {showConfirmSeedphraseModal && (

--- a/packages/frontend/src/components/wallet-migration/modals/RotateKeysModal/RotateKeysModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/RotateKeysModal/RotateKeysModal.jsx
@@ -41,7 +41,7 @@ const Container = styled.div`
 
     .title{
         font-weight: 800;
-        font-size: 20px;
+        font-size: 18px;
         margin-top: 40px;
     }
 `;

--- a/packages/frontend/src/images/wallet-migration/IconKey.js
+++ b/packages/frontend/src/images/wallet-migration/IconKey.js
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+const IconKey = (props) => (
+    <svg width={25} height={24} viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect x={0.5} width={60} height={60} rx={30} fill="#D6EDFF" />
+        <path
+            d="M21.5 2L19.5 4M11.8891 11.6109C12.8844 12.6062 13.5 13.9812 13.5 15.5C13.5 18.5376 11.0376 21 8 21C4.96244 21 2.5 18.5376 2.5 15.5C2.5 12.4624 4.96244 10 8 10C9.51878 10 10.8938 10.6156 11.8891 11.6109ZM11.8891 11.6109L16 7.5M16 7.5L19 10.5L22.5 6.99999L19.5 4M16 7.5L19.5 4"
+            stroke="#0072CE"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+    </svg>
+);
+
+export default IconKey;

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -1889,6 +1889,8 @@
     "walletMigration": {
         "cleanKeys": {
             "accountTitle": "Clean up your keys",
+            "accountDesc": "Now we’ll go through each account and remove your old keys. Next You’ll need your secure passphrase to authorize key removal.",
+            "accountDescTwo": "By removing your keys, you may need to reconnect your account to wallets and dApps.",
             "desc": "For your security, we highly recommend you remove most of your existing access keys.",
             "fullAccessKeys": "Full Access Keys",
             "keep": "Keep",
@@ -1897,7 +1899,9 @@
                 "email": "Email",
                 "phrase": "Recovery Phrase",
                 "sms": "SMS",
-                "unknown": "Unknown"
+                "unknown": "Unknown",
+                "currentAccessKey": "Current Access Key",
+                "rotatedKey": "Rotated Key"
             },
             "nextSteps": "You can manually select which keys to remove in the next step",
             "remove": "Remove",
@@ -1905,14 +1909,16 @@
             "removeKeys": "Remove Keys",
             "title": "Clean up full access keys",
             "verifyPassphrase": {
-                "desc": "Enter your secure passphrase to remove your full access keys from the account: <b>${accountId}</b>",
+                "desc": "Enter your secure passphrase to remove your full access keys from the account: <br /><br /><h4><b>${accountId}</b></h4><br />",
                 "keyMessages": {
                     "doesNotExist": "The input seedphrase does not correspond to any full access keys on ${accountId}.",
                     "insecureRecoveryMethod": "The input seedphrase is associated with an insecure recovery method and may not be used to migrate accounts.",
                     "toBeDeleted": "The input seedphrase corresponds to a key to be deleted and may not be used to migrate accounts."
                 },
                 "title": "Remove your Full Access Keys?"
-            }
+            },
+            "rotatedKeyTooltip": "This key will be used to transfer the account to a new wallet.",
+            "currentAccessKeyTooltip": "This key will be automatically deleted when transfer process is completed."
         },
         "disable2fa": {
             "desc": "2FA must be disabled before you can transfer an account to a new wallet.",


### PR DESCRIPTION
This PR contains UI/UX improvements on clean key step of transfer wizard
Changes are as follow:
- Changed Icon
- Added more context
- Thick box colour change
- Added two private key with info icon to indicate why they can't be deleted at this step
- Updated expand icon
- Upon loading data for each account, it shows `Pending...` label only instead of showing both `x keys` and pending label. 

<img width="435" alt="Greenshot 2023-06-09 13 39 43" src="https://github.com/near/near-wallet/assets/6027014/b88ca562-a0e9-4ab0-a509-4636f664c16e">
<img width="449" alt="Greenshot 2023-06-09 13 40 03" src="https://github.com/near/near-wallet/assets/6027014/5d60b3cc-1988-48d9-8905-1a02d0d29573">
<img width="577" alt="Greenshot 2023-06-09 13 40 13" src="https://github.com/near/near-wallet/assets/6027014/5a4ba99a-a37d-4251-b24a-7245ddafef3f">
<img width="558" alt="Greenshot 2023-06-09 13 40 20" src="https://github.com/near/near-wallet/assets/6027014/355409eb-52c5-4f54-b110-71e35191f7a8">



