### PR TITLE
Minor link update on transfer wizard banner

### DIFF
--- a/packages/frontend/src/components/common/MigrationBanner.js
+++ b/packages/frontend/src/components/common/MigrationBanner.js
@@ -121,7 +121,7 @@ const MigrationBanner = ({ account, onTransfer }) => {
             return;
         }
 
-        window.open('https://near.org/blog/near-opens-the-door-to-more-wallets/', '_blank');
+        window.open('/transfer-wizard', '_blank');
     }, [availableAccounts]);
 
     // If accounts area loading, don't show the banner


### PR DESCRIPTION
This PR contains minor link change on transfer wizard banner with logged out state

![image](https://github.com/near/near-wallet/assets/6027014/567225db-692b-4630-a439-5026ce8bb324)
Upon clicking learn more button, it will redirect to a new static page `/transfer-wizard` which contains a info for transfer wizard process