### PR TITLE
Replace account id on rudderstack with hash id

### DIFF
--- a/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
+++ b/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
@@ -9,7 +9,7 @@ import { MAINNET, TESTNET } from '../../utils/constants';
 import { wallet } from '../../utils/wallet';
 import LoadingDots from '../common/loader/LoadingDots';
 import { MigrationModal, ButtonsContainer, StyledButton, Container } from './CommonComponents';
-import { resetUserState, initAnalytics, recordWalletMigrationEvent, recordWalletMigrationState, rudderAnalyticsReady, getAccountIdHash, accountIdToHash, clearAccountIdHash } from './metrics';
+import { resetUserState, initAnalytics, recordWalletMigrationEvent, recordWalletMigrationState, rudderAnalyticsReady, accountIdToHash, clearHashId } from './metrics';
 import CleanKeysCompleteModal from './modals/CleanKeysCompleteModal/CleanKeyCompleteModal';
 import CleanKeysModal from './modals/CleanKeysModal/CleanKeysModal';
 import Disable2FAModal from './modals/Disable2faModal/Disable2FA';
@@ -141,12 +141,12 @@ const WalletMigration = ({ open, onClose }) => {
                 errorMessage: `fail to delete keys for account(s) ${failedAccounts.join(', ')}`,
             }));
         } else {
-            const hashId = getAccountIdHash(availableAccounts[0]);
+            const hashId = accountIdToHash(availableAccounts[0]);
             recordWalletMigrationState({ state: 'migration completed' }, hashId);
             resetUserState();
             onClose();
+            clearHashId();
             deleteMigrationStep();
-            clearAccountIdHash(availableAccounts[0]);  
             location.reload();
         }
     };
