### PR TITLE
Handling rudderstack with adblock

### DIFF
--- a/packages/frontend/src/components/wallet-migration/metrics.js
+++ b/packages/frontend/src/components/wallet-migration/metrics.js
@@ -7,6 +7,9 @@ import { KEY_ACTIVE_ACCOUNT_ID } from '../../utils/wallet';
 
 export let rudderAnalyticsReady = false;
 const DATA_PLANE_URL = 'https://near.dataplane.rudderstack.com';
+const PROD_WRITE_KEY = '2RPBJoVn6SRht1E7FnPEZLcpNVh';
+const STAGING_WRITE_KEY = '2RPBBhH1Dka2bYG6HKQmvkzNUdz';
+
 const SUPPORTED_ENVIRONMENTS = [
     Environments.MAINNET_NEARORG,
     Environments.MAINNET_STAGING_NEARORG
@@ -18,18 +21,29 @@ export const initAnalytics = () => {
             resolve();
             return;
         }
-
+        
         if (!SUPPORTED_ENVIRONMENTS.includes(NEAR_WALLET_ENV)) {
             resolve();
             return;
         }
       
         const rudderAnalyticsKey = Environments.MAINNET_NEARORG === NEAR_WALLET_ENV
-            ? '2RPBJoVn6SRht1E7FnPEZLcpNVh'
-            : '2RPBBhH1Dka2bYG6HKQmvkzNUdz';
+            ? PROD_WRITE_KEY
+            : STAGING_WRITE_KEY;
+
+        // TODO: instead of fallback, implement our own proxy for RudderStack so that metrics won't be filtered by adblockers
+        // If fail to setup RudderStack within 2 seconds, proceed without it
+        const unableToLoadOnTime = () => {
+            console.log('Unable to load RudderStack. Please turn off your adblockers and refresh the page.');
+            resolve();
+            return;
+        };
+
+        const readyTimeout = setTimeout(unableToLoadOnTime, 2000);
     
         rudderanalytics.load(rudderAnalyticsKey, DATA_PLANE_URL);
         rudderanalytics.ready(() => {
+            clearTimeout(readyTimeout);
             rudderAnalyticsReady = true;
             resolve();
         }); 


### PR DESCRIPTION
This PR contains fix for handling RudderStack upon blocked by ublock. 

It was working fine until recent test against Transfer Wizard on staging where it got stuck on initial loading state. It was caused by initial configuration on `RudderStack` due to a chrome extension called `ublock`. 

Therefore, I have implemented in a way that if it fail to establish the `RudderStack` initial config, it silently skips it and allow to proceed the wallet migration without metrics. 

Do not merge this PR if we decided to merge https://github.com/near/near-wallet/pull/3075 instead