### PR TITLE
Update to a new data plane url on rudderstack config

### DIFF
--- a/packages/frontend/src/components/wallet-migration/metrics.js
+++ b/packages/frontend/src/components/wallet-migration/metrics.js
@@ -6,7 +6,7 @@ import { KEY_ACTIVE_ACCOUNT_ID } from '../../utils/wallet';
 
 
 export let rudderAnalyticsReady = false;
-const DATA_PLANE_URL = 'https://nearpavelsqp.dataplane.rudderstack.com';
+const DATA_PLANE_URL = 'https://near.dataplane.rudderstack.com';
 const SUPPORTED_ENVIRONMENTS = [
     Environment.MAINNET_NEARORG,
     Environment.MAINNET_STAGING_NEARORG


### PR DESCRIPTION
This PR contains minor update on RudderStack config to replace `DATA_PLANE_URL`. This PR must be merged and tested before releasing transfer wizard