@@ -154,6 +154,7 @@ const WalletMigration = ({ open, onClose }) => {
     const onStartOver = () => {
         recordWalletMigrationEvent(`${WALLET_MIGRATION_VIEWS.VERIFYING} START_OVER`);
         deleteMigrationStep();
+        clearHashId();
         handleSetActiveView(WALLET_MIGRATION_VIEWS.DISABLE_2FA);
     };
 

--- a/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
+++ b/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
@@ -9,7 +9,7 @@ import { MAINNET, TESTNET } from '../../utils/constants';
 import { wallet } from '../../utils/wallet';
 import LoadingDots from '../common/loader/LoadingDots';
 import { MigrationModal, ButtonsContainer, StyledButton, Container } from './CommonComponents';
-import { resetUserState, initAnalytics, recordWalletMigrationEvent, recordWalletMigrationState, rudderAnalyticsReady, accountIdToHash, clearHashId } from './metrics';
+import { resetUserState, initAnalytics, recordWalletMigrationEvent, recordWalletMigrationState, rudderAnalyticsReady, accountIdToHash } from './metrics';
 import CleanKeysCompleteModal from './modals/CleanKeysCompleteModal/CleanKeyCompleteModal';
 import CleanKeysModal from './modals/CleanKeysModal/CleanKeysModal';
 import Disable2FAModal from './modals/Disable2faModal/Disable2FA';
@@ -145,7 +145,6 @@ const WalletMigration = ({ open, onClose }) => {
             recordWalletMigrationState({ state: 'migration completed' }, hashId);
             resetUserState();
             onClose();
-            clearHashId();
             deleteMigrationStep();
             location.reload();
         }
@@ -154,7 +153,6 @@ const WalletMigration = ({ open, onClose }) => {
     const onStartOver = () => {
         recordWalletMigrationEvent(`${WALLET_MIGRATION_VIEWS.VERIFYING} START_OVER`);
         deleteMigrationStep();
-        clearHashId();
         handleSetActiveView(WALLET_MIGRATION_VIEWS.DISABLE_2FA);
     };
 

--- a/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
+++ b/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
@@ -9,7 +9,7 @@ import { MAINNET, TESTNET } from '../../utils/constants';
 import { wallet } from '../../utils/wallet';
 import LoadingDots from '../common/loader/LoadingDots';
 import { MigrationModal, ButtonsContainer, StyledButton, Container } from './CommonComponents';
-import { resetUserState, initAnalytics, recordWalletMigrationEvent, recordWalletMigrationState, rudderAnalyticsReady } from './metrics';
+import { resetUserState, initAnalytics, recordWalletMigrationEvent, recordWalletMigrationState, rudderAnalyticsReady, getAccountIdHash, setAccountIdHash } from './metrics';
 import CleanKeysCompleteModal from './modals/CleanKeysCompleteModal/CleanKeyCompleteModal';
 import CleanKeysModal from './modals/CleanKeysModal/CleanKeysModal';
 import Disable2FAModal from './modals/Disable2faModal/Disable2FA';
@@ -141,9 +141,8 @@ const WalletMigration = ({ open, onClose }) => {
                 errorMessage: `fail to delete keys for account(s) ${failedAccounts.join(', ')}`,
             }));
         } else {
-            // On success, update segment with first accountId as reference
-            // Due to .deleteKey above, we have to explicity pass fallbackAcountId to recordWalletMigrationState
-            recordWalletMigrationState({ state: 'migration completed' }, availableAccounts[0]);
+            const hashId = getAccountIdHash() || setAccountIdHash(availableAccounts[0]);
+            recordWalletMigrationState({ state: 'migration completed' }, hashId);
             resetUserState();
             onClose();
             deleteMigrationStep();    

--- a/packages/frontend/src/components/wallet-migration/metrics.js
+++ b/packages/frontend/src/components/wallet-migration/metrics.js
@@ -58,7 +58,7 @@ export const recordWalletMigrationEvent = (eventLabel, properties = {}) => {
 
     try {
         const accountId = localStorage.getItem(KEY_ACTIVE_ACCOUNT_ID);
-        const hashId = getAccountIdHash() || setAccountIdHash(accountId);
+        const hashId = getAccountIdHash(accountId);
         rudderanalytics.track(eventLabel, { ...properties, userId: hashId });
     } catch (e) {
         console.error(e);
@@ -72,7 +72,7 @@ export const recordWalletMigrationState = (traits = {}, fallBackAccountId) => {
 
     try {
         const accountId = localStorage.getItem(KEY_ACTIVE_ACCOUNT_ID) || fallBackAccountId;
-        const hashId = getAccountIdHash() || setAccountIdHash(accountId);
+        const hashId = getAccountIdHash(accountId);
         rudderanalytics.identify(
             hashId,
             {
@@ -92,14 +92,22 @@ export const resetUserState = () => {
     return rudderanalytics.reset();
 };
 
-export function setAccountIdHash(accountId) {
+export function accountIdToHash(accountId) {
     const hash = sha256.create();
     hash.update(accountId);
-    const hashId = hash.hex();
-    localStorage.setItem('hashId', hashId);
+    return hash.hex();
+};
+
+export function setAccountIdHash(accountId) {
+    const hashId = accountIdToHash(accountId);
+    localStorage.setItem(`hash:${accountId}`, hashId);
     return hashId;
 };
 
-export function getAccountIdHash() {
-    return localStorage.getItem('hashId');
+export function getAccountIdHash(accountId) {
+    return localStorage.getItem(`hash:${accountId}`) || setAccountIdHash(accountId);
+};
+
+export function clearAccountIdHash(accountId) {
+    localStorage.removeItem(`hash:${accountId}`);
 };

--- a/packages/frontend/src/components/wallet-migration/metrics.js
+++ b/packages/frontend/src/components/wallet-migration/metrics.js
@@ -16,8 +16,6 @@ const SUPPORTED_ENVIRONMENTS = [
     Environments.MAINNET_STAGING_NEARORG
 ];
 
-let accountIdHash = null;
-
 export const initAnalytics = () => {
     return new Promise((resolve) => {
         if (rudderAnalyticsReady) {
@@ -95,14 +93,7 @@ export const resetUserState = () => {
 };
 
 export function accountIdToHash(accountId) {
-    if (!accountIdHash)  {
-        const hash = sha256.create();
-        hash.update(accountId);
-        accountIdHash = hash.hex();
-    }
-    return accountIdHash;
-};
-
-export function clearHashId () {
-    accountIdHash = null;
+    const hash = sha256.create();
+    hash.update(accountId);
+    return hash.hex();
 };

--- a/packages/frontend/src/components/wallet-migration/metrics.js
+++ b/packages/frontend/src/components/wallet-migration/metrics.js
@@ -16,6 +16,8 @@ const SUPPORTED_ENVIRONMENTS = [
     Environments.MAINNET_STAGING_NEARORG
 ];
 
+let accountIdHash = null;
+
 export const initAnalytics = () => {
     return new Promise((resolve) => {
         if (rudderAnalyticsReady) {
@@ -58,7 +60,7 @@ export const recordWalletMigrationEvent = (eventLabel, properties = {}) => {
 
     try {
         const accountId = localStorage.getItem(KEY_ACTIVE_ACCOUNT_ID);
-        const hashId = getAccountIdHash(accountId);
+        const hashId = accountIdToHash(accountId);
         rudderanalytics.track(eventLabel, { ...properties, userId: hashId });
     } catch (e) {
         console.error(e);
@@ -72,7 +74,7 @@ export const recordWalletMigrationState = (traits = {}, fallBackAccountId) => {
 
     try {
         const accountId = localStorage.getItem(KEY_ACTIVE_ACCOUNT_ID) || fallBackAccountId;
-        const hashId = getAccountIdHash(accountId);
+        const hashId = accountIdToHash(accountId);
         rudderanalytics.identify(
             hashId,
             {
@@ -93,21 +95,14 @@ export const resetUserState = () => {
 };
 
 export function accountIdToHash(accountId) {
-    const hash = sha256.create();
-    hash.update(accountId);
-    return hash.hex();
+    if (!accountIdHash)  {
+        const hash = sha256.create();
+        hash.update(accountId);
+        accountIdHash = hash.hex();
+    }
+    return accountIdHash;
 };
 
-export function setAccountIdHash(accountId) {
-    const hashId = accountIdToHash(accountId);
-    localStorage.setItem(`hash:${accountId}`, hashId);
-    return hashId;
-};
-
-export function getAccountIdHash(accountId) {
-    return localStorage.getItem(`hash:${accountId}`) || setAccountIdHash(accountId);
-};
-
-export function clearAccountIdHash(accountId) {
-    localStorage.removeItem(`hash:${accountId}`);
+export function clearHashId () {
+    accountIdHash = null;
 };

--- a/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/CleanKeysModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/CleanKeysModal/CleanKeysModal.jsx
@@ -11,7 +11,7 @@ import { IMPORT_STATUS } from '../../../accounts/batch_import_accounts';
 import sequentialAccountImportReducer, { ACTIONS } from '../../../accounts/batch_import_accounts/sequentialAccountImportReducer';
 import LoadingDots from '../../../common/loader/LoadingDots';
 import { MigrationModal, Container, IconBackground } from '../../CommonComponents';
-import { recordWalletMigrationEvent } from '../../metrics';
+import { accountIdToHash, recordWalletMigrationEvent } from '../../metrics';
 import { WALLET_MIGRATION_VIEWS } from '../../WalletMigration';
 import AccessKeyList from './AccessKeyList';
 import AccountKeyCleanup from './AccountKeyCleanup';
@@ -209,7 +209,7 @@ const CleanKeysModal = ({ accounts, handleSetActiveView, onNext, onClose, rotate
                                 setKeysAreDeleting(false);
                                 recordWalletMigrationEvent(`${WALLET_MIGRATION_VIEWS.CLEAN_KEYS} COMPLETED`, {
                                     numberOfFAKDeleted: keysToRemove.length,
-                                    accountId: currentAccount.accountId,
+                                    accountId: accountIdToHash(currentAccount.accountId),
                                 });
                             }
                             setShowConfirmSeedphraseModal(false);


### PR DESCRIPTION
This PR contains implementation to replace existing `account id` details on RudderStack metrics with hash id.

The team decided to not track account Id from RudderStack on Transfer Wizard. So similar to how it is implemented on `near-discovery` we hash the accountId and use it instead.

This change need to be published to prod as soon as it passes the review.