### PR TITLE
fix: resolve landing page h2 element mobile view

### DIFF
--- a/packages/frontend/src/translations/en.global.json
+++ b/packages/frontend/src/translations/en.global.json
@@ -675,7 +675,7 @@
     },
     "landing": {
         "banner": "NEAR Wallet is in Private Beta",
-        "desc": "<h2>Wasn't this site a wallet?</h2> <br> wallet.near.org's wallet service has been discontinued <br> <p style='font-size: 14px; text-align: left;'>If you have not already done so, please import your account to a new wallet using your recovery phrase. If you created an email or text message backup, your recovery link will still work but now defaults to <a href='https://app.mynearwallet.com' target='_blank' rel='noreferrer'>app.mynearwallet.com</a>. <br> <br> If you think you have a recovery backup email but are not sure how to find it, search your email for: \"Near Wallet Recovery\" in the subject line. (Include quotes for better results)</p>",
+        "desc": "<h2 style='line-height: 1;'>Wasn't this site a wallet?</h2> <br> wallet.near.org's wallet service has been discontinued <br> <p style='font-size: 14px; text-align: left;'>If you have not already done so, please import your account to a new wallet using your recovery phrase. If you created an email or text message backup, your recovery link will still work but now defaults to <a href='https://app.mynearwallet.com' target='_blank' rel='noreferrer'>app.mynearwallet.com</a>. <br> <br> If you think you have a recovery backup email but are not sure how to find it, search your email for: \"Near Wallet Recovery\" in the subject line. (Include quotes for better results)</p>",
         "or": "or",
         "title": "A new era for NEAR wallets",
         "decentralize": "Decentralization means strength in numbers.",


### PR DESCRIPTION
The new landing page's mobile view has an h2 element with the scrunched font. This PR resolves this by adding line-height

Before:
![Screenshot 2024-11-21 at 3 19 07 PM](https://github.com/user-attachments/assets/a6bd5748-e55c-4331-a9e3-fd1422284a5a)


After:
![Screenshot 2024-11-21 at 3 18 43 PM](https://github.com/user-attachments/assets/2f403468-fea5-4b59-ba60-09deff527f1a)
