### PR TITLE
Minor translation fix related to transfer wizard in RU

### DIFF
--- a/packages/frontend/src/translations/ru.global.json
+++ b/packages/frontend/src/translations/ru.global.json
@@ -551,7 +551,7 @@
         }
     },
     "migration": {
-        "message": "NEAR Wallet переехал на новый домен: <a href='${url}' target='_blank'>mynearwallet.com</a>.<br/>У вас еще есть время перенести Ваши аккаунты, либо экспортировать их ключи из настроек профиля. Переезд завершится ${startDate}.",
+        "message": "NEAR Wallet переехал на новый домен: <a href='${url}' target='_blank'>mynearwallet.com</a>.<br/>У вас еще есть время перенести Ваши аккаунты, либо экспортировать их ключи из настроек профиля.",
         "redirect": "NEAR Wallet переехал на новый домен: <a href='${url}' target='_blank'>mynearwallet.com</a>.<br/>Кликните для перехода.",
         "transferCaption": "Перенести Мои Аккаунты",
         "redirectCaption": "Перейти на MyNearWallet"


### PR DESCRIPTION
This PR contains minor translation fix written in RU. We no longer support `startDate` and this part of translation only exist in RU. Based on commit date, it is very old and out dated. 

Before:
![image](https://github.com/near/near-wallet/assets/6027014/93ec74bb-1308-4b65-ab7a-278f6b66acd7)

Now:
<img width="1060" alt="image" src="https://github.com/near/near-wallet/assets/6027014/c2564e6c-3c95-4c6c-a612-96998f8b5a85">

Thanks to @esaminu and other RU members on reporting this. 