### PR TITLE
Update on wallet migration banner label

### DIFF
--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -791,7 +791,7 @@
         }
     },
     "migration": {
-        "message": "As of <b>October 31st, 2023</b> the NEAR wallet will be discontinued. No changes will be made to your account or it’s assets. Use your recovery phrase or the <a href='/transfer-wizard' target='_blank' rel='noopener noreferrer'>Transfer Wizard</a> to securely migrate to a different wallet. <a href='https://near.org/blog/embracing-decentralization-whats-next-for-the-near-wallet' target='_blank' rel='noopener noreferrer'><b>Learn More</b></a>",
+        "message": "As of <b>October 31st, 2023</b> the NEAR wallet will be discontinued. No changes will be made to your account or its assets. Use your recovery phrase or the <a href='/transfer-wizard' target='_blank' rel='noopener noreferrer'>Transfer Wizard</a> to securely migrate to a different wallet. <a href='https://near.org/blog/embracing-decentralization-whats-next-for-the-near-wallet' target='_blank' rel='noopener noreferrer'><b>Learn More</b></a>",
         "redirectCaption": "Learn More",
         "transferCaption": "Transfer My Accounts"
     },

--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -791,7 +791,7 @@
         }
     },
     "migration": {
-        "message": "The NEAR Wallet will no longer be available after <b>October 31st, 2023</b>. Migrate accounts with your recovery phrase or the <a href='/transfer-wizard' target='_blank' rel='noopener noreferrer'>Transfer Wizard</a> to ensure uninterrupted account access. <a href='https://near.org/blog/embracing-decentralization-whats-next-for-the-near-wallet' target='_blank' rel='noopener noreferrer'><b>Learn More</b></a>",
+        "message": "As of <b>October 31st, 2023</b> the NEAR wallet will be discontinued. No changes will be made to your account or it’s assets. Use your recovery phrase or the <a href='/transfer-wizard' target='_blank' rel='noopener noreferrer'>Transfer Wizard</a> to securely migrate to a different wallet. <a href='https://near.org/blog/embracing-decentralization-whats-next-for-the-near-wallet' target='_blank' rel='noopener noreferrer'><b>Learn More</b></a>",
         "redirectCaption": "Learn More",
         "transferCaption": "Transfer My Accounts"
     },

--- a/packages/frontend/src/translations/kr.global.json
+++ b/packages/frontend/src/translations/kr.global.json
@@ -790,7 +790,6 @@
         }
     },
     "migration": {
-        "message": "NEAR Wallet은 <b>2023년 10월 31일</b> 이후에는 더 이상 사용하실 수 없습니다. 복구 단어(Passphrase)들을 사용하여 계정을 다른 지갑에서 등록 하시거나<a href='/transfer-wizard' target='_blank' rel='noopener noreferrer'>계정 이전 도우미</a>를 사용하여 계정을 이전 후 다른 지갑에서 계속 사용 하실수 있습니다. <a href='https://near.org/blog/embracing-decentralization-whats-next-for-the-near-wallet' target='_blank' rel='noopener noreferrer'><b>자세히 알아보기</b></a>",
         "redirectCaption": "더 알아보기",
         "transferCaption": "계정 전송"
     },

--- a/packages/frontend/src/translations/ru.global.json
+++ b/packages/frontend/src/translations/ru.global.json
@@ -551,7 +551,6 @@
         }
     },
     "migration": {
-        "message": "Кошелёк NEAR будет недоступен с <b>31го октября 2023</b>. Перенесите свои аккаунты с помощью фразы восстановления из 12 слов или <a href='/transfer-wizard' target='_blank' rel='noopener noreferrer'>инструкции по переносу</a> для дальнейшего использования своего аккаунта. <a href='https://near.org/blog/embracing-decentralization-whats-next-for-the-near-wallet' target='_blank' rel='noopener noreferrer'><b>Узнать больше</b></a>",
         "transferCaption": "Перенести Мои Аккаунты",
         "redirectCaption": "Перейти на MyNearWallet"
     },


### PR DESCRIPTION
This PR contains update on migration label. 

<img width="1086" alt="image" src="https://github.com/near/near-wallet/assets/6027014/41e8bd52-2f98-41b2-910f-28835154fe4a">

Intention is to surface the message of `No changes will be made to your account or it's assets`. 

Removed KR and RU translation because we don't have time to wait. We are planning to post a message on wallet builder group to help us update on the translation. 