### PR TITLE
feat: email recovery link to redirect to my near wallet

### DIFF
--- a/packages/frontend/src/components/Routing.js
+++ b/packages/frontend/src/components/Routing.js
@@ -62,6 +62,7 @@ import { PageNotFound } from './page-not-found/PageNotFound';
 import Privacy from './privacy/Privacy';
 import Terms from './terms/Terms';
 import { initAnalytics } from './wallet-migration/metrics';
+import RecoveryRedirect from './wallet-migration/RecoveryRedirect';
 import { getMigrationStep } from './wallet-migration/utils';
 import WalletMigration, { WALLET_MIGRATION_VIEWS } from './wallet-migration/WalletMigration';
 import '../index.css';
@@ -420,6 +421,11 @@ class Routing extends Component {
                                     component={VerifyOwnerWrapper}
                                 />
                             )}
+                            <Route
+                                exact
+                                path="/recover-with-link/:accountId/:seedPhrase"
+                                component={RecoveryRedirect}
+                            />
                             <PrivateRoute component={PageNotFound} />
                         </Switch>
                         <Footer />

--- a/packages/frontend/src/components/wallet-migration/RecoveryRedirect.jsx
+++ b/packages/frontend/src/components/wallet-migration/RecoveryRedirect.jsx
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { IS_MAINNET } from '../../config';
+
+const RedirectToTestnet = () => {
+    const location = useLocation();
+
+    useEffect(() => {
+    // Function to reconstruct the URL
+        const reconstructUrl = (url) => {
+            const urlObj = new URL(url);
+            const myNearWalletUrl = IS_MAINNET ? 'https://app.mynearwallet.com/' : 'https://testnet.mynearwallet.com';
+            const newUrl = new URL(myNearWalletUrl);
+            newUrl.pathname = urlObj.pathname;
+            newUrl.search = urlObj.search;
+            newUrl.hash = urlObj.hash;
+            return newUrl.toString();
+        };
+
+        // Get the current URL
+        const currentUrl = window.location.href;
+
+        // Reconstruct the URL
+        const newUrl = reconstructUrl(currentUrl);
+
+        // Redirect to the new URL
+        window.location.replace(newUrl);
+    }, [location]);
+
+    return null;
+};
+
+export default RedirectToTestnet;


### PR DESCRIPTION
This PR contains implementation to support existing email link recovery method by automatically redirecting to my near wallet. 

To test on testnet locally, run:
```
yarn && NEAR_WALLET_ENV=testnet yarn start
```

with [this link](https://localhost:1234/recover-with-link/testtest12312.testnet/slim%20cluster%20aisle%20option%20rose%20pact%20shadow%20decade%20employ%20duck%20flush%20spray) will redirect to [mynearwallet testnet](https://testnet.mynearwallet.com/recover-with-link/testtest12312.testnet/slim%20cluster%20aisle%20option%20rose%20pact%20shadow%20decade%20employ%20duck%20flush%20spray)

I have also tested it against mainnet by:
```
yarn && NEAR_WALLET_ENV=mainnet_NEARORG yarn start
```
with mainnet account, (please ping me if you need them to test)
will redirect to: 
![Greenshot 2024-05-28 16 34 00](https://github.com/near/near-wallet/assets/6027014/1301de99-d624-4ae1-acab-1927357629e1)
