### PR TITLE
Minor bug fix on rudderstack

### DIFF
--- a/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
+++ b/packages/frontend/src/components/wallet-migration/WalletMigration.jsx
@@ -68,7 +68,9 @@ const WalletMigration = ({ open, onClose }) => {
 
     const handleSetActiveView = useCallback((activeView) => {
         handleStateUpdate({ activeView });
-        recordWalletMigrationEvent(activeView);
+        if (activeView) {
+            recordWalletMigrationEvent(activeView);
+        }
     }, [handleStateUpdate]);
 
   

--- a/packages/frontend/src/components/wallet-migration/metrics.js
+++ b/packages/frontend/src/components/wallet-migration/metrics.js
@@ -52,10 +52,6 @@ export const initAnalytics = () => {
 };
 
 export const recordWalletMigrationEvent = (eventLabel, properties = {}) => {
-    if (!rudderAnalyticsReady) {
-        return;
-    }
-
     try {
         const accountId = localStorage.getItem(KEY_ACTIVE_ACCOUNT_ID);
         const hashId = accountIdToHash(accountId);


### PR DESCRIPTION
This PR contains two minor fixes:
1. Only track if event label is present
2. Let Rudderstack manage the when to send track event instead of explicitly checking `rudderAnalyticsReady` condition

Background:
During the implementation of new events regards to near wallet sunset, I have encountered that some of the events weren't firing to rudderstack even if they have `eventLabel` present. After investigation, I remembered that there was a condition in place to check rudderstack initialize complete and only then send track events. Previously it was enough to cater for wallet migration implementation. However, on near sunset, we are tracking events that occur during visiting landing page + visiting unsupported page and redirect event. This is normally happening in the very early stage of the render and it wasn't sending events because  `rudderAnalyticsReady` wasn't ready. Was planning to implement logic to wait until initialization is complete, but before going to it, I was experimenting that if rudderstack actually handles this type of situation internally where, many other analytics now actually store the events in buffer if track event actually happens before initialization completes. (And send the events after automatically) And luckily it handles internally so decided to remove unnecessary logic. 