### PR TITLE
feat(Footer): add contact us

### DIFF
--- a/packages/frontend/src/components/common/Footer.js
+++ b/packages/frontend/src/components/common/Footer.js
@@ -116,6 +116,11 @@ const Footer = () => {
                         ) : <img src={NearLogo} alt='NEAR' />
                     }
                 </div>
+                <div className='support-link'>
+                    <a href="https://nearhelp.zendesk.com/hc/en-us/requests/new" target="_blank" rel="noopener noreferrer">
+                        Contact Support
+                    </a>
+                </div>
                 <div>
                     &copy; {new Date().getFullYear()} <Translate id='footer.copyrights' />
                 </div>


### PR DESCRIPTION
Adding contact us to wallet.near.org in the footer linking to https://nearhelp.zendesk.com/hc/en-us/requests/new
CC: @reiokam 

![image](https://github.com/near/near-wallet/assets/146785798/6c70ab71-0d6b-4278-a546-807510b06853)
