### PR TITLE
feat: blacklist wildcards

### DIFF
--- a/packages/frontend/src/hooks/useTokenBlacklist.js
+++ b/packages/frontend/src/hooks/useTokenBlacklist.js
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 /**
  * Determine whether a fungible token contract should be included given a token blacklist
- * @param token {string} token contract name under consideration
+ * @param tokenContract {string} token contract name under consideration
  * @param blacklist {string[]} list of blacklisted tokens; either the full name or a leading wildcard ('*')
  * @returns {boolean}
  */

--- a/packages/frontend/src/hooks/useTokenBlacklist.js
+++ b/packages/frontend/src/hooks/useTokenBlacklist.js
@@ -1,5 +1,26 @@
 import { useMemo } from 'react';
 
+/**
+ * Determine whether a fungible token contract should be included given a token blacklist
+ * @param token {string} token contract name under consideration
+ * @param blacklist {string[]} list of blacklisted tokens; either the full name or a leading wildcard ('*')
+ * @returns {boolean}
+ */
+export function isTokenIncluded(tokenContract, blacklist) {
+    for (let blacklistedToken of blacklist) {
+        if (tokenContract === blacklistedToken) {
+            return false;
+        }
+
+        // e.g. *.mallory.near would exclude a.mallory.near and b.mallory.near
+        if (blacklistedToken.startsWith('*') && tokenContract.endsWith(blacklistedToken.slice(1))) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 export function useTokenBlacklist({ tokens }) {
     // TODO: make list dynamic, fetch from db
     const blacklistedTokens = [
@@ -12,7 +33,7 @@ export function useTokenBlacklist({ tokens }) {
             return tokens;
         }
 
-        return tokens.filter((token) => !blacklistedTokens.includes(token.contractName));
+        return tokens.filter((token) => isTokenIncluded(token.contractName, blacklistedTokens));
     }, [tokens]);
 
     return { blacklistedTokens, allowedTokens };

--- a/packages/frontend/src/hooks/useTokenBlacklist.js
+++ b/packages/frontend/src/hooks/useTokenBlacklist.js
@@ -25,7 +25,7 @@ export function useTokenBlacklist({ tokens }) {
     // TODO: make list dynamic, fetch from db
     const blacklistedTokens = [
         'kusama-airdrop.near',
-        'youwon400neartoclaimyourgainwwwlotte.laboratory.jumpfinance.near',
+        '*.laboratory.jumpfinance.near',
     ];
 
     const allowedTokens = useMemo(() => {

--- a/packages/frontend/test/token_blacklist.test.js
+++ b/packages/frontend/test/token_blacklist.test.js
@@ -1,0 +1,22 @@
+const { isTokenIncluded } = require('../src/hooks/useTokenBlacklist');
+
+describe('Fungible Token Blacklist', () => {
+    test('non-blacklisted tokens are included', () => {
+        expect(isTokenIncluded('test.near', ['not.near'])).toBe(true);
+    });
+
+    test('explicitly blacklisted tokens are excluded', () => {
+        expect(isTokenIncluded('test.near', ['test.near'])).toBe(false);
+    });
+
+    test('wildcard-prefixed blacklisted tokens are excluded', () => {
+        expect(isTokenIncluded('mal.test.near', ['*.test.near'])).toBe(false);
+        expect(isTokenIncluded('mal.test.near', ['xyz.near', '*.test.near'])).toBe(false);
+    });
+
+    test('non-matching tokens are included despite wildcard-prefixed blacklisted tokens', () => {
+        expect(isTokenIncluded('test.near', ['*.test.near'])).toBe(true);
+        expect(isTokenIncluded('xyz.near', ['*.test.near'])).toBe(true);
+        expect(isTokenIncluded('xyz.near', ['*.test.near', 'abc.near'])).toBe(true);
+    });
+});


### PR DESCRIPTION
This PR adds support for `*` wildcards as prefixes to token blacklist entries. This allows us to block ranges of subaccounts rather than blocking them individually. Can definitely be extended in the future if needed, this is just a simple implementation to hide spam tokens under the same root account.