### PR TITLE
Fix: Use correct environment variable to match staging

### DIFF
--- a/packages/frontend/src/components/wallet-migration/metrics.js
+++ b/packages/frontend/src/components/wallet-migration/metrics.js
@@ -1,15 +1,15 @@
 import * as rudderanalytics from 'rudder-sdk-js';
 
-import Environment from '../../../../../features/environments.json';
-import { IS_MAINNET, NEAR_WALLET_ENV } from '../../config';
+import Environments from '../../../../../features/environments.json';
+import { NEAR_WALLET_ENV } from '../../config';
 import { KEY_ACTIVE_ACCOUNT_ID } from '../../utils/wallet';
 
 
 export let rudderAnalyticsReady = false;
 const DATA_PLANE_URL = 'https://near.dataplane.rudderstack.com';
 const SUPPORTED_ENVIRONMENTS = [
-    Environment.MAINNET_NEARORG,
-    Environment.MAINNET_STAGING_NEARORG
+    Environments.MAINNET_NEARORG,
+    Environments.MAINNET_STAGING_NEARORG
 ];
 
 export const initAnalytics = () => {
@@ -24,7 +24,7 @@ export const initAnalytics = () => {
             return;
         }
       
-        const rudderAnalyticsKey = IS_MAINNET
+        const rudderAnalyticsKey = Environments.MAINNET_NEARORG === NEAR_WALLET_ENV
             ? '2RPBJoVn6SRht1E7FnPEZLcpNVh'
             : '2RPBBhH1Dka2bYG6HKQmvkzNUdz';
     


### PR DESCRIPTION
Minor bug fix on rudderstack config to use correct environment variable to match if target is staging or not.