### PR TITLE
Wallet Migration skip Key rotation step

### DIFF
--- a/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
+++ b/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
@@ -124,10 +124,7 @@ const WalletMigration = ({ open, onClose }) => {
         setIsLoggingOut(true);
         const failedAccounts = [];
         for (const accountId of availableAccounts) {
-            const publicKey = await wallet.getPublicKey(accountId);
             try {
-                const account = await wallet.getAccount(accountId);
-                await account.deleteKey(publicKey);
                 await wallet.removeWalletAccount(accountId);
             } catch {
                 failedAccounts.push(accountIdToHash(accountId));

--- a/packages/frontend/src/components/wallet-migration/modals/Disable2faModal/Disable2FA.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/Disable2faModal/Disable2FA.jsx
@@ -140,7 +140,7 @@ const Disable2FAModal = ({ handleSetActiveView, onClose, accountWithDetails, set
 
     useEffect(() => {
         if (completedWithSuccess) {
-            handleSetActiveView(WALLET_MIGRATION_VIEWS.ROTATE_KEYS);
+            handleSetActiveView(WALLET_MIGRATION_VIEWS.MIGRATE_ACCOUNTS);
         }
     }, [completedWithSuccess]);
 

--- a/packages/frontend/src/components/wallet-migration/modals/WalletSelectorModal/WalletSelectorModal.jsx
+++ b/packages/frontend/src/components/wallet-migration/modals/WalletSelectorModal/WalletSelectorModal.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
+import { wallet } from '../../../../utils/wallet';
 import { WalletSelectorContent } from './WalletSelectorContent';
 import { ExportAccountSelectorContextProvider } from './WalletSelectorExportContext';
 
@@ -9,11 +10,7 @@ export const WalletSelectorModal = ({ onComplete, migrationAccounts, network, ro
         const init = async () => {
             const accountsWithKey = await Promise.all(migrationAccounts.map(async (account) => {
                 const accountId = account.accountId;
-                const privateKey = rotatedKeys[accountId];
-                if (!privateKey) {
-                    throw new Error('Unable to find a private key from the rotated keys');
-                }
-
+                const privateKey = await wallet.getLocalSecretKey(accountId);
                 return {
                     accountId,
                     privateKey,


### PR DESCRIPTION
Wallet migration team decided to skip the key rotation step to avoid further confusion and stress by users. 

This implementation contains slight change that will skip key rotation steps. (skipping creating new seed phrase and delete keys)

So far I have tested them on testnet environment and it work as expected. 

