### PR TITLE
Add Call To Action Button on Transfer Wizard Doc

### DIFF
--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -520,7 +520,13 @@ class Routing extends Component {
                             <Route
                                 exact
                                 path="/transfer-wizard"
-                                component={TransferWizardWrapper}
+                                render={() => (
+                                    <TransferWizardWrapper
+                                        account={account}
+                                        onTransfer={this.handleTransferClick} 
+                                    />
+                                )}
+                                props
                             />
                             <Route
                                 exact

--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -526,7 +526,6 @@ class Routing extends Component {
                                         onTransfer={this.handleTransferClick} 
                                     />
                                 )}
-                                props
                             />
                             <Route
                                 exact

--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -523,7 +523,7 @@ class Routing extends Component {
                                 render={() => (
                                     <TransferWizardWrapper
                                         account={account}
-                                        onTransfer={this.handleTransferClick} 
+                                        onTransfer={() => this.handleTransferClick()}
                                     />
                                 )}
                             />

--- a/packages/frontend/src/routes/TransferWizardWrapper.js
+++ b/packages/frontend/src/routes/TransferWizardWrapper.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import FormButton from '../components/common/FormButton';
 import Container from '../components/common/styled/Container.css'; 
 import logOutImg from '../images/wallet-migration/screenshots/log-out.png';
 import transferAccountsImg from '../images/wallet-migration/screenshots/transfer-your-accounts.png';
@@ -28,8 +29,12 @@ const ScreenshotImg = styled.img`
     width: 300px;
 `;
 
+const CallToAction = styled(FormButton)`
+    width: 100%;
+`;
 
-export const TransferWizardWrapper = () => {
+
+export const TransferWizardWrapper = ({ onTransfer, account }) => {
     return (
         <Container>
             <h1 >Migrating from Near Wallet</h1>
@@ -171,6 +176,11 @@ export const TransferWizardWrapper = () => {
                     </ImageTd>
                 </tr>
             </Table>
+            {
+                account?.localStorage?.accountFound && (
+                    <CallToAction onClick={onTransfer}>Transfer Accounts</CallToAction>
+                )
+            }
         </ Container>
     );
 };


### PR DESCRIPTION
This PR contains minor change on transfer wizard doc to include call to action button at the bottom of the doc, allowing user to initiate the transfer wizard from doc page:

<img width="1204" alt="image" src="https://github.com/near/near-wallet/assets/6027014/17d1912c-ce3d-4f39-85ae-b06f95732115">

This button will only be visible if there is at least one account already signed in.

https://github.com/near/wallet-experience/issues/15